### PR TITLE
AdminUser 목록 API 구현

### DIFF
--- a/data/src/main/java/com/pocs/data/api/AdminApi.kt
+++ b/data/src/main/java/com/pocs/data/api/AdminApi.kt
@@ -1,0 +1,10 @@
+package com.pocs.data.api
+
+import com.pocs.data.model.ResponseBody
+import com.pocs.data.model.admin.AdminUserListDto
+import retrofit2.http.GET
+
+interface AdminApi {
+    @GET("admin/users")
+    suspend fun getAllUsers(): ResponseBody<AdminUserListDto>
+}

--- a/data/src/main/java/com/pocs/data/di/NetworkModule.kt
+++ b/data/src/main/java/com/pocs/data/di/NetworkModule.kt
@@ -1,6 +1,7 @@
 package com.pocs.data.di
 
 import com.pocs.data.BuildConfig
+import com.pocs.data.api.AdminApi
 import com.pocs.data.api.PostApi
 import com.pocs.data.api.UserApi
 import dagger.Module
@@ -11,6 +12,7 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.create
 import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
@@ -56,5 +58,11 @@ class NetworkModule {
     @Singleton
     fun provideUserApiService(retrofit: Retrofit): UserApi {
         return retrofit.create(UserApi::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun provideAdminApiService(retrofit: Retrofit): AdminApi {
+        return retrofit.create(AdminApi::class.java)
     }
 }

--- a/data/src/main/java/com/pocs/data/di/RepositoryModule.kt
+++ b/data/src/main/java/com/pocs/data/di/RepositoryModule.kt
@@ -1,11 +1,14 @@
 package com.pocs.data.di
 
+import com.pocs.data.api.AdminApi
 import com.pocs.data.api.PostApi
 import com.pocs.data.api.UserApi
+import com.pocs.data.repository.AdminRepositoryImpl
 import com.pocs.data.repository.PostRepositoryImpl
 import com.pocs.data.repository.UserRepositoryImpl
 import com.pocs.data.source.PostRemoteDataSource
 import com.pocs.data.source.UserRemoteDataSource
+import com.pocs.domain.repository.AdminRepository
 import com.pocs.domain.repository.PostRepository
 import com.pocs.domain.repository.UserRepository
 import dagger.Module
@@ -28,5 +31,11 @@ class RepositoryModule {
     @Provides
     fun provideUserRepository(api: UserApi, dataSource: UserRemoteDataSource): UserRepository {
         return UserRepositoryImpl(api = api, dataSource = dataSource)
+    }
+
+    @Singleton
+    @Provides
+    fun provideAdminRepository(api: AdminApi): AdminRepository {
+        return AdminRepositoryImpl(api)
     }
 }

--- a/data/src/main/java/com/pocs/data/mapper/UserMapper.kt
+++ b/data/src/main/java/com/pocs/data/mapper/UserMapper.kt
@@ -1,5 +1,6 @@
 package com.pocs.data.mapper
 
+import com.pocs.data.model.admin.AdminUserDto
 import com.pocs.data.model.user.UserDto
 import com.pocs.domain.model.user.User
 import com.pocs.domain.model.user.UserDetail
@@ -8,7 +9,8 @@ fun UserDto.toEntity() = User(
     id = id,
     name = name,
     studentId = studentId,
-    generation = generation
+    generation = generation,
+    canceledAt = "-"
 )
 
 fun UserDto.toDetailEntity() = UserDetail(
@@ -21,4 +23,13 @@ fun UserDto.toDetailEntity() = UserDetail(
     generation = generation,
     github = github,
     createdAt = createdAt,
+    canceledAt = "-"
+)
+
+fun AdminUserDto.toEntity() = User(
+    id = userId,
+    name = userName,
+    studentId = studentId,
+    generation = generation,
+    canceledAt = canceledAt
 )

--- a/data/src/main/java/com/pocs/data/model/admin/AdminUserDto.kt
+++ b/data/src/main/java/com/pocs/data/model/admin/AdminUserDto.kt
@@ -1,11 +1,11 @@
-package com.pocs.domain.model.user
+package com.pocs.data.model.admin
 
-data class UserDetail(
-    val id: Int,
-    val name: String,
+data class AdminUserDto(
+    val userId: Int,
+    val userName: String,
     val email: String,
     val studentId: Int,
-    val type: UserType,
+    val type: String,
     val company: String,
     val generation: Int,
     val github: String,

--- a/data/src/main/java/com/pocs/data/model/admin/AdminUserListDto.kt
+++ b/data/src/main/java/com/pocs/data/model/admin/AdminUserListDto.kt
@@ -1,0 +1,5 @@
+package com.pocs.data.model.admin
+
+data class AdminUserListDto(
+    val users: List<AdminUserDto>
+)

--- a/data/src/main/java/com/pocs/data/paging/AdminPagingSource.kt
+++ b/data/src/main/java/com/pocs/data/paging/AdminPagingSource.kt
@@ -1,0 +1,48 @@
+package com.pocs.data.paging
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.pocs.data.api.AdminApi
+import com.pocs.data.mapper.toEntity
+import com.pocs.domain.model.user.User
+import java.lang.Exception
+import javax.inject.Inject
+
+class AdminPagingSource @Inject constructor(
+    private val api: AdminApi
+) : PagingSource<Int, User>() {
+
+    companion object {
+        private const val START_PAGE = 1
+    }
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, User> {
+        val page = params.key ?: START_PAGE
+        return try {
+            val response = api.getAllUsers()
+            if (response.isSuccess) {
+                val users = response.data.users.map { it.toEntity() }
+                // TODO: API에서 페이지네이션 구현되면 수정하기
+                val isEnd = true
+
+                LoadResult.Page(
+                    data = users,
+                    // TODO: API에서 페이지네이션 구현되면 수정하기
+                    prevKey = if (page == START_PAGE) null else page - 1,
+                    nextKey = if (isEnd) null else page + 1
+                )
+            } else {
+                throw Exception(response.message)
+            }
+        } catch (e: Exception) {
+            LoadResult.Error(e)
+        }
+    }
+
+    override fun getRefreshKey(state: PagingState<Int, User>): Int? {
+        return state.anchorPosition?.let { anchorPosition ->
+            state.closestPageToPosition(anchorPosition)?.prevKey?.plus(1)
+                ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(1)
+        }
+    }
+}

--- a/data/src/main/java/com/pocs/data/repository/AdminRepositoryImpl.kt
+++ b/data/src/main/java/com/pocs/data/repository/AdminRepositoryImpl.kt
@@ -1,0 +1,37 @@
+package com.pocs.data.repository
+
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import com.pocs.data.api.AdminApi
+import com.pocs.data.paging.AdminPagingSource
+import com.pocs.domain.model.user.User
+import com.pocs.domain.model.user.UserDetail
+import com.pocs.domain.repository.AdminRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class AdminRepositoryImpl @Inject constructor(
+    private val api: AdminApi
+): AdminRepository {
+
+    override fun getAllUsers(): Flow<PagingData<User>> {
+        return Pager(
+            // TODO: API 페이지네이션 구현되면 페이지 사이즈 수정하기
+            config = PagingConfig(pageSize = 30),
+            pagingSourceFactory = { AdminPagingSource(api) }
+        ).flow
+    }
+
+    override suspend fun getUserDetail(id: Int): Result<UserDetail> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun createUser(userDetail: UserDetail, password: String): Result<Unit> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun kickUser(id: Int): Result<Unit> {
+        TODO("Not yet implemented")
+    }
+}

--- a/domain/src/main/java/com/pocs/domain/model/user/User.kt
+++ b/domain/src/main/java/com/pocs/domain/model/user/User.kt
@@ -4,5 +4,6 @@ data class User(
     val id: Int,
     val name: String,
     val studentId: Int,
-    val generation: Int
+    val generation: Int,
+    val canceledAt: String
 )

--- a/domain/src/main/java/com/pocs/domain/repository/AdminRepository.kt
+++ b/domain/src/main/java/com/pocs/domain/repository/AdminRepository.kt
@@ -1,0 +1,20 @@
+package com.pocs.domain.repository
+
+import androidx.paging.PagingData
+import com.pocs.domain.model.user.User
+import com.pocs.domain.model.user.UserDetail
+import kotlinx.coroutines.flow.Flow
+
+interface AdminRepository {
+
+    fun getAllUsers(): Flow<PagingData<User>>
+
+    suspend fun getUserDetail(id: Int): Result<UserDetail>
+
+    suspend fun createUser(
+        userDetail: UserDetail,
+        password: String
+    ): Result<Unit>
+
+    suspend fun kickUser(id: Int): Result<Unit>
+}

--- a/domain/src/main/java/com/pocs/domain/usecase/admin/GetAllUsersAsAdmin.kt
+++ b/domain/src/main/java/com/pocs/domain/usecase/admin/GetAllUsersAsAdmin.kt
@@ -1,0 +1,10 @@
+package com.pocs.domain.usecase.admin
+
+import com.pocs.domain.repository.AdminRepository
+import javax.inject.Inject
+
+class GetAllUsersAsAdmin @Inject constructor(
+    private val repository: AdminRepository
+) {
+    operator fun invoke() = repository.getAllUsers()
+}

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -45,7 +45,6 @@ dependencies {
     implementation project(":domain")
     testImplementation project(":test-library")
     androidTestImplementation project(":test-library")
-    androidTestImplementation project(":data")
 
     // fragment
     debugImplementation "androidx.fragment:fragment-testing:$fragment_version"

--- a/presentation/src/androidTest/java/com/pocs/presentation/AdminUserFragmentTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/AdminUserFragmentTest.kt
@@ -1,0 +1,78 @@
+package com.pocs.presentation
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.*
+import com.pocs.domain.usecase.admin.GetAllUsersAsAdmin
+import com.pocs.presentation.view.admin.user.AdminUserFragment
+import com.pocs.presentation.view.admin.user.AdminUserViewModel
+import com.pocs.test_library.extension.launchFragmentInHiltContainer
+import com.pocs.test_library.fake.FakeAdminRepositoryImpl
+import com.pocs.test_library.mock.mockKickedUser
+import com.pocs.test_library.mock.mockNormalUser
+import dagger.hilt.android.testing.BindValue
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@HiltAndroidTest
+class AdminUserFragmentTest {
+
+    @get:Rule(order = 0)
+    val hiltRule = HiltAndroidRule(this)
+
+    @BindValue
+    val repository = FakeAdminRepositoryImpl()
+
+    @BindValue
+    lateinit var viewModel: AdminUserViewModel
+
+    @Before
+    fun setUp() {
+        hiltRule.inject()
+    }
+
+    private fun initViewModel() {
+        viewModel = AdminUserViewModel(GetAllUsersAsAdmin(repository))
+    }
+
+    @Test
+    fun showUserData_AfterInitViewModel() = runTest {
+        repository.userList = listOf(mockNormalUser)
+        initViewModel()
+
+        launchFragmentInHiltContainer<AdminUserFragment>(themeResId = R.style.Theme_PocsBlog)
+
+        onView(withText(mockNormalUser.name)).check(matches(isDisplayed()))
+        onView(withSubstring(mockNormalUser.studentId.toString())).check(matches(isDisplayed()))
+        onView(withSubstring(mockNormalUser.generation.toString())).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun showKickedText_WhenUserWasKicked() = runTest {
+        repository.userList = listOf(mockKickedUser)
+        initViewModel()
+
+        launchFragmentInHiltContainer<AdminUserFragment>(themeResId = R.style.Theme_PocsBlog)
+
+        onView(withSubstring("탈퇴됨")).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun shouldNotShowKickedText_WhenUserWasNotKicked() = runTest {
+        repository.userList = listOf(mockNormalUser)
+        initViewModel()
+
+        launchFragmentInHiltContainer<AdminUserFragment>(themeResId = R.style.Theme_PocsBlog)
+
+        onView(withSubstring("탈퇴됨")).check { _, noViewFoundException ->
+            assertNotNull(noViewFoundException)
+        }
+    }
+}

--- a/presentation/src/androidTest/java/com/pocs/presentation/UserDetailActivityTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/UserDetailActivityTest.kt
@@ -49,7 +49,8 @@ class UserDetailActivityTest {
         company = "google",
         generation = 10,
         github = "https://github.com/",
-        createdAt = ""
+        createdAt = "",
+        canceledAt = ""
     )
 
     @Before

--- a/presentation/src/main/java/com/pocs/presentation/extension/ContentLoadStateBindingExt.kt
+++ b/presentation/src/main/java/com/pocs/presentation/extension/ContentLoadStateBindingExt.kt
@@ -1,0 +1,29 @@
+package com.pocs.presentation.extension
+
+import androidx.core.view.isVisible
+import androidx.paging.LoadState
+import androidx.paging.PagingDataAdapter
+import com.pocs.presentation.R
+import com.pocs.presentation.databinding.ContentLoadStateBinding
+import java.net.ConnectException
+
+fun <PA : PagingDataAdapter<T, VH>, T, VH> ContentLoadStateBinding.setListeners(adapter: PA) {
+    this.retryButton.setOnClickListener {
+        adapter.retry()
+    }
+
+    adapter.addLoadStateListener { loadStates ->
+        val refreshLoadState = loadStates.refresh
+        val isError = loadStates.refresh is LoadState.Error
+
+        this.progressBar.isVisible = loadStates.refresh is LoadState.Loading
+        this.retryButton.isVisible = isError
+        this.errorMsg.isVisible = isError
+        if (refreshLoadState is LoadState.Error) {
+            errorMsg.text = when (val exception = refreshLoadState.error) {
+                is ConnectException -> root.context.getString(R.string.fail_to_connect)
+                else -> exception.message
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/pocs/presentation/extension/StringExt.kt
+++ b/presentation/src/main/java/com/pocs/presentation/extension/StringExt.kt
@@ -1,0 +1,18 @@
+package com.pocs.presentation.extension
+
+import java.text.ParseException
+import java.text.SimpleDateFormat
+
+enum class DatePattern(val value: String) {
+    COMPACT("yyyy-MM-DD")
+}
+
+fun String.isDateFormat(pattern: DatePattern): Boolean {
+    val dateFormat = SimpleDateFormat(pattern.value)
+    return try {
+        dateFormat.parse(this)
+        true
+    } catch (e: ParseException) {
+        false
+    }
+}

--- a/presentation/src/main/java/com/pocs/presentation/mapper/UserMapper.kt
+++ b/presentation/src/main/java/com/pocs/presentation/mapper/UserMapper.kt
@@ -7,5 +7,6 @@ fun User.toUiState() = UserItemUiState(
     id = id,
     name = name,
     studentId = studentId.toString(),
-    generation = generation
+    generation = generation,
+    canceledAt = canceledAt
 )

--- a/presentation/src/main/java/com/pocs/presentation/model/admin/AdminUserUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/admin/AdminUserUiState.kt
@@ -1,0 +1,8 @@
+package com.pocs.presentation.model.admin
+
+import androidx.paging.PagingData
+import com.pocs.presentation.model.user.item.UserItemUiState
+
+data class AdminUserUiState(
+    val userPagingData: PagingData<UserItemUiState> = PagingData.empty()
+)

--- a/presentation/src/main/java/com/pocs/presentation/model/user/item/UserItemUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/user/item/UserItemUiState.kt
@@ -1,7 +1,7 @@
 package com.pocs.presentation.model.user.item
 
-import java.text.ParseException
-import java.text.SimpleDateFormat
+import com.pocs.presentation.extension.DatePattern
+import com.pocs.presentation.extension.isDateFormat
 
 data class UserItemUiState(
     val id: Int,
@@ -10,14 +10,5 @@ data class UserItemUiState(
     val generation: Int,
     val canceledAt: String
 ) {
-    val isKicked: Boolean
-        get() {
-            val dateFormat = SimpleDateFormat("yyyy-MM-DD")
-            return try {
-                dateFormat.parse(canceledAt)
-                true
-            } catch (e: ParseException) {
-                false
-            }
-        }
+    val isKicked: Boolean get() = canceledAt.isDateFormat(DatePattern.COMPACT)
 }

--- a/presentation/src/main/java/com/pocs/presentation/model/user/item/UserItemUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/user/item/UserItemUiState.kt
@@ -1,8 +1,23 @@
 package com.pocs.presentation.model.user.item
 
+import java.text.ParseException
+import java.text.SimpleDateFormat
+
 data class UserItemUiState(
     val id: Int,
     val name: String,
     val studentId: String,
-    val generation: Int
-)
+    val generation: Int,
+    val canceledAt: String
+) {
+    val isKicked: Boolean
+        get() {
+            val dateFormat = SimpleDateFormat("yyyy-MM-DD")
+            return try {
+                dateFormat.parse(canceledAt)
+                true
+            } catch (e: ParseException) {
+                false
+            }
+        }
+}

--- a/presentation/src/main/java/com/pocs/presentation/view/admin/AdminAdapter.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/admin/AdminAdapter.kt
@@ -4,8 +4,8 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.Lifecycle
 import androidx.viewpager2.adapter.FragmentStateAdapter
+import com.pocs.presentation.view.admin.user.AdminUserFragment
 import com.pocs.presentation.view.home.notice.NoticeFragment
-import com.pocs.presentation.view.user.UserFragment
 
 class AdminAdapter(
     fragmentManager: FragmentManager,
@@ -23,7 +23,7 @@ class AdminAdapter(
     override fun createFragment(position: Int): Fragment {
         when (position) {
             0 -> return NoticeFragment()
-            1 -> return UserFragment()
+            1 -> return AdminUserFragment()
         }
         throw IllegalArgumentException()
     }

--- a/presentation/src/main/java/com/pocs/presentation/view/admin/user/AdminUserFragment.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/admin/user/AdminUserFragment.kt
@@ -4,17 +4,16 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import androidx.paging.LoadState
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.pocs.domain.model.user.UserType
 import com.pocs.presentation.R
 import com.pocs.presentation.databinding.FragmentAdminUserBinding
+import com.pocs.presentation.extension.setListeners
 import com.pocs.presentation.model.admin.AdminUserUiState
 import com.pocs.presentation.paging.PagingLoadStateAdapter
 import com.pocs.presentation.view.user.UserAdapter
@@ -50,17 +49,7 @@ class AdminUserFragment : Fragment(R.layout.fragment_admin_user) {
             )
             recyclerView.layoutManager = LinearLayoutManager(view.context)
 
-            val loadStateBinding = loadState
-            loadStateBinding.retryButton.setOnClickListener {
-                adapter.retry()
-            }
-
-            adapter.addLoadStateListener { loadStates ->
-                val isError = loadStates.refresh is LoadState.Error
-                loadStateBinding.progressBar.isVisible = loadStates.refresh is LoadState.Loading
-                loadStateBinding.retryButton.isVisible = isError
-                loadStateBinding.errorMsg.isVisible = isError
-            }
+            loadState.setListeners(adapter)
 
             viewLifecycleOwner.lifecycleScope.launch {
                 viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {

--- a/presentation/src/main/java/com/pocs/presentation/view/admin/user/AdminUserFragment.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/admin/user/AdminUserFragment.kt
@@ -1,10 +1,9 @@
-package com.pocs.presentation.view.user
+package com.pocs.presentation.view.admin.user
 
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.appcompat.widget.PopupMenu
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -13,30 +12,29 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.paging.LoadState
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.pocs.domain.model.user.UserListSortingMethod
 import com.pocs.domain.model.user.UserType
 import com.pocs.presentation.R
-import com.pocs.presentation.databinding.FragmentUserBinding
-import com.pocs.presentation.model.user.UserUiState
+import com.pocs.presentation.databinding.FragmentAdminUserBinding
+import com.pocs.presentation.model.admin.AdminUserUiState
 import com.pocs.presentation.paging.PagingLoadStateAdapter
+import com.pocs.presentation.view.user.UserAdapter
 import kotlinx.coroutines.launch
 
+class AdminUserFragment : Fragment(R.layout.fragment_admin_user) {
 
-class UserFragment : Fragment(R.layout.fragment_user) {
-
-    private var _binding: FragmentUserBinding? = null
+    private var _binding: FragmentAdminUserBinding? = null
     private val binding get() = _binding!!
 
     private var _adapter: UserAdapter? = null
     private val adapter get() = _adapter!!
 
-    private val viewModel: UserViewModel by activityViewModels()
+    private val viewModel: AdminUserViewModel by activityViewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        _binding = FragmentUserBinding.inflate(inflater, container, false)
+        _binding = FragmentAdminUserBinding.inflate(inflater, container, false)
         return binding.root
     }
 
@@ -64,8 +62,6 @@ class UserFragment : Fragment(R.layout.fragment_user) {
                 loadStateBinding.errorMsg.isVisible = isError
             }
 
-            sortBox.setOnClickListener { showSortingMethodPopUpMenu() }
-
             viewLifecycleOwner.lifecycleScope.launch {
                 viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                     viewModel.uiState.collect(::updateUi)
@@ -85,27 +81,7 @@ class UserFragment : Fragment(R.layout.fragment_user) {
         _adapter = null
     }
 
-    private fun showSortingMethodPopUpMenu() {
-        PopupMenu(requireContext(), binding.sortButton).apply {
-            menuInflater.inflate(R.menu.menu_sorting_method_pop_up, menu)
-            setOnMenuItemClickListener {
-                val newSortingMethod = when (it.itemId) {
-                    R.id.action_generation_descending -> UserListSortingMethod.GENERATION
-                    R.id.action_student_id_ascending -> UserListSortingMethod.STUDENT_ID
-                    else -> throw IllegalArgumentException()
-                }
-                viewModel.updateSortingMethod(newSortingMethod)
-                true
-            }
-        }.show()
-    }
-
-    private fun updateUi(uiState: UserUiState) {
+    private fun updateUi(uiState: AdminUserUiState) {
         adapter.submitData(viewLifecycleOwner.lifecycle, uiState.userPagingData)
-        val stringResource = when (uiState.sortingMethod) {
-            UserListSortingMethod.STUDENT_ID -> R.string.sorting_by_student_id_ascending
-            UserListSortingMethod.GENERATION -> R.string.sorting_by_generation_descending
-        }
-        binding.sortText.text = getString(stringResource)
     }
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/admin/user/AdminUserViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/admin/user/AdminUserViewModel.kt
@@ -1,0 +1,35 @@
+package com.pocs.presentation.view.admin.user
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.paging.cachedIn
+import androidx.paging.map
+import com.pocs.domain.usecase.admin.GetAllUsersAsAdmin
+import com.pocs.presentation.mapper.toUiState
+import com.pocs.presentation.model.admin.AdminUserUiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class AdminUserViewModel @Inject constructor(
+    private val getAllUsersAsAdmin: GetAllUsersAsAdmin
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(AdminUserUiState())
+    val uiState = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            getAllUsersAsAdmin()
+                .cachedIn(viewModelScope)
+                .map { it.map { user -> user.toUiState() } }
+                .collectLatest { pagingData ->
+                    _uiState.update {
+                        it.copy(userPagingData = pagingData)
+                    }
+                }
+        }
+    }
+}

--- a/presentation/src/main/java/com/pocs/presentation/view/home/article/ArticleFragment.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/home/article/ArticleFragment.kt
@@ -8,19 +8,16 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import androidx.paging.CombinedLoadStates
-import androidx.paging.LoadState
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.pocs.domain.model.post.PostCategory
 import com.pocs.presentation.R
-import com.pocs.presentation.databinding.ContentLoadStateBinding
 import com.pocs.presentation.databinding.FragmentArticleBinding
+import com.pocs.presentation.extension.setListeners
 import com.pocs.presentation.model.ArticleUiState
 import com.pocs.presentation.model.post.item.PostItemUiState
 import com.pocs.presentation.paging.PagingLoadStateAdapter
@@ -28,7 +25,6 @@ import com.pocs.presentation.view.post.adapter.PostAdapter
 import com.pocs.presentation.view.post.create.PostCreateActivity
 import com.pocs.presentation.view.post.detail.PostDetailActivity
 import kotlinx.coroutines.launch
-import java.net.ConnectException
 
 class ArticleFragment : Fragment(R.layout.fragment_article) {
 
@@ -57,14 +53,7 @@ class ArticleFragment : Fragment(R.layout.fragment_article) {
             )
             recyclerView.layoutManager = LinearLayoutManager(view.context)
 
-            val loadStateBinding = loadState
-            loadStateBinding.retryButton.setOnClickListener {
-                adapter.retry()
-            }
-
-            adapter.addLoadStateListener { loadStates ->
-                listenLoadState(loadStates, loadStateBinding)
-            }
+            loadState.setListeners(adapter)
 
             fab.setOnClickListener { startPostCreateActivity() }
 
@@ -87,25 +76,6 @@ class ArticleFragment : Fragment(R.layout.fragment_article) {
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
-    }
-
-    private fun listenLoadState(
-        loadStates: CombinedLoadStates,
-        loadStateBinding: ContentLoadStateBinding
-    ) {
-        val refreshLoadState = loadStates.refresh
-        val isError = refreshLoadState is LoadState.Error
-        loadStateBinding.apply {
-            progressBar.isVisible = refreshLoadState is LoadState.Loading
-            retryButton.isVisible = isError
-            errorMsg.isVisible = isError
-            if (refreshLoadState is LoadState.Error) {
-                errorMsg.text = when (val exception = refreshLoadState.error) {
-                    is ConnectException -> getString(R.string.fail_to_connect)
-                    else -> exception.message
-                }
-            }
-        }
     }
 
     private fun updateUi(uiState: ArticleUiState, adapter: PostAdapter) {

--- a/presentation/src/main/java/com/pocs/presentation/view/home/notice/NoticeFragment.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/home/notice/NoticeFragment.kt
@@ -9,16 +9,15 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import androidx.paging.LoadState
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.pocs.domain.model.post.PostCategory
 import com.pocs.presentation.R
 import com.pocs.presentation.databinding.FragmentNoticeBinding
+import com.pocs.presentation.extension.setListeners
 import com.pocs.presentation.model.NoticeUiState
 import com.pocs.presentation.model.post.item.PostItemUiState
 import com.pocs.presentation.paging.PagingLoadStateAdapter
@@ -55,17 +54,7 @@ class NoticeFragment : Fragment(R.layout.fragment_notice) {
             )
             recyclerView.layoutManager = LinearLayoutManager(view.context)
 
-            val loadStateBinding = loadState
-            loadStateBinding.retryButton.setOnClickListener {
-                adapter.retry()
-            }
-
-            adapter.addLoadStateListener { loadStates ->
-                val isError = loadStates.refresh is LoadState.Error
-                loadStateBinding.progressBar.isVisible = loadStates.refresh is LoadState.Loading
-                loadStateBinding.retryButton.isVisible = isError
-                loadStateBinding.errorMsg.isVisible = isError
-            }
+            loadState.setListeners(adapter)
 
             fab.setOnClickListener { startPostCreateActivity() }
 

--- a/presentation/src/main/java/com/pocs/presentation/view/user/UserAdapter.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/user/UserAdapter.kt
@@ -4,15 +4,18 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
+import com.pocs.domain.model.user.UserType
 import com.pocs.presentation.databinding.ItemUserBinding
 import com.pocs.presentation.model.user.item.UserItemUiState
 
-class UserAdapter : PagingDataAdapter<UserItemUiState, UserViewHolder>(diffCallback) {
+class UserAdapter(
+    private val currentUserType: UserType
+) : PagingDataAdapter<UserItemUiState, UserViewHolder>(diffCallback) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): UserViewHolder {
         val layoutInflater = LayoutInflater.from(parent.context)
         val binding = ItemUserBinding.inflate(layoutInflater, parent, false)
-        return UserViewHolder(binding)
+        return UserViewHolder(binding, currentUserType = currentUserType)
     }
 
     override fun onBindViewHolder(holder: UserViewHolder, position: Int) {

--- a/presentation/src/main/java/com/pocs/presentation/view/user/UserFragment.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/user/UserFragment.kt
@@ -5,22 +5,20 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.widget.PopupMenu
-import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import androidx.paging.LoadState
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.pocs.domain.model.user.UserListSortingMethod
 import com.pocs.domain.model.user.UserType
 import com.pocs.presentation.R
 import com.pocs.presentation.databinding.FragmentUserBinding
+import com.pocs.presentation.extension.setListeners
 import com.pocs.presentation.model.user.UserUiState
 import com.pocs.presentation.paging.PagingLoadStateAdapter
 import kotlinx.coroutines.launch
-
 
 class UserFragment : Fragment(R.layout.fragment_user) {
 
@@ -52,17 +50,7 @@ class UserFragment : Fragment(R.layout.fragment_user) {
             )
             recyclerView.layoutManager = LinearLayoutManager(view.context)
 
-            val loadStateBinding = loadState
-            loadStateBinding.retryButton.setOnClickListener {
-                adapter.retry()
-            }
-
-            adapter.addLoadStateListener { loadStates ->
-                val isError = loadStates.refresh is LoadState.Error
-                loadStateBinding.progressBar.isVisible = loadStates.refresh is LoadState.Loading
-                loadStateBinding.retryButton.isVisible = isError
-                loadStateBinding.errorMsg.isVisible = isError
-            }
+            loadState.setListeners(adapter)
 
             sortBox.setOnClickListener { showSortingMethodPopUpMenu() }
 

--- a/presentation/src/main/java/com/pocs/presentation/view/user/UserFragment.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/user/UserFragment.kt
@@ -99,7 +99,7 @@ class UserFragment : Fragment(R.layout.fragment_user) {
     }
 
     private fun updateUi(uiState: UserUiState) {
-        adapter.submitData(lifecycle, uiState.userPagingData)
+        adapter.submitData(viewLifecycleOwner.lifecycle, uiState.userPagingData)
         val stringResource = when (uiState.sortingMethod) {
             UserListSortingMethod.STUDENT_ID -> R.string.sorting_by_student_id_ascending
             UserListSortingMethod.GENERATION -> R.string.sorting_by_generation_descending

--- a/presentation/src/main/java/com/pocs/presentation/view/user/UserViewHolder.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/user/UserViewHolder.kt
@@ -30,7 +30,9 @@ class UserViewHolder(
             uiState.generation.toString()
         )
 
-        if (currentUserType != UserType.UNKNOWN) {
+        val isUnknownUser = currentUserType == UserType.UNKNOWN
+        cardView.isClickable = !isUnknownUser
+        if (!isUnknownUser) {
             cardView.setOnClickListener {
                 val intent = UserDetailActivity.getIntent(context, uiState.id)
                 context.startActivity(intent)

--- a/presentation/src/main/java/com/pocs/presentation/view/user/UserViewHolder.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/user/UserViewHolder.kt
@@ -29,7 +29,8 @@ class UserViewHolder(
             context.startActivity(intent)
         }
 
-        button.setOnClickListener {
+        // TODO: 관리자인 경우에만 보이도록 하기
+        moreInfoButton.setOnClickListener {
             showPopup(it)
         }
     }

--- a/presentation/src/main/java/com/pocs/presentation/view/user/UserViewHolder.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/user/UserViewHolder.kt
@@ -2,7 +2,9 @@ package com.pocs.presentation.view.user
 
 import android.view.View
 import androidx.appcompat.widget.PopupMenu
+import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
+import com.pocs.domain.model.user.UserType
 import com.pocs.presentation.R
 import com.pocs.presentation.databinding.ItemUserBinding
 import com.pocs.presentation.model.user.item.UserItemUiState
@@ -10,33 +12,41 @@ import com.pocs.presentation.view.user.detail.UserDetailActivity
 import com.pocs.presentation.view.user.detail.UserPostListActivity
 
 class UserViewHolder(
-    private val binding: ItemUserBinding
+    private val binding: ItemUserBinding,
+    private val currentUserType: UserType
 ) : RecyclerView.ViewHolder(binding.root) {
 
-    private val context = binding.root.context
-
     fun bind(uiState: UserItemUiState) = with(binding) {
+        val context = root.context
+
         name.text = uiState.name
-        subtitle.text = root.context.getString(
-            R.string.user_item_subtitle,
+        subtitle.text = context.getString(
+            if (uiState.isKicked) {
+                R.string.kicked_user_item_subtitle
+            } else {
+                R.string.user_item_subtitle
+            },
             uiState.studentId,
             uiState.generation.toString()
         )
 
-        cardView.setOnClickListener {
-            val context = binding.root.context
-            val intent = UserDetailActivity.getIntent(context, uiState.id)
-            context.startActivity(intent)
+        if (currentUserType != UserType.UNKNOWN) {
+            cardView.setOnClickListener {
+                val intent = UserDetailActivity.getIntent(context, uiState.id)
+                context.startActivity(intent)
+            }
         }
 
-        // TODO: 관리자인 경우에만 보이도록 하기
-        moreInfoButton.setOnClickListener {
-            showPopup(it)
+        if (currentUserType == UserType.ADMIN) {
+            moreInfoButton.isVisible = true
+            moreInfoButton.setOnClickListener { showPopup(it) }
         }
     }
 
     private fun showPopup(v: View) {
-        PopupMenu(binding.root.context, v).apply {
+        val context = binding.root.context
+
+        PopupMenu(context, v).apply {
             inflate(R.menu.menu_admin_user)
             setOnMenuItemClickListener {
                 when (it.itemId) {

--- a/presentation/src/main/res/layout/content_home.xml
+++ b/presentation/src/main/res/layout/content_home.xml
@@ -5,6 +5,7 @@
     android:layout_height="match_parent"
     app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
+    <!-- TODO: FragmentContainerView로 교체하기-->
     <fragment
         android:id="@+id/nav_host_fragment_content_home"
         android:name="androidx.navigation.fragment.NavHostFragment"

--- a/presentation/src/main/res/layout/fragment_admin_user.xml
+++ b/presentation/src/main/res/layout/fragment_admin_user.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".view.user.UserFragment">
+    tools:context=".view.admin.user.AdminUserFragment">
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerView"

--- a/presentation/src/main/res/layout/fragment_admin_user.xml
+++ b/presentation/src/main/res/layout/fragment_admin_user.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".view.user.UserFragment">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:listitem="@layout/item_user" />
+
+    <include
+        android:id="@+id/load_state"
+        layout="@layout/content_load_state"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/layout/fragment_user.xml
+++ b/presentation/src/main/res/layout/fragment_user.xml
@@ -51,8 +51,9 @@
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerView"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
         app:layout_constraintTop_toBottomOf="@+id/sortBox"
+        app:layout_constraintBottom_toBottomOf="parent"
         tools:listitem="@layout/item_user" />
 
     <include

--- a/presentation/src/main/res/layout/item_user.xml
+++ b/presentation/src/main/res/layout/item_user.xml
@@ -45,7 +45,7 @@
                 android:layout_weight="1"
                 android:orientation="vertical"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toStartOf="@+id/button"
+                app:layout_constraintEnd_toStartOf="@+id/moreInfoButton"
                 app:layout_constraintStart_toEndOf="@+id/imageView"
                 app:layout_constraintTop_toTopOf="parent">
 
@@ -79,14 +79,15 @@
             </androidx.appcompat.widget.LinearLayoutCompat>
 
             <ImageButton
-                android:id="@+id/button"
+                android:id="@+id/moreInfoButton"
                 android:layout_width="48dp"
                 android:layout_height="48dp"
                 android:background="@android:color/transparent"
                 android:src="@drawable/more_vert_ripple"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toTopOf="parent"
+                android:contentDescription="@string/more_info_button" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/presentation/src/main/res/layout/item_user.xml
+++ b/presentation/src/main/res/layout/item_user.xml
@@ -83,11 +83,13 @@
                 android:layout_width="48dp"
                 android:layout_height="48dp"
                 android:background="@android:color/transparent"
+                android:contentDescription="@string/more_info_button"
                 android:src="@drawable/more_vert_ripple"
+                android:visibility="gone"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
-                android:contentDescription="@string/more_info_button" />
+                tools:visibility="visible" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -49,6 +49,7 @@
     <string name="show_password">비밀번호 보이기</string>
     <string name="hide_password">비밀번호 숨기기</string>
     <string name="failed_to_update">수정에 실패했습니다.</string>
+    <string name="more_info_button">더보기 버튼</string>
     <string-array name="admin_tab">
         <item>공지사항</item>
         <item>회원목록</item>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="user_list">회원 목록</string>
     <string name="article_subtitle">%s · %s</string>
     <string name="user_item_subtitle">%s · %s기</string>
+    <string name="kicked_user_item_subtitle">탈퇴됨 · %s · %s기</string>
     <string name="fail_to_connect">연결에 실패하였습니다.</string>
     <string name="retry">재시도</string>
     <string name="user_image">회원 사진</string>

--- a/presentation/src/test/java/com/pocs/presentation/StringExtensionTest.kt
+++ b/presentation/src/test/java/com/pocs/presentation/StringExtensionTest.kt
@@ -1,0 +1,22 @@
+package com.pocs.presentation
+
+import com.pocs.presentation.extension.DatePattern
+import com.pocs.presentation.extension.isDateFormat
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StringExtensionTest {
+
+    @Test
+    fun shouldBeTrue_WhenStringMatchesDateFormat() {
+        val isDateFormat = "2022-01-31".isDateFormat(DatePattern.COMPACT)
+        assertTrue(isDateFormat)
+    }
+
+    @Test
+    fun shouldBeFalse_WhenStringDoesNotMatchDateFormat() {
+        val isDateFormat = "-".isDateFormat(DatePattern.COMPACT)
+        assertFalse(isDateFormat)
+    }
+}

--- a/presentation/src/test/java/com/pocs/presentation/UserDetailViewModelTest.kt
+++ b/presentation/src/test/java/com/pocs/presentation/UserDetailViewModelTest.kt
@@ -33,6 +33,7 @@ class UserDetailViewModelTest {
         "google",
         30,
         "https://github/jja08111",
+        "",
         ""
     )
 

--- a/test-library/src/main/java/com/pocs/test_library/di/FakeRepositoryModule.kt
+++ b/test-library/src/main/java/com/pocs/test_library/di/FakeRepositoryModule.kt
@@ -1,8 +1,10 @@
 package com.pocs.test_library.di
 
 import com.pocs.data.di.RepositoryModule
+import com.pocs.domain.repository.AdminRepository
 import com.pocs.domain.repository.PostRepository
 import com.pocs.domain.repository.UserRepository
+import com.pocs.test_library.fake.FakeAdminRepositoryImpl
 import com.pocs.test_library.fake.FakePostRepositoryImpl
 import com.pocs.test_library.fake.FakeUserRepositoryImpl
 import dagger.Binds
@@ -25,4 +27,8 @@ abstract class FakeRepositoryModule {
     @Singleton
     @Binds
     abstract fun provideUserRepository(fakeUserRepositoryImpl: FakeUserRepositoryImpl): UserRepository
+
+    @Singleton
+    @Binds
+    abstract fun provideAdminRepository(fakeAdminRepositoryImpl: FakeAdminRepositoryImpl): AdminRepository
 }

--- a/test-library/src/main/java/com/pocs/test_library/fake/FakeAdminRepositoryImpl.kt
+++ b/test-library/src/main/java/com/pocs/test_library/fake/FakeAdminRepositoryImpl.kt
@@ -5,13 +5,14 @@ import com.pocs.domain.model.user.User
 import com.pocs.domain.model.user.UserDetail
 import com.pocs.domain.repository.AdminRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import javax.inject.Inject
 
 class FakeAdminRepositoryImpl @Inject constructor() : AdminRepository {
 
-    override fun getAllUsers(): Flow<PagingData<User>> {
-        TODO("Not yet implemented")
-    }
+    var userList: List<User> = emptyList()
+
+    override fun getAllUsers(): Flow<PagingData<User>> = flowOf(PagingData.from(userList))
 
     override suspend fun getUserDetail(id: Int): Result<UserDetail> {
         TODO("Not yet implemented")

--- a/test-library/src/main/java/com/pocs/test_library/fake/FakeAdminRepositoryImpl.kt
+++ b/test-library/src/main/java/com/pocs/test_library/fake/FakeAdminRepositoryImpl.kt
@@ -1,0 +1,27 @@
+package com.pocs.test_library.fake
+
+import androidx.paging.PagingData
+import com.pocs.domain.model.user.User
+import com.pocs.domain.model.user.UserDetail
+import com.pocs.domain.repository.AdminRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class FakeAdminRepositoryImpl @Inject constructor() : AdminRepository {
+
+    override fun getAllUsers(): Flow<PagingData<User>> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getUserDetail(id: Int): Result<UserDetail> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun createUser(userDetail: UserDetail, password: String): Result<Unit> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun kickUser(id: Int): Result<Unit> {
+        TODO("Not yet implemented")
+    }
+}

--- a/test-library/src/main/java/com/pocs/test_library/mock/User.kt
+++ b/test-library/src/main/java/com/pocs/test_library/mock/User.kt
@@ -1,6 +1,10 @@
 package com.pocs.test_library.mock
 
 import com.pocs.domain.model.post.PostWriter
+import com.pocs.domain.model.user.User
 import com.pocs.domain.model.user.UserType
 
 val mockPostWriter1 = PostWriter(1, "kim", "jja0i213@naver.com", UserType.MEMBER)
+
+val mockNormalUser = User(1, "권김정", 1971034, 30, "-")
+val mockKickedUser = User(1, "권김정", 1971034, 30, "2021-02-12")


### PR DESCRIPTION
Resolves #73 

결국 `AdminUserFragment`를 따로 만들었습니다. 요청하는 API가 달랐기 때문입니다. 만약 어드민 유저목록 조회 API도 정렬을 지원했다면 GetAllUsersUseCase에서 현재 유저가 어드민인지 아닌지 여부에 따라 다른 API를 호출하도록 하여서 이전에 만들었던 `UserFramgment`를 재사용했을 것 입니다. 추후에 정렬 기능이 추가된다면 수정을 고려해봐야겠습니다.

**기타 수정**
- User 모델에 canceledAt 속성을 추가했습니다. 이는 `String.isDateFormat()` extension을 통해 "yyyy-MM-DD" 포맷인지 확인하여 탈퇴된 회원인지 확인합니다.
- `ContentLoadStateBinding.setListeners()` extension을 만들어 반복되는 초기 셋팅 코드를 제거했습니다.

![image](https://user-images.githubusercontent.com/57604817/182037887-dcf061c6-be30-4443-adc6-762e6658a93b.png)


## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [ ] Action에서 진행하는 테스트를 모두 통과했는가?
- [x] 수정 사항을 검증할 테스트를 추가하였는가?
- [ ] 리뷰를 받았는가?