### PR TITLE
Post 편집할 때 뒤로가기를 누른 경우 다시 확인하는 다이어로그 보이도록 수정

### DIFF
--- a/presentation/src/androidTest/java/com/pocs/presentation/PostEditScreenTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/PostEditScreenTest.kt
@@ -1,12 +1,16 @@
 package com.pocs.presentation
 
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
 import com.pocs.domain.model.PostCategory
 import com.pocs.presentation.model.PostEditUiState
 import com.pocs.presentation.view.post.edit.PostEditScreen
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 
@@ -25,6 +29,29 @@ class PostEditScreenTest {
         onSave = { Result.success(true) }
     )
 
+    companion object {
+        private const val HOME_STACK_TEXT = "Home"
+    }
+
+    @Suppress("TestFunctionName")
+    @Composable
+    private fun PostEditScreenWithHomeBackStack(uiState: PostEditUiState) {
+        val navController = rememberNavController()
+
+        SideEffect {
+            navController.navigate("edit")
+        }
+
+        NavHost(navController, startDestination = "home") {
+            composable(route = "home") {
+                Text(HOME_STACK_TEXT)
+            }
+            composable(route = "edit") {
+                PostEditScreen(uiState = uiState, navigateUp = navController::navigateUp)
+            }
+        }
+    }
+
     @Test
     fun disableSendButton_IfTitleIsEmpty() {
         val fakeUiState = emptyUiState.copy(
@@ -32,7 +59,7 @@ class PostEditScreenTest {
             content = "hello",
         )
         composeTestRule.setContent {
-            PostEditScreen(uiState = fakeUiState)
+            PostEditScreen(uiState = fakeUiState) {}
         }
 
         composeTestRule.onNodeWithContentDescription("저장하기").assertIsNotEnabled()
@@ -45,7 +72,7 @@ class PostEditScreenTest {
             content = "",
         )
         composeTestRule.setContent {
-            PostEditScreen(uiState = fakeUiState)
+            PostEditScreen(uiState = fakeUiState) {}
         }
 
         composeTestRule.onNodeWithContentDescription("저장하기").assertIsNotEnabled()
@@ -58,7 +85,7 @@ class PostEditScreenTest {
             content = "content",
         )
         composeTestRule.setContent {
-            PostEditScreen(uiState = fakeUiState)
+            PostEditScreen(uiState = fakeUiState) {}
         }
 
         composeTestRule.onNodeWithContentDescription("저장하기").assertIsEnabled()
@@ -72,16 +99,15 @@ class PostEditScreenTest {
             isInSaving = true,
         )
         composeTestRule.setContent {
-            PostEditScreen(uiState = fakeUiState)
+            PostEditScreen(uiState = fakeUiState) {}
         }
 
         composeTestRule.onNodeWithTag("CircularProgressIndicator").assertIsDisplayed()
         composeTestRule.onNodeWithContentDescription("저장하기").assertDoesNotExist()
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun showSnackBar_IfFailedToSavePost() = runTest {
+    fun showSnackBar_IfFailedToSavePost() {
         val exception = Exception("fail!!")
         val fakeUiState = emptyUiState.copy(
             title = "title",
@@ -90,13 +116,56 @@ class PostEditScreenTest {
             onSave = { Result.failure(exception) }
         )
         composeTestRule.setContent {
-            PostEditScreen(uiState = fakeUiState)
+            PostEditScreen(uiState = fakeUiState) {}
         }
 
         composeTestRule.onNodeWithContentDescription("저장하기").performClick()
 
-        // "SnackBar"가 보이는 시간으로 앞당긴다.
-        composeTestRule.mainClock.advanceTimeBy(50)
         composeTestRule.onNodeWithText(exception.message!!).assertIsDisplayed()
+    }
+
+    @Test
+    fun navigateToUp_WhenSuccessSaving() {
+        composeTestRule.run {
+            setContent {
+                PostEditScreenWithHomeBackStack(emptyUiState.copy(title = "a", content = "a"))
+            }
+
+            onNodeWithContentDescription("저장하기").performClick()
+
+            onNodeWithText(HOME_STACK_TEXT).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun navigateToUp_WhenClickOkButtonOfAlertDialog() {
+        composeTestRule.run {
+            setContent {
+                PostEditScreenWithHomeBackStack(emptyUiState)
+            }
+
+            onNodeWithContentDescription("뒤로가기").performClick()
+            onNodeWithText("정말로 중단할까요?").assertIsDisplayed()
+
+            onNodeWithText("확인").performClick()
+
+            onNodeWithText(HOME_STACK_TEXT).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun continueEditing_WhenClickCancelButtonOfAlertDialog() {
+        composeTestRule.run {
+            setContent {
+                PostEditScreenWithHomeBackStack(emptyUiState)
+            }
+
+            onNodeWithContentDescription("뒤로가기").performClick()
+            onNodeWithText("정말로 중단할까요?").assertIsDisplayed()
+
+            onNodeWithText("취소").performClick()
+
+            onNodeWithText(HOME_STACK_TEXT).assertDoesNotExist()
+        }
     }
 }

--- a/presentation/src/androidTest/java/com/pocs/presentation/PostEditScreenTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/PostEditScreenTest.kt
@@ -141,7 +141,7 @@ class PostEditScreenTest {
     fun navigateToUp_WhenClickOkButtonOfAlertDialog() {
         composeTestRule.run {
             setContent {
-                PostEditScreenWithHomeBackStack(emptyUiState)
+                PostEditScreenWithHomeBackStack(emptyUiState.copy(title = "Hi"))
             }
 
             onNodeWithContentDescription("뒤로가기").performClick()
@@ -157,7 +157,7 @@ class PostEditScreenTest {
     fun continueEditing_WhenClickCancelButtonOfAlertDialog() {
         composeTestRule.run {
             setContent {
-                PostEditScreenWithHomeBackStack(emptyUiState)
+                PostEditScreenWithHomeBackStack(emptyUiState.copy(title = "Hi"))
             }
 
             onNodeWithContentDescription("뒤로가기").performClick()
@@ -166,6 +166,20 @@ class PostEditScreenTest {
             onNodeWithText("취소").performClick()
 
             onNodeWithText(HOME_STACK_TEXT).assertDoesNotExist()
+        }
+    }
+
+    @Test
+    fun shouldNotShowAlertDialog_WhenPressingBackButtonWithEmptyTitleAndContent() {
+        composeTestRule.run {
+            setContent {
+                PostEditScreenWithHomeBackStack(emptyUiState)
+            }
+
+            onNodeWithContentDescription("뒤로가기").performClick()
+
+            onNodeWithText("정말로 중단할까요?").assertDoesNotExist()
+            onNodeWithText(HOME_STACK_TEXT).assertIsDisplayed()
         }
     }
 }

--- a/presentation/src/main/java/com/pocs/presentation/model/BasePostEditUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/BasePostEditUiState.kt
@@ -12,4 +12,5 @@ interface BasePostEditUiState {
     val onSave: suspend () -> Result<Boolean>
 
     val canSave get() = title.isNotEmpty() && content.isNotEmpty()
+    val isEmpty get() = title.isEmpty() && content.isEmpty()
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/post/create/PostCreateActivity.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/create/PostCreateActivity.kt
@@ -31,7 +31,7 @@ class PostCreateActivity : AppCompatActivity() {
 
         setContent {
             Mdc3Theme(this) {
-                PostCreateScreen(uiState = viewModel.uiState.value)
+                PostCreateScreen(uiState = viewModel.uiState.value, navigateUp = ::finish)
             }
         }
     }

--- a/presentation/src/main/java/com/pocs/presentation/view/post/create/PostCreateScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/create/PostCreateScreen.kt
@@ -1,6 +1,5 @@
 package com.pocs.presentation.view.post.create
 
-import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import com.pocs.presentation.R
@@ -9,12 +8,9 @@ import com.pocs.presentation.view.post.edit.PostEditContent
 
 @Composable
 fun PostCreateScreen(uiState: PostCreateUiState) {
-    val onBackPressedDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
-
     PostEditContent(
         // TODO: 게시글 속성에 따라 "OOO 편집"과 같이 다르게 보이기
         title = stringResource(R.string.write_post),
-        onBackPressed = { onBackPressedDispatcher?.onBackPressed() },
         uiState = uiState
     )
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/post/create/PostCreateScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/create/PostCreateScreen.kt
@@ -7,10 +7,11 @@ import com.pocs.presentation.model.PostCreateUiState
 import com.pocs.presentation.view.post.edit.PostEditContent
 
 @Composable
-fun PostCreateScreen(uiState: PostCreateUiState) {
+fun PostCreateScreen(uiState: PostCreateUiState, navigateUp: () -> Unit) {
     PostEditContent(
         // TODO: 게시글 속성에 따라 "OOO 편집"과 같이 다르게 보이기
         title = stringResource(R.string.write_post),
-        uiState = uiState
+        uiState = uiState,
+        navigateUp = navigateUp
     )
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditActivity.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditActivity.kt
@@ -46,7 +46,7 @@ class PostEditActivity : AppCompatActivity() {
 
         setContent {
             Mdc3Theme(this) {
-                PostEditScreen(uiState = viewModel.uiState.value)
+                PostEditScreen(uiState = viewModel.uiState.value, navigateUp = ::finish)
             }
         }
     }

--- a/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditScreen.kt
@@ -22,12 +22,9 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun PostEditScreen(uiState: PostEditUiState) {
-    val onBackPressedDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
-
     PostEditContent(
         // TODO: 게시글 속성에 따라 "OOO 편집"과 같이 다르게 보이기
         title = stringResource(id = R.string.edit_post),
-        onBackPressed = { onBackPressedDispatcher?.onBackPressed() },
         uiState = uiState,
     )
 }
@@ -36,9 +33,12 @@ fun PostEditScreen(uiState: PostEditUiState) {
 @Composable
 fun PostEditContent(
     title: String,
-    onBackPressed: () -> Unit,
     uiState: BasePostEditUiState
 ) {
+    val onBackPressedDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
+    val onBackPressed: () -> Unit = {
+        onBackPressedDispatcher?.onBackPressed()
+    }
     val snackBarHostState = remember { SnackbarHostState() }
 
     Scaffold(
@@ -173,7 +173,6 @@ fun SendIconButton(
 fun PostEditContentEmptyPreview() {
     PostEditContent(
         "게시글 수정",
-        {},
         PostEditUiState(
             id = 1,
             title = "",
@@ -191,7 +190,6 @@ fun PostEditContentEmptyPreview() {
 fun PostEditContentPreview() {
     PostEditContent(
         "게시글 수정",
-        {},
         PostEditUiState(
             id = 1,
             title = "공지입니다.",

--- a/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditScreen.kt
@@ -1,6 +1,7 @@
 package com.pocs.presentation.view.post.edit
 
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.material.icons.Icons
@@ -38,8 +39,10 @@ fun PostEditContent(
     navigateUp: () -> Unit
 ) {
     var enabledAlertDialog by remember { mutableStateOf(false) }
+    val enabledBackHandler = rememberUpdatedState(newValue = !uiState.isEmpty)
     val snackBarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
+    val onBackPressedDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
 
     if (enabledAlertDialog) {
         PostEditAlertDialog(
@@ -48,7 +51,7 @@ fun PostEditContent(
         )
     }
 
-    BackHandler {
+    BackHandler(enabledBackHandler.value) {
         enabledAlertDialog = true
     }
 
@@ -57,7 +60,7 @@ fun PostEditContent(
         topBar = {
             PostEditAppBar(
                 title = title,
-                onBackPressed = { enabledAlertDialog = true },
+                onBackPressed = { onBackPressedDispatcher?.onBackPressed() },
                 isInSaving = uiState.isInSaving,
                 enableSendIcon = uiState.canSave,
                 onClickSend = {

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -21,6 +21,10 @@
     <string name="write_article">글 쓰기</string>
     <string name="write_post">게시글 쓰기</string>
     <string name="failed_to_load">불러오기에 실패했습니다.</string>
+    <string name="cancel">취소</string>
+    <string name="ok">확인</string>
+    <string name="post_alert_dialog_title">정말로 중단할까요?</string>
+    <string name="post_alert_dialog_text">작성하신 내용은 저장되지 않습니다.</string>
     <string-array name="admin_tab">
         <item>공지사항</item>
         <item>회원목록</item>


### PR DESCRIPTION
Resolves #57 

다음과 같은 경우에 AlertDialog를 보입니다.
- 제목 혹은 글 내용이 작성되어 있을 때 뒤로가기(앱바의 버튼 혹은 기기의 뒤로가기 버튼)를 누른 경우

다음과 같은 경우에 보이지 **않습니다.**
- 제목과 글 내용 모두 비어있는 경우
- 포스트를 저장할 때

![image](https://user-images.githubusercontent.com/57604817/181400139-31ff21b3-550f-45df-b1ff-c8f0d771e9d5.png)


## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [ ] Action에서 진행하는 테스트를 모두 통과했는가?
- [x] 수정 사항을 검증할 테스트를 추가하였는가?
- [ ] 리뷰를 받았는가?