### PR TITLE
Gradle 버전들 일원화

### DIFF
--- a/android.gradle
+++ b/android.gradle
@@ -1,11 +1,13 @@
 android {
-    compileSdk 32
+    def globalConfiguration = rootProject.extensions.getByName("ext")
+
+    compileSdk globalConfiguration["android_compile_sdk_version"]
 
     defaultConfig {
-        minSdk 23
-        targetSdk 32
-        versionCode 1
-        versionName "1.0"
+        minSdk globalConfiguration["android_min_sdk_version"]
+        targetSdk globalConfiguration["android_target_sdk_version"]
+        versionCode globalConfiguration["android_version_code"]
+        versionName globalConfiguration["android_version_name"]
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,13 @@
 buildscript {
     ext {
+        // Android
+        android_compile_sdk_version = 32
+        android_min_sdk_version = 23
+        android_target_sdk_version = 32
+        android_version_code = 1
+        android_version_name = "1.0.0"
+
+        // Dependencies
         androidx_core = "1.8.0"
         hilt_version = "2.42"
         fragment_version = "1.5.0"

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -6,13 +6,15 @@ plugins {
 }
 
 android {
-    compileSdk 32
+    def globalConfiguration = rootProject.extensions.getByName("ext")
+
+    compileSdk globalConfiguration["android_compile_sdk_version"]
 
     defaultConfig {
-        minSdk 23
-        targetSdk 32
-        versionCode 1
-        versionName "1.0"
+        minSdk globalConfiguration["android_min_sdk_version"]
+        targetSdk globalConfiguration["android_target_sdk_version"]
+        versionCode globalConfiguration["android_version_code"]
+        versionName globalConfiguration["android_version_name"]
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
Resolves #50 

안드로이드 SDK 버전, 앱 빌드 넘버 등 presentation과 나머지 모듈로 나눠져 있던 것을 루트 레벨의 gradle에 명시하여 일원화 했습니다.
앞으로 앱의 버전을 수정할 때는 루트 레벨의 gradle에서 수정하면 됩니다.

## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [ ] Action에서 진행하는 테스트를 모두 통과했는가?
- [ ] 수정 사항을 검증할 테스트를 추가하였는가?
- [ ] 리뷰를 받았는가?