### PR TITLE
PostDelete API 구현 및 UI 추가 구현

### DIFF
--- a/data/src/main/java/com/pocs/data/api/PostApi.kt
+++ b/data/src/main/java/com/pocs/data/api/PostApi.kt
@@ -4,6 +4,7 @@ import com.pocs.data.model.post.PostAddBody
 import com.pocs.data.model.post.PostDetailDto
 import com.pocs.data.model.post.PostListDto
 import com.pocs.data.model.ResponseBody
+import com.pocs.data.model.post.PostDeleteBody
 import retrofit2.http.*
 
 interface PostApi {
@@ -18,5 +19,11 @@ interface PostApi {
     @POST("posts")
     suspend fun addPost(
         @Body postAddBody: PostAddBody,
+    ): ResponseBody<Unit>
+
+    @PATCH("posts/{postId}/delete")
+    suspend fun deletePost(
+        @Path("postId") postId: Int,
+        @Body postDeleteBody: PostDeleteBody
     ): ResponseBody<Unit>
 }

--- a/data/src/main/java/com/pocs/data/model/post/PostDeleteBody.kt
+++ b/data/src/main/java/com/pocs/data/model/post/PostDeleteBody.kt
@@ -1,0 +1,5 @@
+package com.pocs.data.model.post
+
+data class PostDeleteBody(
+    val userId: Int
+)

--- a/data/src/main/java/com/pocs/data/repository/PostRepositoryImpl.kt
+++ b/data/src/main/java/com/pocs/data/repository/PostRepositoryImpl.kt
@@ -7,6 +7,7 @@ import com.pocs.data.api.PostApi
 import com.pocs.data.mapper.toDto
 import com.pocs.data.mapper.toEntity
 import com.pocs.data.model.post.PostAddBody
+import com.pocs.data.model.post.PostDeleteBody
 import com.pocs.data.paging.PostPagingSource
 import com.pocs.data.source.PostRemoteDataSource
 import com.pocs.domain.model.post.Post
@@ -77,7 +78,22 @@ class PostRepositoryImpl @Inject constructor(
         TODO("Not yet implemented")
     }
 
-    override suspend fun deletePost(postId: Int, userId: Int): Result<Unit> {
-        TODO("Not yet implemented")
+    override suspend fun deletePost(
+        postId: Int,
+        userId: Int
+    ): Result<Unit> {
+        return try {
+            val result = dataSource.deletePost(
+                postId = postId,
+                postDeleteBody = PostDeleteBody(userId = userId)
+            )
+            if (result.isSuccess) {
+                Result.success(Unit)
+            } else {
+                throw Exception(result.message)
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
     }
 }

--- a/data/src/main/java/com/pocs/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/pocs/data/repository/UserRepositoryImpl.kt
@@ -20,6 +20,20 @@ class UserRepositoryImpl @Inject constructor(
     private val dataSource: UserRemoteDataSource
 ) : UserRepository {
 
+    // TODO: 로그인 기능이 구현되면 실제 로그인한 사용자의 정보로 초기화하기
+    private val currentUser = UserDetail(
+        2,
+        "권김정",
+        "abc@google.com",
+        1971034,
+        UserType.ADMIN,
+        "-",
+        30,
+        "https://github.com/",
+        "2021-02-12",
+        "-",
+    )
+
     override fun getAll(sortingMethod: UserListSortingMethod): Flow<PagingData<User>> {
         return Pager(
             // TODO: API 페이지네이션 구현되면 페이지 사이즈 수정하기
@@ -68,8 +82,8 @@ class UserRepositoryImpl @Inject constructor(
         }
     }
 
-    override fun getCurrentUserType(): UserType {
-        // TODO: 로그인 기능 API 구현되면 현재 로그인한 유저의 타입을 반환하도록 수정하기
-        return UserType.ADMIN
+    override fun getCurrentUserDetail(): UserDetail {
+        // TODO: 로그인 기능 API 구현되면 현재 로그인한 유저를 반환하도록 수정하기
+        return currentUser
     }
 }

--- a/data/src/main/java/com/pocs/data/source/PostRemoteDataSource.kt
+++ b/data/src/main/java/com/pocs/data/source/PostRemoteDataSource.kt
@@ -4,9 +4,11 @@ import com.pocs.data.model.post.PostAddBody
 import com.pocs.data.model.post.PostDetailDto
 import com.pocs.data.model.post.PostListDto
 import com.pocs.data.model.ResponseBody
+import com.pocs.data.model.post.PostDeleteBody
 
 interface PostRemoteDataSource {
     suspend fun getAll(): ResponseBody<PostListDto>
     suspend fun getPostDetail(postId: Int): ResponseBody<PostDetailDto>
     suspend fun addPost(postAddBody: PostAddBody): ResponseBody<Unit>
+    suspend fun deletePost(postId: Int, postDeleteBody: PostDeleteBody): ResponseBody<Unit>
 }

--- a/data/src/main/java/com/pocs/data/source/PostRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/pocs/data/source/PostRemoteDataSourceImpl.kt
@@ -1,7 +1,9 @@
 package com.pocs.data.source
 
 import com.pocs.data.api.PostApi
+import com.pocs.data.model.ResponseBody
 import com.pocs.data.model.post.PostAddBody
+import com.pocs.data.model.post.PostDeleteBody
 import javax.inject.Inject
 
 class PostRemoteDataSourceImpl @Inject constructor(
@@ -13,4 +15,11 @@ class PostRemoteDataSourceImpl @Inject constructor(
     override suspend fun getPostDetail(postId: Int) = api.getPostDetail(postId)
 
     override suspend fun addPost(postAddBody: PostAddBody) = api.addPost(postAddBody)
+
+    override suspend fun deletePost(
+        postId: Int,
+        postDeleteBody: PostDeleteBody
+    ): ResponseBody<Unit> {
+        return api.deletePost(postId, postDeleteBody)
+    }
 }

--- a/domain/src/main/java/com/pocs/domain/repository/UserRepository.kt
+++ b/domain/src/main/java/com/pocs/domain/repository/UserRepository.kt
@@ -22,5 +22,5 @@ interface UserRepository {
         github: String
     ): Result<Unit>
 
-    fun getCurrentUserType(): UserType
+    fun getCurrentUserDetail(): UserDetail
 }

--- a/domain/src/main/java/com/pocs/domain/usecase/post/CanDeletePostUseCase.kt
+++ b/domain/src/main/java/com/pocs/domain/usecase/post/CanDeletePostUseCase.kt
@@ -1,0 +1,18 @@
+package com.pocs.domain.usecase.post
+
+import com.pocs.domain.model.post.PostDetail
+import com.pocs.domain.model.user.UserType
+import com.pocs.domain.repository.UserRepository
+import javax.inject.Inject
+
+class CanDeletePostUseCase @Inject constructor(
+    private val repository: UserRepository
+) {
+    operator fun invoke(postDetail: PostDetail): Boolean {
+        val currentUser = repository.getCurrentUserDetail()
+        if (currentUser.type == UserType.ADMIN) {
+            return true
+        }
+        return currentUser.id == postDetail.writer.id
+    }
+}

--- a/domain/src/main/java/com/pocs/domain/usecase/post/CanEditPostUseCase.kt
+++ b/domain/src/main/java/com/pocs/domain/usecase/post/CanEditPostUseCase.kt
@@ -1,0 +1,14 @@
+package com.pocs.domain.usecase.post
+
+import com.pocs.domain.model.post.PostDetail
+import com.pocs.domain.repository.UserRepository
+import javax.inject.Inject
+
+class CanEditPostUseCase @Inject constructor(
+    private val repository: UserRepository
+) {
+    operator fun invoke(postDetail: PostDetail): Boolean {
+        val currentUser = repository.getCurrentUserDetail()
+        return currentUser.id == postDetail.writer.id
+    }
+}

--- a/domain/src/main/java/com/pocs/domain/usecase/post/DeletePostUseCase.kt
+++ b/domain/src/main/java/com/pocs/domain/usecase/post/DeletePostUseCase.kt
@@ -1,13 +1,15 @@
 package com.pocs.domain.usecase.post
 
 import com.pocs.domain.repository.PostRepository
+import com.pocs.domain.repository.UserRepository
 import javax.inject.Inject
 
 class DeletePostUseCase @Inject constructor(
-    private val repository: PostRepository
+    private val postRepository: PostRepository,
+    private val userRepository: UserRepository
 ) {
-    suspend operator fun invoke(
-        postId: Int,
-        userId: Int
-    ) = repository.deletePost(postId = postId, userId = userId)
+    suspend operator fun invoke(postId: Int) : Result<Unit> {
+        val currentUserId = userRepository.getCurrentUserDetail().id
+        return postRepository.deletePost(postId = postId, userId = currentUserId)
+    }
 }

--- a/domain/src/main/java/com/pocs/domain/usecase/user/GetCurrentUserTypeUseCase.kt
+++ b/domain/src/main/java/com/pocs/domain/usecase/user/GetCurrentUserTypeUseCase.kt
@@ -1,10 +1,11 @@
 package com.pocs.domain.usecase.user
 
+import com.pocs.domain.model.user.UserType
 import com.pocs.domain.repository.UserRepository
 import javax.inject.Inject
 
 class GetCurrentUserTypeUseCase @Inject constructor(
     private val repository: UserRepository,
 ) {
-    operator fun invoke() = repository.getCurrentUserType()
+    operator fun invoke(): UserType = repository.getCurrentUserDetail().type
 }

--- a/domain/src/test/java/com/pocs/domain/CanDeletePostUseCaseTest.kt
+++ b/domain/src/test/java/com/pocs/domain/CanDeletePostUseCaseTest.kt
@@ -1,0 +1,87 @@
+package com.pocs.domain
+
+import com.pocs.domain.model.post.PostCategory
+import com.pocs.domain.model.post.PostDetail
+import com.pocs.domain.model.post.PostWriter
+import com.pocs.domain.model.user.UserDetail
+import com.pocs.domain.model.user.UserType
+import com.pocs.domain.usecase.post.CanDeletePostUseCase
+import com.pocs.test_library.fake.FakeUserRepositoryImpl
+import com.pocs.test_library.mock.mockPostWriter1
+import org.junit.Assert.*
+import org.junit.Test
+
+class CanDeletePostUseCaseTest {
+
+    private val userRepository = FakeUserRepositoryImpl()
+
+    private val useCase = CanDeletePostUseCase(userRepository)
+
+    private val postDetail = PostDetail(1, "", mockPostWriter1, "", "", "", PostCategory.NOTICE)
+    private val userDetail = UserDetail(
+        2,
+        "권김정",
+        "abc@google.com",
+        1971034,
+        UserType.ADMIN,
+        "-",
+        30,
+        "https://github.com/",
+        "2021-02-12",
+        "-",
+    )
+
+    @Test
+    fun shouldReturnTrue_WhenCurrentUserTypeIsAdmin() {
+        userRepository.currentUser = userDetail.copy(type = UserType.ADMIN)
+
+        val result = useCase(
+            postDetail = postDetail.copy(
+                writer = PostWriter(
+                    id = 987654321,
+                    name = "123",
+                    email = "123",
+                    type = UserType.ADMIN
+                )
+            )
+        )
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun shouldReturnTrue_WhenSamePostWriterIdAndCurrentUserId() {
+        userRepository.currentUser = userDetail
+
+        val result = useCase(
+            postDetail = postDetail.copy(
+                writer = PostWriter(
+                    id = userDetail.id,
+                    name = userDetail.name,
+                    email = userDetail.email,
+                    type = userDetail.type
+                )
+            )
+        )
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun shouldReturnFalse_WhenDifferentPostWriterIdAndCurrentUserId_AndNotAdmin() {
+        userRepository.currentUser = userDetail.copy(type = UserType.MEMBER)
+
+        val result = useCase(
+            postDetail = postDetail.copy(
+                writer = PostWriter(
+                    id = 987654321,
+                    name = "123",
+                    email = "123",
+                    type = UserType.ADMIN
+                )
+            )
+        )
+
+        assertFalse(result)
+    }
+}

--- a/domain/src/test/java/com/pocs/domain/CanEditPostUseCaseTest.kt
+++ b/domain/src/test/java/com/pocs/domain/CanEditPostUseCaseTest.kt
@@ -1,0 +1,69 @@
+package com.pocs.domain
+
+import com.pocs.domain.model.post.PostCategory
+import com.pocs.domain.model.post.PostDetail
+import com.pocs.domain.model.post.PostWriter
+import com.pocs.domain.model.user.UserDetail
+import com.pocs.domain.model.user.UserType
+import com.pocs.domain.usecase.post.CanEditPostUseCase
+import com.pocs.test_library.fake.FakeUserRepositoryImpl
+import com.pocs.test_library.mock.mockPostWriter1
+import org.junit.Assert.*
+import org.junit.Test
+
+class CanEditPostUseCaseTest {
+
+    private val userRepository = FakeUserRepositoryImpl()
+
+    private val useCase = CanEditPostUseCase(userRepository)
+
+    private val postDetail = PostDetail(1, "", mockPostWriter1, "", "", "", PostCategory.NOTICE)
+    private val userDetail = UserDetail(
+        2,
+        "권김정",
+        "abc@google.com",
+        1971034,
+        UserType.ADMIN,
+        "-",
+        30,
+        "https://github.com/",
+        "2021-02-12",
+        "-",
+    )
+
+    @Test
+    fun shouldReturnTrue_WhenSamePostWriterIdAndCurrentUserId() {
+        userRepository.currentUser = userDetail
+
+        val result = useCase(
+            postDetail = postDetail.copy(
+                writer = PostWriter(
+                    id = userDetail.id,
+                    name = userDetail.name,
+                    email = userDetail.email,
+                    type = userDetail.type
+                )
+            )
+        )
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun shouldReturnFalse_WhenDifferentPostWriterIdAndCurrentUserId() {
+        userRepository.currentUser = userDetail
+
+        val result = useCase(
+            postDetail = postDetail.copy(
+                writer = PostWriter(
+                    id = 987654321,
+                    name = "123",
+                    email = "123",
+                    type = UserType.ADMIN
+                )
+            )
+        )
+
+        assertFalse(result)
+    }
+}

--- a/domain/src/test/java/com/pocs/domain/GetUserDetailUseCaseTest.kt
+++ b/domain/src/test/java/com/pocs/domain/GetUserDetailUseCaseTest.kt
@@ -34,7 +34,7 @@ class GetUserDetailUseCaseTest {
 
     @Test
     fun returnsUserDetailFromAdmin_WhenCurrentUserTypeIsAdmin() {
-        userRepository.userType = UserType.ADMIN
+        userRepository.changeCurrentUserType(UserType.ADMIN)
 
         runBlocking {
             val result = getUserDetailUseCase(userDetailFromAdmin.id)
@@ -44,7 +44,7 @@ class GetUserDetailUseCaseTest {
 
     @Test
     fun returnsUserDetailFromMember_WhenCurrentUserTypeIsMember() {
-        userRepository.userType = UserType.MEMBER
+        userRepository.changeCurrentUserType(UserType.MEMBER)
 
         runBlocking {
             val result = getUserDetailUseCase(userDetailFromMember.id)
@@ -54,7 +54,7 @@ class GetUserDetailUseCaseTest {
 
     @Test
     fun returnsFailureResult_WhenCurrentUserTypeIsUnknown() {
-        userRepository.userType = UserType.UNKNOWN
+        userRepository.changeCurrentUserType(UserType.UNKNOWN)
 
         runBlocking {
             val result = getUserDetailUseCase(userDetailFromMember.id)

--- a/presentation/src/androidTest/java/com/pocs/presentation/UserDetailActivityTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/UserDetailActivityTest.kt
@@ -68,6 +68,7 @@ class UserDetailActivityTest {
     fun setUp() {
         hiltRule.inject()
         context = InstrumentationRegistry.getInstrumentation().targetContext
+        userRepository.currentUser = userDetail.copy(type = UserType.MEMBER)
     }
 
     @Test

--- a/presentation/src/main/java/com/pocs/presentation/mapper/PostDetailMapper.kt
+++ b/presentation/src/main/java/com/pocs/presentation/mapper/PostDetailMapper.kt
@@ -7,7 +7,7 @@ fun PostDetail.toUiState() = PostDetailItemUiState(
     id = id,
     title = title,
     content = content,
-    writer = writer.name,
+    writer = writer.toUiState(),
     date = createdAt,
     category = category
 )

--- a/presentation/src/main/java/com/pocs/presentation/mapper/PostWriterMapper.kt
+++ b/presentation/src/main/java/com/pocs/presentation/mapper/PostWriterMapper.kt
@@ -1,0 +1,9 @@
+package com.pocs.presentation.mapper
+
+import com.pocs.domain.model.post.PostWriter
+import com.pocs.presentation.model.post.item.PostWriterUiState
+
+fun PostWriter.toUiState() = PostWriterUiState(
+    name = name,
+    id = id
+)

--- a/presentation/src/main/java/com/pocs/presentation/model/post/PostDetailUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/post/PostDetailUiState.kt
@@ -3,8 +3,11 @@ package com.pocs.presentation.model.post
 import com.pocs.presentation.model.post.item.PostDetailItemUiState
 
 sealed class PostDetailUiState {
-
-    class Success(val postDetail: PostDetailItemUiState) : PostDetailUiState()
+    class Success(
+        val postDetail: PostDetailItemUiState,
+        val canEditPost: Boolean,
+        val canDeletePost: Boolean
+    ) : PostDetailUiState()
 
     class Failure(val message: String?) : PostDetailUiState()
 

--- a/presentation/src/main/java/com/pocs/presentation/model/post/PostDetailUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/post/PostDetailUiState.kt
@@ -3,13 +3,15 @@ package com.pocs.presentation.model.post
 import com.pocs.presentation.model.post.item.PostDetailItemUiState
 
 sealed class PostDetailUiState {
-    class Success(
+    data class Success(
         val postDetail: PostDetailItemUiState,
         val canEditPost: Boolean,
-        val canDeletePost: Boolean
+        val canDeletePost: Boolean,
+        val isSuccessToDelete: Boolean = false,
+        val errorMessage: String? = null
     ) : PostDetailUiState()
 
-    class Failure(val message: String?) : PostDetailUiState()
+    data class Failure(val message: String?) : PostDetailUiState()
 
     object Loading : PostDetailUiState()
 }

--- a/presentation/src/main/java/com/pocs/presentation/model/post/item/PostDetailItemUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/post/item/PostDetailItemUiState.kt
@@ -6,7 +6,7 @@ data class PostDetailItemUiState(
     val id: Int,
     val title: String,
     val content: String,
-    val writer: String,
+    val writer: PostWriterUiState,
     val date: String,
     val category: PostCategory
 )

--- a/presentation/src/main/java/com/pocs/presentation/model/post/item/PostWriterUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/post/item/PostWriterUiState.kt
@@ -1,0 +1,6 @@
+package com.pocs.presentation.model.post.item
+
+data class PostWriterUiState(
+    val name: String,
+    val id: Int
+)

--- a/presentation/src/main/java/com/pocs/presentation/view/home/article/ArticleFragment.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/home/article/ArticleFragment.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.android.material.snackbar.Snackbar
 import com.pocs.domain.model.post.PostCategory
 import com.pocs.presentation.R
 import com.pocs.presentation.databinding.FragmentArticleBinding
@@ -69,6 +70,11 @@ class ArticleFragment : Fragment(R.layout.fragment_article) {
         launcher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
             if (it.resultCode == RESULT_OK) {
                 adapter.refresh()
+
+                val message = it.data?.getStringExtra("message")
+                if (message != null) {
+                    showSnackBar(message)
+                }
             }
         }
     }
@@ -84,7 +90,13 @@ class ArticleFragment : Fragment(R.layout.fragment_article) {
 
     private fun onClickArticle(postItemUiState: PostItemUiState) {
         val intent = PostDetailActivity.getIntent(requireContext(), postItemUiState.id)
-        startActivity(intent)
+        launcher?.launch(intent)
+    }
+
+    private fun showSnackBar(message: String) {
+        Snackbar.make(binding.root, message, Snackbar.LENGTH_SHORT).apply {
+            anchorView = binding.fab
+        }.show()
     }
 
     private fun startPostCreateActivity() {

--- a/presentation/src/main/java/com/pocs/presentation/view/home/notice/NoticeFragment.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/home/notice/NoticeFragment.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.android.material.snackbar.Snackbar
 import com.pocs.domain.model.post.PostCategory
 import com.pocs.presentation.R
 import com.pocs.presentation.databinding.FragmentNoticeBinding
@@ -70,6 +71,11 @@ class NoticeFragment : Fragment(R.layout.fragment_notice) {
         launcher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
             if (it.resultCode == Activity.RESULT_OK) {
                 adapter.refresh()
+
+                val message = it.data?.getStringExtra("message")
+                if (message != null) {
+                    showSnackBar(message)
+                }
             }
         }
     }
@@ -86,6 +92,12 @@ class NoticeFragment : Fragment(R.layout.fragment_notice) {
     private fun onClickArticle(postItemUiState: PostItemUiState) {
         val intent = PostDetailActivity.getIntent(requireContext(), postItemUiState.id)
         startActivity(intent)
+    }
+
+    private fun showSnackBar(message: String) {
+        Snackbar.make(binding.root, message, Snackbar.LENGTH_SHORT).apply {
+            anchorView = binding.fab
+        }.show()
     }
 
     private fun startPostCreateActivity() {

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailActivity.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailActivity.kt
@@ -32,6 +32,8 @@ class PostDetailActivity : AppCompatActivity() {
 
     private var launcher: ActivityResultLauncher<Intent>? = null
 
+    private val id = intent.getIntExtra("id", -1)
+
     companion object {
         fun getIntent(context: Context, id: Int): Intent {
             return Intent(context, PostDetailActivity::class.java).apply {
@@ -87,7 +89,6 @@ class PostDetailActivity : AppCompatActivity() {
                 true
             }
             R.id.action_delete_post -> {
-                // TODO: 삭제 API 연동 후 구현하기
                 deletePost()
                 true
             }
@@ -96,7 +97,6 @@ class PostDetailActivity : AppCompatActivity() {
     }
 
     private fun fetchPost() {
-        val id = intent.getIntExtra("id", -1)
         viewModel.fetchPost(id)
     }
 
@@ -114,7 +114,8 @@ class PostDetailActivity : AppCompatActivity() {
                 val postDetail = uiState.postDetail
 
                 title.text = postDetail.title
-                subtitle.text = getString(R.string.article_subtitle, postDetail.date, postDetail.writer)
+                subtitle.text =
+                    getString(R.string.article_subtitle, postDetail.date, postDetail.writer)
                 content.text = postDetail.content
             }
             is PostDetailUiState.Failure -> {
@@ -139,8 +140,9 @@ class PostDetailActivity : AppCompatActivity() {
         )
         launcher?.launch(intent)
     }
-    private fun deletePost(){
-        //viewModel.deletePost()
+
+    private fun deletePost() {
+        viewModel.deletePost(id)
         this.finish()
     }
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailActivity.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailActivity.kt
@@ -88,6 +88,7 @@ class PostDetailActivity : AppCompatActivity() {
             }
             R.id.action_delete_post -> {
                 // TODO: 삭제 API 연동 후 구현하기
+                deletePost()
                 true
             }
             else -> super.onOptionsItemSelected(item)
@@ -137,5 +138,9 @@ class PostDetailActivity : AppCompatActivity() {
             postDetail.category
         )
         launcher?.launch(intent)
+    }
+    private fun deletePost(){
+        //viewModel.deletePost()
+        this.finish()
     }
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailActivity.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailActivity.kt
@@ -76,9 +76,17 @@ class PostDetailActivity : AppCompatActivity() {
 
     override fun onPrepareOptionsMenu(menu: Menu): Boolean {
         val uiState = viewModel.uiState.value
-        val isSuccess = uiState is PostDetailUiState.Success
-        // TODO: 작성자인 경우에만 보이도록 하기
-        menu.children.forEach { it.isVisible = isSuccess }
+
+        menu.children.forEach {
+            when (it.itemId) {
+                R.id.action_edit_post -> {
+                    it.isVisible = (uiState as? PostDetailUiState.Success)?.canEditPost ?: false
+                }
+                R.id.action_delete_post -> {
+                    it.isVisible = (uiState as? PostDetailUiState.Success)?.canDeletePost ?: false
+                }
+            }
+        }
         return true
     }
 
@@ -114,8 +122,11 @@ class PostDetailActivity : AppCompatActivity() {
                 val postDetail = uiState.postDetail
 
                 title.text = postDetail.title
-                subtitle.text =
-                    getString(R.string.article_subtitle, postDetail.date, postDetail.writer)
+                subtitle.text = getString(
+                    R.string.article_subtitle,
+                    postDetail.date,
+                    postDetail.writer.name
+                )
                 content.text = postDetail.content
             }
             is PostDetailUiState.Failure -> {

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailActivity.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailActivity.kt
@@ -15,6 +15,7 @@ import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.pocs.presentation.R
 import com.pocs.presentation.databinding.ActivityPostDetailBinding
 import com.pocs.presentation.model.post.PostDetailUiState
@@ -31,8 +32,6 @@ class PostDetailActivity : AppCompatActivity() {
     private val viewModel: PostDetailViewModel by viewModels()
 
     private var launcher: ActivityResultLauncher<Intent>? = null
-
-    private val id = intent.getIntExtra("id", -1)
 
     companion object {
         fun getIntent(context: Context, id: Int): Intent {
@@ -97,7 +96,7 @@ class PostDetailActivity : AppCompatActivity() {
                 true
             }
             R.id.action_delete_post -> {
-                deletePost()
+                showRecheckDialog()
                 true
             }
             else -> super.onOptionsItemSelected(item)
@@ -105,6 +104,7 @@ class PostDetailActivity : AppCompatActivity() {
     }
 
     private fun fetchPost() {
+        val id = intent.getIntExtra("id", -1)
         viewModel.fetchPost(id)
     }
 
@@ -137,6 +137,22 @@ class PostDetailActivity : AppCompatActivity() {
         }
     }
 
+    private fun showRecheckDialog() {
+       MaterialAlertDialogBuilder(this).apply {
+            setTitle(getString(R.string.are_you_sure_you_want_to_delete))
+            setPositiveButton(getString(R.string.delete)) { _, _ ->
+                deletePost()
+            }
+            setNegativeButton(getString(R.string.cancel)) { _, _ -> }
+        }.show()
+    }
+
+    private fun deletePost() {
+        val postId = intent.getIntExtra("id", -1)
+        viewModel.deletePost(postId)
+        this.finish()
+    }
+
     private fun startPostEditActivity() {
         val uiState = viewModel.uiState.value
         if (uiState !is PostDetailUiState.Success) return
@@ -150,10 +166,5 @@ class PostDetailActivity : AppCompatActivity() {
             postDetail.category
         )
         launcher?.launch(intent)
-    }
-
-    private fun deletePost() {
-        viewModel.deletePost(id)
-        this.finish()
     }
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailActivity.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailActivity.kt
@@ -16,6 +16,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.snackbar.Snackbar
 import com.pocs.presentation.R
 import com.pocs.presentation.databinding.ActivityPostDetailBinding
 import com.pocs.presentation.model.post.PostDetailUiState
@@ -128,6 +129,15 @@ class PostDetailActivity : AppCompatActivity() {
                     postDetail.writer.name
                 )
                 content.text = postDetail.content
+
+                if (uiState.isSuccessToDelete) {
+                    finish()
+                    // TODO: 이전 엑티비티에서 "삭제됨" 스낵바 띄우기
+                }
+                if (uiState.errorMessage != null) {
+                    showSnackBar(uiState.errorMessage)
+                    viewModel.shownErrorMessage()
+                }
             }
             is PostDetailUiState.Failure -> {
                 title.text = getString(R.string.failed_to_load)
@@ -141,16 +151,19 @@ class PostDetailActivity : AppCompatActivity() {
        MaterialAlertDialogBuilder(this).apply {
             setTitle(getString(R.string.are_you_sure_you_want_to_delete))
             setPositiveButton(getString(R.string.delete)) { _, _ ->
-                deletePost()
+                requestPostDeleting()
             }
             setNegativeButton(getString(R.string.cancel)) { _, _ -> }
         }.show()
     }
 
-    private fun deletePost() {
+    private fun showSnackBar(message: String) {
+        Snackbar.make(binding.root, message, Snackbar.LENGTH_SHORT).show()
+    }
+
+    private fun requestPostDeleting() {
         val postId = intent.getIntExtra("id", -1)
-        viewModel.deletePost(postId)
-        this.finish()
+        viewModel.requestPostDeleting(postId)
     }
 
     private fun startPostEditActivity() {

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailActivity.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailActivity.kt
@@ -104,6 +104,12 @@ class PostDetailActivity : AppCompatActivity() {
         }
     }
 
+    private fun onDeleteSuccess() {
+        val intent = Intent().putExtra("message", getString(R.string.post_deleted))
+        setResult(RESULT_OK, intent)
+        finish()
+    }
+
     private fun fetchPost() {
         val id = intent.getIntExtra("id", -1)
         viewModel.fetchPost(id)
@@ -131,8 +137,7 @@ class PostDetailActivity : AppCompatActivity() {
                 content.text = postDetail.content
 
                 if (uiState.isSuccessToDelete) {
-                    finish()
-                    // TODO: 이전 엑티비티에서 "삭제됨" 스낵바 띄우기
+                    onDeleteSuccess()
                 }
                 if (uiState.errorMessage != null) {
                     showSnackBar(uiState.errorMessage)

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailViewModel.kt
@@ -49,13 +49,29 @@ class PostDetailViewModel @Inject constructor(
         }
     }
 
-    fun deletePost(id: Int) {
+    fun requestPostDeleting(id: Int) {
+        assert(_uiState.value is PostDetailUiState.Success)
         viewModelScope.launch {
-            deletePostUseCase(
-                postId = id,
-                // TODO: 현재 접속중인 유저의 ID로 변경하기
-                userId = 1
-            )
+            val result = deletePostUseCase(postId = id)
+
+            if (result.isSuccess) {
+                _uiState.update {
+                    (it as PostDetailUiState.Success).copy(isSuccessToDelete = true)
+                }
+            } else {
+                _uiState.update {
+                    val errorMessage = result.exceptionOrNull()!!.message ?: "삭제에 실패했습니다."
+                    (it as PostDetailUiState.Success).copy(errorMessage = errorMessage)
+                }
+            }
+        }
+    }
+
+    fun shownErrorMessage() {
+        val uiStateValue = _uiState.value
+        if(uiStateValue !is PostDetailUiState.Success) return
+        _uiState.update {
+            uiStateValue.copy(errorMessage = null)
         }
     }
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailViewModel.kt
@@ -17,7 +17,7 @@ import javax.inject.Inject
 @HiltViewModel
 class PostDetailViewModel @Inject constructor(
     private val getPostDetailUseCase: GetPostDetailUseCase,
-    private val deletePostUseCase : DeletePostUseCase
+    private val deletePostUseCase: DeletePostUseCase
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<PostDetailUiState>(PostDetailUiState.Loading)
@@ -38,9 +38,14 @@ class PostDetailViewModel @Inject constructor(
             }
         }
     }
-    fun deletePost(id : Int){
+
+    fun deletePost(id: Int) {
         viewModelScope.launch {
-            val result = deletePostUseCase
+            deletePostUseCase(
+                postId = id,
+                // TODO: 현재 접속중인 유저의 ID로 변경하기
+                userId = 1
+            )
         }
     }
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailViewModel.kt
@@ -2,6 +2,7 @@ package com.pocs.presentation.view.post.detail
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.pocs.domain.usecase.post.DeletePostUseCase
 import com.pocs.domain.usecase.post.GetPostDetailUseCase
 import com.pocs.presentation.mapper.toUiState
 import com.pocs.presentation.model.post.PostDetailUiState
@@ -15,7 +16,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class PostDetailViewModel @Inject constructor(
-    private val getPostDetailUseCase: GetPostDetailUseCase
+    private val getPostDetailUseCase: GetPostDetailUseCase,
+    private val deletePostUseCase : DeletePostUseCase
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<PostDetailUiState>(PostDetailUiState.Loading)
@@ -34,6 +36,11 @@ class PostDetailViewModel @Inject constructor(
                 val errorMessage = result.exceptionOrNull()!!.message
                 _uiState.update { PostDetailUiState.Failure(message = errorMessage) }
             }
+        }
+    }
+    fun deletePost(id : Int){
+        viewModelScope.launch {
+            val result = deletePostUseCase
         }
     }
 }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -54,6 +54,7 @@
     <string name="is_kicked">탈퇴됨</string>
     <string name="create_user">회원 생성</string>
     <string name="type">타입</string>
+    <string name="are_you_sure_you_want_to_delete">정말로 삭제하시겠습니까?</string>
     <string-array name="admin_tab">
         <item>공지사항</item>
         <item>회원목록</item>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -55,6 +55,7 @@
     <string name="create_user">회원 생성</string>
     <string name="type">타입</string>
     <string name="are_you_sure_you_want_to_delete">정말로 삭제하시겠습니까?</string>
+    <string name="post_deleted">글이 삭제됨</string>
     <string-array name="admin_tab">
         <item>공지사항</item>
         <item>회원목록</item>

--- a/presentation/src/test/java/com/pocs/presentation/UserDetailViewModelTest.kt
+++ b/presentation/src/test/java/com/pocs/presentation/UserDetailViewModelTest.kt
@@ -51,6 +51,7 @@ class UserDetailViewModelTest {
                 getCurrentUserTypeUseCase = GetCurrentUserTypeUseCase(userRepository)
             ),
         )
+        userRepository.currentUser = mockUserDetail
     }
 
     @After

--- a/test-library/src/main/java/com/pocs/test_library/fake/FakePostRepositoryImpl.kt
+++ b/test-library/src/main/java/com/pocs/test_library/fake/FakePostRepositoryImpl.kt
@@ -13,6 +13,8 @@ class FakePostRepositoryImpl @Inject constructor() : PostRepository {
     private val postFlow = MutableSharedFlow<PagingData<Post>>()
     var postDetailResult: Result<PostDetail> = Result.failure(Exception())
 
+    var deletePostResult = Result.success(Unit)
+
 //    suspend fun emit(pagingData: PagingData<Post>) {
 //        postFlow.emit(pagingData)
 //    }
@@ -42,7 +44,5 @@ class FakePostRepositoryImpl @Inject constructor() : PostRepository {
         TODO("Not yet implemented")
     }
 
-    override suspend fun deletePost(postId: Int, userId: Int): Result<Unit> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun deletePost(postId: Int, userId: Int) = deletePostResult
 }

--- a/test-library/src/main/java/com/pocs/test_library/fake/FakeUserRepositoryImpl.kt
+++ b/test-library/src/main/java/com/pocs/test_library/fake/FakeUserRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.pocs.domain.model.user.UserDetail
 import com.pocs.domain.model.user.UserListSortingMethod
 import com.pocs.domain.model.user.UserType
 import com.pocs.domain.repository.UserRepository
+import com.pocs.test_library.mock.mockNormalUserDetail
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
@@ -14,7 +15,11 @@ class FakeUserRepositoryImpl @Inject constructor() : UserRepository {
 
     var userDetailResult: Result<UserDetail> = Result.failure(Exception("Empty"))
 
-    var userType: UserType = UserType.MEMBER
+    var currentUser: UserDetail = mockNormalUserDetail
+
+    fun changeCurrentUserType(userType: UserType) {
+        currentUser = currentUser.copy(type = userType)
+    }
 
     override fun getAll(sortingMethod: UserListSortingMethod): Flow<PagingData<User>> {
         return flow {
@@ -35,5 +40,5 @@ class FakeUserRepositoryImpl @Inject constructor() : UserRepository {
         TODO("Not yet implemented")
     }
 
-    override fun getCurrentUserType() = userType
+    override fun getCurrentUserDetail() = currentUser
 }


### PR DESCRIPTION
<!-- 이곳에 PR 내용을 작성하세요 -->

resovles #37 

- Post 삭제를 위한 API 연결,
- PostWriterUIstate 생성을 위한 PostDeleteMapper 수정 및 WriterMapper 생성
- ViewModel 기능 구현 과정에서 필요한 CanEditUseCase , CandeleteUseCase 의 생성
- ViewModel 과 Activity에서는 사용자의 권한에 따라 menu가 보이거나 보이지않는 설정 추가
- 삭제가 되었을때, 이전의 Acitvity에서 SnackBar가 보이도록 함



## Merge 전 체크리스트

- [X] 코딩 컨벤션을 지켰는가?
- [ ] Action에서 진행하는 테스트를 모두 통과했는가?
- [X] 수정 사항을 검증할 테스트를 추가하였는가?
- [ ] 리뷰를 받았는가?