### PR TITLE
AdminUserCreate API, UI 구현 

### DIFF
--- a/data/src/main/java/com/pocs/data/api/AdminApi.kt
+++ b/data/src/main/java/com/pocs/data/api/AdminApi.kt
@@ -1,9 +1,12 @@
 package com.pocs.data.api
 
 import com.pocs.data.model.ResponseBody
+import com.pocs.data.model.admin.UserCreateInfoBody
 import com.pocs.data.model.admin.AdminUserDto
 import com.pocs.data.model.admin.AdminUserListDto
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.POST
 import retrofit2.http.Path
 
 interface AdminApi {
@@ -14,4 +17,9 @@ interface AdminApi {
     suspend fun getUserDetail(
         @Path("userId") userId: Int
     ): ResponseBody<AdminUserDto>
+
+    @POST("admin/users")
+    suspend fun createUser(
+        @Body userCreateInfoBody: UserCreateInfoBody
+    ): ResponseBody<Unit>
 }

--- a/data/src/main/java/com/pocs/data/mapper/UserCreateInfoMapper.kt
+++ b/data/src/main/java/com/pocs/data/mapper/UserCreateInfoMapper.kt
@@ -1,0 +1,16 @@
+package com.pocs.data.mapper
+
+import com.pocs.data.model.admin.UserCreateInfoBody
+import com.pocs.domain.model.admin.UserCreateInfo
+
+fun UserCreateInfo.toDto() = UserCreateInfoBody(
+    nickname = nickname,
+    password = password,
+    name = name,
+    studentId = studentId,
+    email = email,
+    generation = generation,
+    type = type.toDto(),
+    company = company,
+    github = github
+)

--- a/data/src/main/java/com/pocs/data/mapper/UserTypeMapper.kt
+++ b/data/src/main/java/com/pocs/data/mapper/UserTypeMapper.kt
@@ -3,3 +3,5 @@ package com.pocs.data.mapper
 import com.pocs.domain.model.user.UserType
 
 fun String.toUserType() = UserType.valueOf(this.uppercase())
+
+fun UserType.toDto() = this.toString().lowercase()

--- a/data/src/main/java/com/pocs/data/model/admin/UserCreateInfoBody.kt
+++ b/data/src/main/java/com/pocs/data/model/admin/UserCreateInfoBody.kt
@@ -1,0 +1,15 @@
+package com.pocs.data.model.admin
+
+import com.google.gson.annotations.SerializedName
+
+data class UserCreateInfoBody(
+    @SerializedName("userName") val nickname: String,
+    val password: String,
+    val name: String,
+    val studentId: Int,
+    val email: String,
+    val generation: Int,
+    val type: String,
+    val company: String,
+    val github: String
+)

--- a/data/src/main/java/com/pocs/data/repository/AdminRepositoryImpl.kt
+++ b/data/src/main/java/com/pocs/data/repository/AdminRepositoryImpl.kt
@@ -4,9 +4,11 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import com.pocs.data.api.AdminApi
+import com.pocs.data.mapper.toDto
 import com.pocs.data.mapper.toDetailEntity
 import com.pocs.data.paging.AdminPagingSource
 import com.pocs.data.source.AdminRemoteDataSource
+import com.pocs.domain.model.admin.UserCreateInfo
 import com.pocs.domain.model.user.User
 import com.pocs.domain.model.user.UserDetail
 import com.pocs.domain.repository.AdminRepository
@@ -16,7 +18,7 @@ import javax.inject.Inject
 class AdminRepositoryImpl @Inject constructor(
     private val api: AdminApi,
     private val dataSource: AdminRemoteDataSource
-): AdminRepository {
+) : AdminRepository {
 
     override fun getAllUsers(): Flow<PagingData<User>> {
         return Pager(
@@ -39,8 +41,17 @@ class AdminRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun createUser(userDetail: UserDetail, password: String): Result<Unit> {
-        TODO("Not yet implemented")
+    override suspend fun createUser(userCreateInfo: UserCreateInfo): Result<Unit> {
+        return try {
+            val response = dataSource.createUser(userCreateInfo.toDto())
+            if (response.isSuccess) {
+                Result.success(Unit)
+            } else {
+                throw Exception(response.message)
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
     }
 
     override suspend fun kickUser(id: Int): Result<Unit> {

--- a/data/src/main/java/com/pocs/data/source/AdminRemoteDataSource.kt
+++ b/data/src/main/java/com/pocs/data/source/AdminRemoteDataSource.kt
@@ -1,8 +1,10 @@
 package com.pocs.data.source
 
 import com.pocs.data.model.ResponseBody
+import com.pocs.data.model.admin.UserCreateInfoBody
 import com.pocs.data.model.admin.AdminUserDto
 
 interface AdminRemoteDataSource {
     suspend fun getUserDetail(userId: Int): ResponseBody<AdminUserDto>
+    suspend fun createUser(userCreateInfoBody: UserCreateInfoBody): ResponseBody<Unit>
 }

--- a/data/src/main/java/com/pocs/data/source/AdminRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/pocs/data/source/AdminRemoteDataSourceImpl.kt
@@ -1,6 +1,8 @@
 package com.pocs.data.source
 
 import com.pocs.data.api.AdminApi
+import com.pocs.data.model.ResponseBody
+import com.pocs.data.model.admin.UserCreateInfoBody
 import javax.inject.Inject
 
 class AdminRemoteDataSourceImpl @Inject constructor(
@@ -8,4 +10,8 @@ class AdminRemoteDataSourceImpl @Inject constructor(
 ): AdminRemoteDataSource {
 
     override suspend fun getUserDetail(userId: Int) = api.getUserDetail(userId)
+
+    override suspend fun createUser(userCreateInfoBody: UserCreateInfoBody): ResponseBody<Unit> {
+        return api.createUser(userCreateInfoBody)
+    }
 }

--- a/domain/src/main/java/com/pocs/domain/model/admin/UserCreateInfo.kt
+++ b/domain/src/main/java/com/pocs/domain/model/admin/UserCreateInfo.kt
@@ -1,0 +1,15 @@
+package com.pocs.domain.model.admin
+
+import com.pocs.domain.model.user.UserType
+
+data class UserCreateInfo(
+    val nickname: String,
+    val password: String,
+    val name: String,
+    val studentId: Int,
+    val email: String,
+    val generation: Int,
+    val type: UserType,
+    val company: String,
+    val github: String
+)

--- a/domain/src/main/java/com/pocs/domain/model/user/UserType.kt
+++ b/domain/src/main/java/com/pocs/domain/model/user/UserType.kt
@@ -1,7 +1,7 @@
 package com.pocs.domain.model.user
 
-enum class UserType {
-    ADMIN,
-    MEMBER,
-    UNKNOWN
+enum class UserType(val koreanString: String) {
+    ADMIN("관리자"),
+    MEMBER("회원"),
+    UNKNOWN("비회원")
 }

--- a/domain/src/main/java/com/pocs/domain/repository/AdminRepository.kt
+++ b/domain/src/main/java/com/pocs/domain/repository/AdminRepository.kt
@@ -1,6 +1,7 @@
 package com.pocs.domain.repository
 
 import androidx.paging.PagingData
+import com.pocs.domain.model.admin.UserCreateInfo
 import com.pocs.domain.model.user.User
 import com.pocs.domain.model.user.UserDetail
 import kotlinx.coroutines.flow.Flow
@@ -11,10 +12,7 @@ interface AdminRepository {
 
     suspend fun getUserDetail(id: Int): Result<UserDetail>
 
-    suspend fun createUser(
-        userDetail: UserDetail,
-        password: String
-    ): Result<Unit>
+    suspend fun createUser(userCreateInfo: UserCreateInfo): Result<Unit>
 
     suspend fun kickUser(id: Int): Result<Unit>
 }

--- a/domain/src/main/java/com/pocs/domain/usecase/admin/CreateUserUseCase.kt
+++ b/domain/src/main/java/com/pocs/domain/usecase/admin/CreateUserUseCase.kt
@@ -1,0 +1,13 @@
+package com.pocs.domain.usecase.admin
+
+import com.pocs.domain.model.admin.UserCreateInfo
+import com.pocs.domain.repository.AdminRepository
+import javax.inject.Inject
+
+class CreateUserUseCase @Inject constructor(
+    private val repository: AdminRepository
+) {
+    suspend operator fun invoke(
+        userCreateInfo: UserCreateInfo
+    ) = repository.createUser(userCreateInfo = userCreateInfo)
+}

--- a/presentation/src/androidTest/java/com/pocs/presentation/AdminUserCreateScreenTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/AdminUserCreateScreenTest.kt
@@ -1,0 +1,58 @@
+package com.pocs.presentation
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import com.pocs.presentation.model.admin.AdminUserCreateUiState
+import com.pocs.presentation.view.admin.user.create.AdminUserCreateScreen
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class AdminUserCreateScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private var mockUiState by mutableStateOf(AdminUserCreateUiState(
+        onSave = {},
+        shownErrorMessage = {},
+        onUpdateCreateInfo = {}
+    ))
+
+    @Test
+    fun showSnackBar_WhenErrorMessageIsNotNull() {
+        composeTestRule.run {
+            setContent { AdminUserCreateScreen(uiState = mockUiState, navigateUp = {}) }
+
+            val errorMessage = "ERROR!!"
+            onNodeWithText(errorMessage).assertDoesNotExist()
+
+            mockUiState = mockUiState.copy(errorMessage = errorMessage)
+            onNodeWithText(errorMessage).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun shouldCallNavigateUp_WhenIsSuccessToSaveIsTrue() {
+        composeTestRule.run {
+            var callCount = 0
+            setContent {
+                AdminUserCreateScreen(
+                    uiState = mockUiState,
+                    navigateUp = { callCount++ }
+                )
+            }
+
+            assertEquals(0, callCount)
+
+            mockUiState = mockUiState.copy(isSuccessToSave = true)
+            mainClock.advanceTimeByFrame()
+
+            assertEquals(1, callCount)
+        }
+    }
+}

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -7,6 +7,10 @@
             android:name=".view.admin.AdminActivity"
             android:exported="false" />
         <activity
+            android:name=".view.admin.user.create.AdminUserCreateActivity"
+            android:exported="false"
+            android:windowSoftInputMode="adjustResize" />
+        <activity
             android:name=".view.home.HomeActivity"
             android:exported="true"
             android:label="@string/app_name"

--- a/presentation/src/main/java/com/pocs/presentation/mapper/UserCreateInfoMapper.kt
+++ b/presentation/src/main/java/com/pocs/presentation/mapper/UserCreateInfoMapper.kt
@@ -1,0 +1,16 @@
+package com.pocs.presentation.mapper
+
+import com.pocs.domain.model.admin.UserCreateInfo
+import com.pocs.presentation.model.admin.UserCreateInfoUiState
+
+fun UserCreateInfoUiState.toEntity() = UserCreateInfo(
+    nickname = nickname,
+    password = password,
+    name = name,
+    studentId = studentId.toInt(),
+    email = email,
+    generation = generation.toInt(),
+    type = type,
+    company = company,
+    github = github
+)

--- a/presentation/src/main/java/com/pocs/presentation/model/admin/AdminUserCreateUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/admin/AdminUserCreateUiState.kt
@@ -1,0 +1,25 @@
+package com.pocs.presentation.model.admin
+
+data class AdminUserCreateUiState(
+    val createInfo: UserCreateInfoUiState = UserCreateInfoUiState(),
+    val isInSaving: Boolean = false,
+    val onSave: () -> Unit,
+    val isSuccessToSave: Boolean = false,
+    val errorMessage: String? = null,
+    val shownErrorMessage: () -> Unit,
+    private val onUpdateCreateInfo: (UserCreateInfoUiState) -> Unit,
+) {
+    val canSave
+        get() : Boolean {
+            return createInfo.nickname.isNotEmpty()
+                    && createInfo.password.isNotEmpty()
+                    && createInfo.name.isNotEmpty()
+                    && createInfo.studentId.isNotEmpty()
+                    && createInfo.email.isNotEmpty()
+                    && createInfo.generation.isNotEmpty()
+        }
+
+    fun updateCreateInfo(updater: (UserCreateInfoUiState) -> UserCreateInfoUiState) {
+        onUpdateCreateInfo(updater(createInfo))
+    }
+}

--- a/presentation/src/main/java/com/pocs/presentation/model/admin/UserCreateInfoUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/admin/UserCreateInfoUiState.kt
@@ -1,0 +1,15 @@
+package com.pocs.presentation.model.admin
+
+import com.pocs.domain.model.user.UserType
+
+data class UserCreateInfoUiState(
+    val nickname: String = "",
+    val password: String = "",
+    val name: String = "",
+    val studentId: String = "",
+    val email: String = "",
+    val generation: String = "",
+    val type: UserType = UserType.MEMBER,
+    val company: String = "",
+    val github: String = ""
+)

--- a/presentation/src/main/java/com/pocs/presentation/view/admin/user/AdminUserFragment.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/admin/user/AdminUserFragment.kt
@@ -15,6 +15,7 @@ import com.pocs.presentation.databinding.FragmentAdminUserBinding
 import com.pocs.presentation.extension.setListeners
 import com.pocs.presentation.model.admin.AdminUserUiState
 import com.pocs.presentation.paging.PagingLoadStateAdapter
+import com.pocs.presentation.view.admin.user.create.AdminUserCreateActivity
 import com.pocs.presentation.view.user.UserAdapter
 import kotlinx.coroutines.launch
 
@@ -49,6 +50,8 @@ class AdminUserFragment : Fragment(R.layout.fragment_admin_user) {
 
             loadState.setListeners(adapter)
 
+            fab.setOnClickListener { startAdminUserCreateActivity() }
+
             viewLifecycleOwner.lifecycleScope.launch {
                 viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                     viewModel.uiState.collect(::updateUi)
@@ -70,5 +73,10 @@ class AdminUserFragment : Fragment(R.layout.fragment_admin_user) {
 
     private fun updateUi(uiState: AdminUserUiState) {
         adapter.submitData(viewLifecycleOwner.lifecycle, uiState.userPagingData)
+    }
+
+    private fun startAdminUserCreateActivity() {
+        val intent = AdminUserCreateActivity.getIntent(requireContext())
+        startActivity(intent)
     }
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/admin/user/create/AdminUserCreateActivity.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/admin/user/create/AdminUserCreateActivity.kt
@@ -1,0 +1,35 @@
+package com.pocs.presentation.view.admin.user.create
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.WindowCompat
+import com.google.android.material.composethemeadapter3.Mdc3Theme
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class AdminUserCreateActivity : AppCompatActivity() {
+
+    private val viewModel: AdminUserCreateViewModel by viewModels()
+
+    companion object {
+        fun getIntent(context: Context): Intent {
+            return Intent(context, AdminUserCreateActivity::class.java)
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        WindowCompat.setDecorFitsSystemWindows(window, true)
+
+        setContent {
+            Mdc3Theme(this) {
+                AdminUserCreateScreen(viewModel.uiState, ::finish)
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/pocs/presentation/view/admin/user/create/AdminUserCreateScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/admin/user/create/AdminUserCreateScreen.kt
@@ -1,0 +1,199 @@
+package com.pocs.presentation.view.admin.user.create
+
+import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.pocs.domain.model.user.UserType
+import com.pocs.presentation.R
+import com.pocs.presentation.model.admin.AdminUserCreateUiState
+import com.pocs.presentation.view.component.RecheckHandler
+import com.pocs.presentation.view.component.appbar.EditContentAppBar
+import com.pocs.presentation.view.component.textfield.PocsOutlineTextField
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AdminUserCreateScreen(uiState: AdminUserCreateUiState, navigateUp: () -> Unit) {
+    val onBackPressedDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
+    val snackBarHostState = remember { SnackbarHostState() }
+    val coroutineScope = rememberCoroutineScope()
+
+    if (uiState.isSuccessToSave) {
+        navigateUp()
+    }
+    if (uiState.errorMessage != null) {
+        coroutineScope.launch {
+            snackBarHostState.showSnackbar(uiState.errorMessage)
+            uiState.shownErrorMessage()
+        }
+    }
+
+    RecheckHandler(navigateUp = navigateUp)
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(hostState = snackBarHostState) },
+        topBar = {
+            EditContentAppBar(
+                title = stringResource(id = R.string.create_user),
+                onBackPressed = { onBackPressedDispatcher?.onBackPressed() },
+                isInSaving = uiState.isInSaving,
+                enableSendIcon = uiState.canSave,
+                onClickSend = { uiState.onSave() }
+            )
+        }
+    ) { innerPadding ->
+        val scrollState = rememberScrollState()
+        val createInfo = uiState.createInfo
+
+        Column(
+            Modifier
+                .padding(innerPadding)
+                .padding(horizontal = 16.dp)
+                .verticalScroll(scrollState)
+                .fillMaxWidth()
+        ) {
+            PocsOutlineTextField(
+                value = createInfo.nickname,
+                label = "닉네임",
+                onValueChange = { nickname ->
+                    uiState.updateCreateInfo { it.copy(nickname = nickname) }
+                },
+                onClearClick = {
+                    uiState.updateCreateInfo { it.copy(nickname = "") }
+                }
+            )
+            PocsOutlineTextField(
+                value = createInfo.password,
+                label = "비밀번호",
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                onValueChange = { password ->
+                    uiState.updateCreateInfo { it.copy(password = password) }
+                },
+                onClearClick = {
+                    uiState.updateCreateInfo { it.copy(password = "") }
+                }
+            )
+            PocsOutlineTextField(
+                value = createInfo.name,
+                label = stringResource(id = R.string.name),
+                onValueChange = { name ->
+                    uiState.updateCreateInfo { it.copy(name = name) }
+                },
+                onClearClick = {
+                    uiState.updateCreateInfo { it.copy(name = "") }
+                }
+            )
+            PocsOutlineTextField(
+                value = createInfo.studentId,
+                label = stringResource(id = R.string.student_id),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                onValueChange = { studentId ->
+                    uiState.updateCreateInfo { it.copy(studentId = studentId) }
+                },
+                onClearClick = {
+                    uiState.updateCreateInfo { it.copy(studentId = "") }
+                }
+            )
+            PocsOutlineTextField(
+                value = createInfo.email,
+                label = stringResource(id = R.string.email),
+                placeholder = stringResource(R.string.email_placeholder),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
+                onValueChange = { email ->
+                    uiState.updateCreateInfo { it.copy(email = email) }
+                },
+                onClearClick = {
+                    uiState.updateCreateInfo { it.copy(email = "") }
+                }
+            )
+            PocsOutlineTextField(
+                value = createInfo.generation,
+                label = stringResource(id = R.string.generation),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                onValueChange = { generation ->
+                    uiState.updateCreateInfo { it.copy(generation = generation) }
+                },
+                onClearClick = {
+                    uiState.updateCreateInfo { it.copy(generation = "") }
+                }
+            )
+            UserTypeDropdownMenu(
+                selectedType = createInfo.type,
+                onItemClick = { userType ->
+                    uiState.updateCreateInfo { it.copy(type = userType) }
+                }
+            )
+            PocsOutlineTextField(
+                value = createInfo.company,
+                label = stringResource(id = R.string.company),
+                onValueChange = { company ->
+                    uiState.updateCreateInfo { it.copy(company = company) }
+                },
+                onClearClick = {
+                    uiState.updateCreateInfo { it.copy(company = "") }
+                }
+            )
+            PocsOutlineTextField(
+                value = createInfo.github,
+                label = stringResource(id = R.string.github),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+                placeholder = stringResource(R.string.github_placeholder),
+                onValueChange = { github ->
+                    uiState.updateCreateInfo { it.copy(github = github) }
+                },
+                onClearClick = {
+                    uiState.updateCreateInfo { it.copy(github = "") }
+                }
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun UserTypeDropdownMenu(selectedType: UserType, onItemClick: (UserType) -> Unit) {
+    val options = remember { listOf(UserType.ADMIN, UserType.MEMBER) }
+    var expanded by remember { mutableStateOf(false) }
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = !expanded }
+    ) {
+        OutlinedTextField(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp),
+            readOnly = true,
+            value = selectedType.koreanString,
+            onValueChange = { },
+            label = { Text(stringResource(R.string.type)) },
+            trailingIcon = {
+                ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
+            },
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            options.forEach { userType ->
+                DropdownMenuItem(
+                    onClick = {
+                        onItemClick(userType)
+                        expanded = false
+                    },
+                    text = { Text(text = userType.koreanString) }
+                )
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/pocs/presentation/view/admin/user/create/AdminUserCreateScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/admin/user/create/AdminUserCreateScreen.kt
@@ -19,20 +19,18 @@ import com.pocs.presentation.model.admin.AdminUserCreateUiState
 import com.pocs.presentation.view.component.RecheckHandler
 import com.pocs.presentation.view.component.appbar.EditContentAppBar
 import com.pocs.presentation.view.component.textfield.PocsOutlineTextField
-import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AdminUserCreateScreen(uiState: AdminUserCreateUiState, navigateUp: () -> Unit) {
     val onBackPressedDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
     val snackBarHostState = remember { SnackbarHostState() }
-    val coroutineScope = rememberCoroutineScope()
 
     if (uiState.isSuccessToSave) {
         navigateUp()
     }
     if (uiState.errorMessage != null) {
-        coroutineScope.launch {
+        LaunchedEffect(uiState.errorMessage) {
             snackBarHostState.showSnackbar(uiState.errorMessage)
             uiState.shownErrorMessage()
         }

--- a/presentation/src/main/java/com/pocs/presentation/view/admin/user/create/AdminUserCreateViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/admin/user/create/AdminUserCreateViewModel.kt
@@ -1,0 +1,52 @@
+package com.pocs.presentation.view.admin.user.create
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.pocs.domain.usecase.admin.CreateUserUseCase
+import com.pocs.presentation.mapper.toEntity
+import com.pocs.presentation.model.admin.AdminUserCreateUiState
+import com.pocs.presentation.model.admin.UserCreateInfoUiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class AdminUserCreateViewModel @Inject constructor(
+    private val createUserUseCase: CreateUserUseCase
+) : ViewModel() {
+
+    var uiState by mutableStateOf(
+        AdminUserCreateUiState(
+            onUpdateCreateInfo = ::updateInfo,
+            onSave = ::createUser,
+            shownErrorMessage = ::shownErrorMessage
+        )
+    )
+        private set
+
+    private fun updateInfo(info: UserCreateInfoUiState) {
+        this.uiState = this.uiState.copy(createInfo = info)
+    }
+
+    private fun createUser() {
+        viewModelScope.launch {
+            uiState = uiState.copy(isInSaving = true)
+            val result = createUserUseCase(uiState.createInfo.toEntity())
+            uiState = uiState.copy(isInSaving = false)
+
+            uiState = if (result.isSuccess) {
+                uiState.copy(isSuccessToSave = true)
+            } else {
+                val message = result.exceptionOrNull()!!.message ?: "저장에 실패했습니다."
+                uiState.copy(errorMessage = message)
+            }
+        }
+    }
+
+    private fun shownErrorMessage() {
+        uiState = uiState.copy(errorMessage = null)
+    }
+}

--- a/presentation/src/main/java/com/pocs/presentation/view/component/dialog/PasswordDialog.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/dialog/PasswordDialog.kt
@@ -1,0 +1,110 @@
+package com.pocs.presentation.view.component.dialog
+
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.tooling.preview.Preview
+import com.pocs.presentation.R
+import kotlinx.coroutines.delay
+
+@Composable
+fun PasswordDialog(
+    onDismissRequest: () -> Unit,
+    onSaveClick: (password: String) -> Unit
+) {
+    var password by remember { mutableStateOf("") }
+    var passwordVisible by remember { mutableStateOf(false) }
+
+    PasswordDialogContent(
+        password = password,
+        passwordVisible = passwordVisible,
+        onPasswordChange = { password = it },
+        onClickPasswordVisibleButton = { passwordVisible = !passwordVisible },
+        onDismissRequest = onDismissRequest,
+        onSaveClick = onSaveClick
+    )
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+private fun PasswordDialogContent(
+    password: String,
+    passwordVisible: Boolean,
+    onPasswordChange: (String) -> Unit,
+    onClickPasswordVisibleButton: () -> Unit,
+    onDismissRequest: () -> Unit,
+    onSaveClick: (password: String) -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        title = { Text(text = stringResource(R.string.enter_password)) },
+        text = {
+            val keyboardController = LocalSoftwareKeyboardController.current
+            val focusRequester = remember { FocusRequester() }
+
+            LaunchedEffect(focusRequester) {
+                focusRequester.requestFocus()
+                delay(100)
+                keyboardController?.show()
+            }
+
+            OutlinedTextField(
+                modifier = Modifier.focusRequester(focusRequester),
+                value = password,
+                onValueChange = onPasswordChange,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                visualTransformation = if (passwordVisible) {
+                    VisualTransformation.None
+                } else {
+                    PasswordVisualTransformation()
+                },
+                trailingIcon = {
+                    val imageVector = if (passwordVisible) {
+                        Icons.Filled.Visibility
+                    } else {
+                        Icons.Filled.VisibilityOff
+                    }
+
+                    val description = if (passwordVisible) {
+                        stringResource(R.string.hide_password)
+                    } else {
+                        stringResource(R.string.show_password)
+                    }
+
+                    IconButton(onClick = onClickPasswordVisibleButton) {
+                        Icon(imageVector = imageVector, description)
+                    }
+                }
+            )
+        },
+        dismissButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text(text = stringResource(id = R.string.cancel))
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onSaveClick(password) }, enabled = password.isNotEmpty()) {
+                Text(text = stringResource(id = R.string.save))
+            }
+        }
+    )
+}
+
+
+@Preview(showBackground = true)
+@Composable
+fun PasswordDialogContent() {
+    PasswordDialogContent("1234", false, {}, {}, {}) {}
+}

--- a/presentation/src/main/java/com/pocs/presentation/view/component/textfield/PocsOutlineTextField.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/textfield/PocsOutlineTextField.kt
@@ -19,7 +19,8 @@ fun PocsOutlineTextField(
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     placeholder: String? = null,
     onValueChange: (String) -> Unit,
-    onClearClick: () -> Unit
+    onClearClick: () -> Unit,
+    preventToInputEnterKey: Boolean = true
 ) {
     OutlinedTextField(
         keyboardOptions = keyboardOptions,
@@ -27,7 +28,13 @@ fun PocsOutlineTextField(
             .fillMaxWidth()
             .padding(vertical = 8.dp),
         value = value,
-        onValueChange = onValueChange,
+        onValueChange = {
+            var newValue = it
+            if (preventToInputEnterKey) {
+                newValue = newValue.filterNot { char -> char == '\n' }
+            }
+            onValueChange(newValue)
+        },
         label = {
             Text(text = label)
         },

--- a/presentation/src/main/java/com/pocs/presentation/view/component/textfield/PocsOutlineTextField.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/textfield/PocsOutlineTextField.kt
@@ -1,0 +1,47 @@
+package com.pocs.presentation.view.component.textfield
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.pocs.presentation.R
+
+@Composable
+fun PocsOutlineTextField(
+    value: String,
+    label: String,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    placeholder: String? = null,
+    onValueChange: (String) -> Unit,
+    onClearClick: () -> Unit
+) {
+    OutlinedTextField(
+        keyboardOptions = keyboardOptions,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        value = value,
+        onValueChange = onValueChange,
+        label = {
+            Text(text = label)
+        },
+        placeholder = {
+            placeholder?.let { Text(text = it) }
+        },
+        trailingIcon = {
+            IconButton(onClick = onClearClick) {
+                Icon(
+                    imageVector = Icons.Filled.Clear,
+                    contentDescription = stringResource(R.string.clear_text_field),
+                    tint = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f)
+                )
+            }
+        }
+    )
+}

--- a/presentation/src/main/java/com/pocs/presentation/view/user/edit/UserEditScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/user/edit/UserEditScreen.kt
@@ -7,30 +7,22 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Person
-import androidx.compose.material.icons.filled.Visibility
-import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.pocs.presentation.R
 import com.pocs.presentation.model.user.UserEditUiState
 import com.pocs.presentation.view.component.RecheckHandler
 import com.pocs.presentation.view.component.appbar.EditContentAppBar
-import kotlinx.coroutines.delay
+import com.pocs.presentation.view.component.dialog.PasswordDialog
+import com.pocs.presentation.view.component.textfield.PocsOutlineTextField
 import kotlinx.coroutines.launch
 
 @Composable
@@ -52,7 +44,7 @@ fun UserEditContent(uiState: UserEditUiState, navigateUp: () -> Unit) {
     if (showPasswordDialog) {
         val failedToUpdateString = stringResource(R.string.failed_to_update)
 
-        UserEditPasswordDialog(
+        PasswordDialog(
             onDismissRequest = { showPasswordDialog = false },
             onSaveClick = { password ->
                 if (!uiState.isInSaving) {
@@ -98,7 +90,7 @@ fun UserEditContent(uiState: UserEditUiState, navigateUp: () -> Unit) {
                 .fillMaxWidth()
         ) {
             UserEditAvatar {}
-            UserEditTextField(
+            PocsOutlineTextField(
                 value = uiState.name,
                 label = stringResource(R.string.name),
                 onValueChange = { name ->
@@ -108,7 +100,7 @@ fun UserEditContent(uiState: UserEditUiState, navigateUp: () -> Unit) {
                     uiState.update { it.copy(name = "") }
                 }
             )
-            UserEditTextField(
+            PocsOutlineTextField(
                 value = uiState.email,
                 label = stringResource(R.string.email),
                 placeholder = stringResource(R.string.email_placeholder),
@@ -120,7 +112,7 @@ fun UserEditContent(uiState: UserEditUiState, navigateUp: () -> Unit) {
                     uiState.update { it.copy(email = "") }
                 }
             )
-            UserEditTextField(
+            PocsOutlineTextField(
                 value = uiState.company,
                 label = stringResource(R.string.company),
                 onValueChange = { company ->
@@ -130,7 +122,7 @@ fun UserEditContent(uiState: UserEditUiState, navigateUp: () -> Unit) {
                     uiState.update { it.copy(company = "") }
                 }
             )
-            UserEditTextField(
+            PocsOutlineTextField(
                 value = uiState.github,
                 label = stringResource(R.string.github),
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
@@ -166,124 +158,6 @@ fun UserEditAvatar(onClick: () -> Unit) {
     }
 }
 
-@Composable
-fun UserEditTextField(
-    value: String,
-    label: String,
-    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
-    placeholder: String? = null,
-    onValueChange: (String) -> Unit,
-    onClearClick: () -> Unit
-) {
-    OutlinedTextField(
-        keyboardOptions = keyboardOptions,
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 8.dp),
-        value = value,
-        onValueChange = onValueChange,
-        label = {
-            Text(text = label)
-        },
-        placeholder = {
-            placeholder?.let { Text(text = it) }
-        },
-        trailingIcon = {
-            IconButton(onClick = onClearClick) {
-                Icon(
-                    imageVector = Icons.Filled.Clear,
-                    contentDescription = stringResource(R.string.clear_text_field),
-                    tint = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f)
-                )
-            }
-        }
-    )
-}
-
-@Composable
-fun UserEditPasswordDialog(
-    onDismissRequest: () -> Unit,
-    onSaveClick: (password: String) -> Unit
-) {
-    var password by remember { mutableStateOf("") }
-    var passwordVisible by remember { mutableStateOf(false) }
-
-    UserEditPasswordDialogContent(
-        password = password,
-        passwordVisible = passwordVisible,
-        onPasswordChange = { password = it },
-        onClickPasswordVisibleButton = { passwordVisible = !passwordVisible },
-        onDismissRequest = onDismissRequest,
-        onSaveClick = onSaveClick
-    )
-}
-
-@OptIn(ExperimentalComposeUiApi::class)
-@Composable
-private fun UserEditPasswordDialogContent(
-    password: String,
-    passwordVisible: Boolean,
-    onPasswordChange: (String) -> Unit,
-    onClickPasswordVisibleButton: () -> Unit,
-    onDismissRequest: () -> Unit,
-    onSaveClick: (password: String) -> Unit
-) {
-    AlertDialog(
-        onDismissRequest = onDismissRequest,
-        title = { Text(text = stringResource(R.string.enter_password)) },
-        text = {
-            val keyboardController = LocalSoftwareKeyboardController.current
-            val focusRequester = remember { FocusRequester() }
-
-            LaunchedEffect(focusRequester) {
-                focusRequester.requestFocus()
-                delay(100)
-                keyboardController?.show()
-            }
-
-            OutlinedTextField(
-                modifier = Modifier.focusRequester(focusRequester),
-                value = password,
-                onValueChange = onPasswordChange,
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-                visualTransformation = if (passwordVisible) {
-                    VisualTransformation.None
-                } else {
-                    PasswordVisualTransformation()
-                },
-                trailingIcon = {
-                    val imageVector = if (passwordVisible) {
-                        Icons.Filled.Visibility
-                    } else {
-                        Icons.Filled.VisibilityOff
-                    }
-
-                    val description = if (passwordVisible) {
-                        stringResource(R.string.hide_password)
-                    } else {
-                        stringResource(R.string.show_password)
-                    }
-
-                    IconButton(onClick = onClickPasswordVisibleButton) {
-                        Icon(imageVector = imageVector, description)
-                    }
-                }
-            )
-        },
-        dismissButton = {
-            TextButton(onClick = onDismissRequest) {
-                Text(text = stringResource(id = R.string.cancel))
-            }
-        },
-        confirmButton = {
-            TextButton(onClick = { onSaveClick(password) }, enabled = password.isNotEmpty()) {
-                Text(text = stringResource(id = R.string.save))
-            }
-        }
-    )
-}
-
-
 @Preview
 @Composable
 fun UserEditContentPreview() {
@@ -298,10 +172,4 @@ fun UserEditContentPreview() {
             {}
         ) { Result.success(Unit) }
     ) {}
-}
-
-@Preview(showBackground = true)
-@Composable
-fun UserEditPasswordDialogContent() {
-    UserEditPasswordDialogContent("1234", false, {}, {}, {}) {}
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/user/edit/UserEditScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/user/edit/UserEditScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
@@ -33,7 +32,6 @@ fun UserEditScreen(viewModel: UserEditViewModel, navigateUp: () -> Unit) {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun UserEditContent(uiState: UserEditUiState, navigateUp: () -> Unit) {
-    val localFocusManager = LocalFocusManager.current
     val onBackPressedDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
     val coroutineScope = rememberCoroutineScope()
     val snackBarHostState = remember { SnackbarHostState() }
@@ -73,10 +71,7 @@ fun UserEditContent(uiState: UserEditUiState, navigateUp: () -> Unit) {
                 onBackPressed = { onBackPressedDispatcher?.onBackPressed() },
                 isInSaving = uiState.isInSaving,
                 enableSendIcon = true,
-                onClickSend = {
-                    localFocusManager.clearFocus()
-                    showPasswordDialog = true
-                }
+                onClickSend = { showPasswordDialog = true }
             )
         }
     ) { innerPadding ->

--- a/presentation/src/main/res/drawable/ic_baseline_add_24.xml
+++ b/presentation/src/main/res/drawable/ic_baseline_add_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+</vector>

--- a/presentation/src/main/res/layout/fragment_admin_user.xml
+++ b/presentation/src/main/res/layout/fragment_admin_user.xml
@@ -10,6 +10,8 @@
         android:id="@+id/recyclerView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:clipToPadding="false"
+        android:paddingBottom="@dimen/fab_height"
         tools:listitem="@layout/item_user" />
 
     <include
@@ -17,5 +19,18 @@
         layout="@layout/content_load_state"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
+
+    <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
+        android:id="@+id/fab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top"
+        android:layout_marginEnd="24dp"
+        android:layout_marginBottom="24dp"
+        android:text="@string/create_user"
+        app:icon="@drawable/ic_baseline_add_24"
+        app:layout_anchorGravity="top|end"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -52,6 +52,8 @@
     <string name="failed_to_update">수정에 실패했습니다.</string>
     <string name="more_info_button">더보기 버튼</string>
     <string name="is_kicked">탈퇴됨</string>
+    <string name="create_user">회원 생성</string>
+    <string name="type">타입</string>
     <string-array name="admin_tab">
         <item>공지사항</item>
         <item>회원목록</item>

--- a/test-library/src/main/java/com/pocs/test_library/fake/FakeAdminRepositoryImpl.kt
+++ b/test-library/src/main/java/com/pocs/test_library/fake/FakeAdminRepositoryImpl.kt
@@ -1,8 +1,8 @@
 package com.pocs.test_library.fake
 
 import androidx.paging.PagingData
+import com.pocs.domain.model.admin.UserCreateInfo
 import com.pocs.domain.model.user.User
-import com.pocs.domain.model.user.UserDetail
 import com.pocs.domain.repository.AdminRepository
 import com.pocs.test_library.mock.mockKickedUserDetail
 import kotlinx.coroutines.flow.Flow
@@ -19,7 +19,7 @@ class FakeAdminRepositoryImpl @Inject constructor() : AdminRepository {
 
     override suspend fun getUserDetail(id: Int) = userDetailResult
 
-    override suspend fun createUser(userDetail: UserDetail, password: String): Result<Unit> {
+    override suspend fun createUser(userCreateInfo: UserCreateInfo): Result<Unit> {
         TODO("Not yet implemented")
     }
 


### PR DESCRIPTION
Resolves #75, resolves #82 

**참고사항**
- 기존에 유저 편집 화면에서 사용하던 텍스트 필드를 재사용했습니다. 이 텍스트 필드의 이름은 `PocsOutlineTextField`입니다. 엔터키 입력을 못하도록 했습니다.

![image](https://user-images.githubusercontent.com/57604817/182199886-faa009b0-2a32-4de1-b347-587139bf175a.png)


## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [ ] Action에서 진행하는 테스트를 모두 통과했는가?
- [x] 수정 사항을 검증할 테스트를 추가하였는가?
- [ ] 리뷰를 받았는가?