### PR TITLE
ArticleDetailActivity 구현

### DIFF
--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -18,6 +18,10 @@
         <activity
             android:name=".view.userlist.UserListActivity"
             android:exported="false" />
+
+        <activity
+            android:name=".view.detail.article.ArticleDetailActivity"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/presentation/src/main/java/com/pocs/presentation/mock/Mocks.kt
+++ b/presentation/src/main/java/com/pocs/presentation/mock/Mocks.kt
@@ -1,31 +1,70 @@
 package com.pocs.presentation.mock
 
 import androidx.paging.PagingData
+import com.pocs.presentation.model.PostDetailItemUiState
 import com.pocs.presentation.model.PostItemUiState
 import com.pocs.presentation.model.UserItemUiState
 
 val mockArticleItemsPagingData = PagingData.from(
     listOf(
-        PostItemUiState("가나다라마", "작성자", "2022.07.19"),
-        PostItemUiState("가나다라마", "작성자", "2022.07.19"),
-        PostItemUiState("가나다라마", "작성자", "2022.07.19"),
-        PostItemUiState("가나다라마", "작성자", "2022.07.19"),
-        PostItemUiState("가나다라마", "작성자", "2022.07.19"),
+        PostItemUiState(1, "가나다라마", "작성자", "2022.07.19"),
+        PostItemUiState(2, "가나다라마", "작성자", "2022.07.19"),
+        PostItemUiState(3, "가나다라마", "작성자", "2022.07.19"),
+        PostItemUiState(4, "가나다라마", "작성자", "2022.07.19"),
+        PostItemUiState(5, "가나다라마", "작성자", "2022.07.19"),
     )
+)
+
+val mockArticleDetailItems = listOf(
+    PostDetailItemUiState(
+        1,
+        title = "가나다라마",
+        writer = "작성자",
+        date = "2022.07.19",
+        content = "Material Design은 사용자 인터페이스 설계의 모범 사례를 지원하는 지침, 구성 요소 및 도구의 적응 가능한 시스템입니다. 오픈 소스 코드를 기반으로 하는 Material Design은 디자이너와 개발자 간의 협업을 간소화하고 팀이 아름다운 제품을 신속하게 제작할 수 있도록 지원합니다."
+    ),
+    PostDetailItemUiState(
+        2,
+        title = "가나다라마",
+        writer = "작성자",
+        date = "2022.07.19",
+        content = "Material Design은 사용자 인터페이스 설계의 모범 사례를 지원하는 지침, 구성 요소 및 도구의 적응 가능한 시스템입니다. 오픈 소스 코드를 기반으로 하는 Material Design은 디자이너와 개발자 간의 협업을 간소화하고 팀이 아름다운 제품을 신속하게 제작할 수 있도록 지원합니다."
+    ),
+    PostDetailItemUiState(
+        3,
+        title = "가나다라마",
+        writer = "작성자",
+        date = "2022.07.19",
+        content = "Material Design은 사용자 인터페이스 설계의 모범 사례를 지원하는 지침, 구성 요소 및 도구의 적응 가능한 시스템입니다. 오픈 소스 코드를 기반으로 하는 Material Design은 디자이너와 개발자 간의 협업을 간소화하고 팀이 아름다운 제품을 신속하게 제작할 수 있도록 지원합니다."
+    ),
+    PostDetailItemUiState(
+        4,
+        title = "가나다라마",
+        writer = "작성자",
+        date = "2022.07.19",
+        content = "Material Design은 사용자 인터페이스 설계의 모범 사례를 지원하는 지침, 구성 요소 및 도구의 적응 가능한 시스템입니다. 오픈 소스 코드를 기반으로 하는 Material Design은 디자이너와 개발자 간의 협업을 간소화하고 팀이 아름다운 제품을 신속하게 제작할 수 있도록 지원합니다."
+    ),
+    PostDetailItemUiState(
+        5,
+        title = "가나다라마",
+        writer = "작성자",
+        date = "2022.07.19",
+        content = "Material Design은 사용자 인터페이스 설계의 모범 사례를 지원하는 지침, 구성 요소 및 도구의 적응 가능한 시스템입니다. 오픈 소스 코드를 기반으로 하는 Material Design은 디자이너와 개발자 간의 협업을 간소화하고 팀이 아름다운 제품을 신속하게 제작할 수 있도록 지원합니다."
+    ),
 )
 
 val mockNoticeItemsPagingData = PagingData.from(
     listOf(
-        PostItemUiState("가나다라마", "관리자", "2022.07.19"),
-        PostItemUiState("가나다라마", "관리자", "2022.07.19"),
-        PostItemUiState("가나다라마", "관리자", "2022.07.19"),
-        PostItemUiState("가나다라마", "관리자", "2022.07.19"),
-        PostItemUiState("가나다라마", "관리자", "2022.07.19"),
-        PostItemUiState("가나다라마", "관리자", "2022.07.19"),
-        PostItemUiState("가나다라마", "관리자", "2022.07.19"),
-        PostItemUiState("가나다라마", "관리자", "2022.07.19"),
-        PostItemUiState("가나다라마", "관리자", "2022.07.19"),
-        PostItemUiState("가나다라마", "관리자", "2022.07.19")
+        PostItemUiState(6, "가나다라마", "관리자", "2022.07.19"),
+        PostItemUiState(7, "가나다라마", "관리자", "2022.07.19"),
+        PostItemUiState(8, "가나다라마", "관리자", "2022.07.19"),
+        PostItemUiState(9, "가나다라마", "관리자", "2022.07.19"),
+        PostItemUiState(10, "가나다라마", "관리자", "2022.07.19"),
+        PostItemUiState(11, "가나다라마", "관리자", "2022.07.19"),
+        PostItemUiState(12, "가나다라마", "관리자", "2022.07.19"),
+        PostItemUiState(13, "가나다라마", "관리자", "2022.07.19"),
+        PostItemUiState(14, "가나다라마", "관리자", "2022.07.19"),
+        PostItemUiState(15, "가나다라마", "관리자", "2022.07.19"),
     )
 )
 

