### PR TITLE
Workflow SERVER_URL이 없어 발생하는 문제 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      - name: Access SERVER_URL
+        env:
+          SERVER_URL: $
+        run: echo SERVER_URL=\"SERVER_URL\" > ./apikey.properties
+
       - name: Setup JDK 11
         uses: actions/setup-java@v3
         with:
@@ -33,6 +39,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Access SERVER_URL
+        env:
+          SERVER_URL: $
+        run: echo SERVER_URL=\"SERVER_URL\" > ./apikey.properties
+
       - name: Setup JDK 11
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
레파지토리에는 SERVER_URL이 존재하는 apikey 파일이 없기 때문에 발생하던 문제를 해결했습니다.
github secret에 키를 등록하여 이를 이용하는 방식입니다.

## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [ ] Action에서 진행하는 테스트를 모두 통과했는가?
- [ ] 수정 사항을 검증할 테스트를 추가하였는가?
- [ ] 리뷰를 받았는가?