--- a/presentation/src/main/java/com/pocs/presentation/model/ArticleDetailUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/ArticleDetailUiState.kt
@@ -1,0 +1,5 @@
+package com.pocs.presentation.model
+
+data class ArticleDetailUiState(
+    val article: PostDetailItemUiState? = null
+)

--- a/presentation/src/main/java/com/pocs/presentation/model/PostDetailItemUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/PostDetailItemUiState.kt
@@ -1,0 +1,9 @@
+package com.pocs.presentation.model
+
+data class PostDetailItemUiState(
+    val id: Int,
+    val title: String,
+    val content: String,
+    val writer: String,
+    val date: String
+)

--- a/presentation/src/main/java/com/pocs/presentation/model/PostItemUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/PostItemUiState.kt
@@ -1,6 +1,7 @@
 package com.pocs.presentation.model
 
 data class PostItemUiState(
+    val id: Int,
     val title : String,
     val writer : String,
     val date : String

--- a/presentation/src/main/java/com/pocs/presentation/view/common/PostAdapter.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/common/PostAdapter.kt
@@ -7,12 +7,14 @@ import androidx.recyclerview.widget.DiffUtil
 import com.pocs.presentation.databinding.ItemPostBinding
 import com.pocs.presentation.model.PostItemUiState
 
-class PostAdapter : PagingDataAdapter<PostItemUiState, PostViewHolder>(diffCallback) {
+class PostAdapter(
+    private val onClickItem: (PostItemUiState) -> Unit
+) : PagingDataAdapter<PostItemUiState, PostViewHolder>(diffCallback) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PostViewHolder {
         val layoutInflater = LayoutInflater.from(parent.context)
         val binding = ItemPostBinding.inflate(layoutInflater, parent, false)
-        return PostViewHolder(binding)
+        return PostViewHolder(binding, onClickItem)
     }
 
     override fun onBindViewHolder(holder: PostViewHolder, position: Int) {
@@ -21,7 +23,10 @@ class PostAdapter : PagingDataAdapter<PostItemUiState, PostViewHolder>(diffCallb
 
     companion object {
         private val diffCallback = object : DiffUtil.ItemCallback<PostItemUiState>() {
-            override fun areItemsTheSame(oldItem: PostItemUiState, newItem: PostItemUiState): Boolean {
+            override fun areItemsTheSame(
+                oldItem: PostItemUiState,
+                newItem: PostItemUiState
+            ): Boolean {
                 return oldItem === newItem
             }
 

--- a/presentation/src/main/java/com/pocs/presentation/view/common/PostViewHolder.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/common/PostViewHolder.kt
@@ -7,6 +7,7 @@ import com.pocs.presentation.model.PostItemUiState
 
 class PostViewHolder(
     private val binding: ItemPostBinding,
+    private val onClickItem: (PostItemUiState) -> Unit
 ) : RecyclerView.ViewHolder(binding.root) {
 
     fun bind(uiState: PostItemUiState) = with(binding) {
@@ -16,5 +17,7 @@ class PostViewHolder(
             uiState.date,
             uiState.writer
         )
+
+        root.setOnClickListener { onClickItem(uiState) }
     }
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/detail/article/ArticleDetailActivity.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/detail/article/ArticleDetailActivity.kt
@@ -1,0 +1,71 @@
+package com.pocs.presentation.view.detail.article
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.pocs.presentation.R
+import com.pocs.presentation.databinding.ActivityPostDetailBinding
+import com.pocs.presentation.model.ArticleDetailUiState
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class ArticleDetailActivity : AppCompatActivity() {
+
+    private var _binding: ActivityPostDetailBinding? = null
+    private val binding: ActivityPostDetailBinding get() = requireNotNull(_binding)
+
+    private val viewModel: ArticleDetailViewModel by viewModels()
+
+    companion object {
+        fun getIntent(context: Context, id: Int): Intent {
+            return Intent(context, ArticleDetailActivity::class.java).apply {
+                putExtra("id", id)
+            }
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        _binding = ActivityPostDetailBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        loadArticle()
+        initToolBar()
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect(::updateUi)
+            }
+        }
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        onBackPressed()
+        return true
+    }
+
+    private fun loadArticle() {
+        val id = intent.getIntExtra("id", -1)
+        viewModel.loadArticle(id)
+    }
+
+    private fun initToolBar() {
+        setSupportActionBar(binding.toolBar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        supportActionBar?.setDisplayShowTitleEnabled(false)
+    }
+
+    private fun updateUi(uiState: ArticleDetailUiState) = with(binding) {
+        val article = uiState.article ?: return@with
+        title.text = article.title
+        subtitle.text = getString(R.string.article_subtitle, article.date, article.writer)
+        content.text = article.content
+    }
+}

--- a/presentation/src/main/java/com/pocs/presentation/view/detail/article/ArticleDetailViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/detail/article/ArticleDetailViewModel.kt
@@ -1,0 +1,26 @@
+package com.pocs.presentation.view.detail.article
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.pocs.presentation.mock.mockArticleDetailItems
+import com.pocs.presentation.model.ArticleDetailUiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ArticleDetailViewModel @Inject constructor() : ViewModel() {
+
+    private val _uiState = MutableStateFlow(ArticleDetailUiState())
+    val uiState = _uiState.asStateFlow()
+
+    fun loadArticle(id: Int) {
+        viewModelScope.launch {
+            val article = mockArticleDetailItems.first { it.id == id }
+            _uiState.update { it.copy(article = article) }
+        }
+    }
+}

--- a/presentation/src/main/java/com/pocs/presentation/view/home/article/ArticleFragment.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/home/article/ArticleFragment.kt
@@ -15,8 +15,10 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.pocs.presentation.R
 import com.pocs.presentation.databinding.FragmentArticleBinding
 import com.pocs.presentation.model.ArticleUiState
+import com.pocs.presentation.model.PostItemUiState
 import com.pocs.presentation.paging.PagingLoadStateAdapter
 import com.pocs.presentation.view.common.PostAdapter
+import com.pocs.presentation.view.detail.article.ArticleDetailActivity
 import kotlinx.coroutines.launch
 
 class ArticleFragment : Fragment(R.layout.fragment_article) {
@@ -37,7 +39,7 @@ class ArticleFragment : Fragment(R.layout.fragment_article) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val adapter = PostAdapter()
+        val adapter = PostAdapter(::onClickArticle)
         binding.apply {
             recyclerView.adapter = adapter.withLoadStateFooter(
                 PagingLoadStateAdapter { adapter.retry() }
@@ -73,5 +75,10 @@ class ArticleFragment : Fragment(R.layout.fragment_article) {
 
     private fun updateUi(uiState: ArticleUiState, adapter: PostAdapter) {
         adapter.submitData(viewLifecycleOwner.lifecycle, uiState.articlePagingData)
+    }
+
+    private fun onClickArticle(postItemUiState: PostItemUiState) {
+        val intent = ArticleDetailActivity.getIntent(requireContext(), postItemUiState.id)
+        startActivity(intent)
     }
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/home/notice/NoticeFragment.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/home/notice/NoticeFragment.kt
@@ -38,7 +38,7 @@ class NoticeFragment : Fragment(R.id.NoticeFragment) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val adapter = PostAdapter()
+        val adapter = PostAdapter {}
         binding.apply {
             recyclerView.adapter = adapter.withLoadStateFooter(
                 PagingLoadStateAdapter { adapter.retry() }

--- a/presentation/src/main/res/layout/activity_post_detail.xml
+++ b/presentation/src/main/res/layout/activity_post_detail.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolBar">
+
+        <androidx.appcompat.widget.LinearLayoutCompat
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/title"
+                style="?attr/textAppearanceHeadlineMedium"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="24dp"
+                android:layout_marginTop="8dp"
+                android:textColor="?attr/colorOnBackground"
+                tools:text="이번주 공지 알립니다."
+                tools:textColor="@color/black"
+                tools:textSize="28sp" />
+
+            <TextView
+                android:id="@+id/subtitle"
+                style="?attr/textAppearanceBodyMedium"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="24dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginBottom="24dp"
+                android:alpha="0.6"
+                android:textColor="?attr/colorOnBackground"
+                tools:text="2022.07.16 · 관리자"
+                tools:textColor="@color/black"
+                tools:textSize="14sp" />
+
+            <com.google.android.material.divider.MaterialDivider
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:alpha="0.5" />
+
+            <TextView
+                android:id="@+id/content"
+                style="?attr/textAppearanceBodyMedium"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="24dp"
+                android:textColor="?attr/colorOnBackground"
+                tools:text="Material Design은 사용자 인터페이스 설계의 모범 사례를 지원하는 지침, 구성 요소 및 도구의 적응 가능한 시스템입니다. 오픈 소스 코드를 기반으로 하는 Material Design은 디자이너와 개발자 간의 협업을 간소화하고 팀이 아름다운 제품을 신속하게 제작할 수 있도록 지원합니다."
+                tools:textColor="@color/black"
+                tools:textSize="14sp" />
+
+            <com.google.android.material.divider.MaterialDivider
+                android:layout_width="match_parent"
+                android:layout_height="8dp"
+                android:alpha="0.5" />
+
+        </androidx.appcompat.widget.LinearLayoutCompat>
+
+    </ScrollView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Resolves #23 

콜백을 이용하여 article 항목을 하나 누른 경우 디테일 엑티비티를 시작하도록 했습니다. 
목업에 `id: Int` 속성을 추가했습니다.

![image](https://user-images.githubusercontent.com/57604817/179978485-9246f531-777d-4d7f-ae38-254f2cdbb1ad.png)


## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [ ] Action에서 진행하는 테스트를 모두 통과했는가?
- [ ] 수정 사항을 검증할 테스트를 추가하였는가?
- [x] 리뷰를 받았는가?