### PR TITLE
Post 편집 기능 API 연결 및 기능 구현 및 보완

### DIFF
--- a/data/src/main/java/com/pocs/data/api/PostApi.kt
+++ b/data/src/main/java/com/pocs/data/api/PostApi.kt
@@ -2,6 +2,7 @@ package com.pocs.data.api
 
 import com.pocs.data.model.ResponseBody
 import com.pocs.data.model.post.*
+import retrofit2.Response
 import retrofit2.http.*
 
 interface PostApi {
@@ -28,5 +29,5 @@ interface PostApi {
     suspend fun updatePost(
         @Path("postId") PostId: Int,
         @Body postUpdateBody: PostUpdateBody
-    ): ResponseBody<Unit>
+    ): Response<Unit>
 }

--- a/data/src/main/java/com/pocs/data/api/PostApi.kt
+++ b/data/src/main/java/com/pocs/data/api/PostApi.kt
@@ -1,10 +1,7 @@
 package com.pocs.data.api
 
-import com.pocs.data.model.post.PostAddBody
-import com.pocs.data.model.post.PostDetailDto
-import com.pocs.data.model.post.PostListDto
 import com.pocs.data.model.ResponseBody
-import com.pocs.data.model.post.PostDeleteBody
+import com.pocs.data.model.post.*
 import retrofit2.http.*
 
 interface PostApi {
@@ -25,5 +22,11 @@ interface PostApi {
     suspend fun deletePost(
         @Path("postId") postId: Int,
         @Body postDeleteBody: PostDeleteBody
+    ): ResponseBody<Unit>
+
+    @PATCH("posts/{postId}")
+    suspend fun updatePost(
+        @Path("postId") PostId: Int,
+        @Body postUpdateBody: PostUpdateBody
     ): ResponseBody<Unit>
 }

--- a/data/src/main/java/com/pocs/data/api/PostApi.kt
+++ b/data/src/main/java/com/pocs/data/api/PostApi.kt
@@ -27,7 +27,7 @@ interface PostApi {
 
     @PATCH("posts/{postId}")
     suspend fun updatePost(
-        @Path("postId") PostId: Int,
+        @Path("postId") postId: Int,
         @Body postUpdateBody: PostUpdateBody
     ): Response<Unit>
 }

--- a/data/src/main/java/com/pocs/data/model/post/PostUpdateBody.kt
+++ b/data/src/main/java/com/pocs/data/model/post/PostUpdateBody.kt
@@ -1,0 +1,8 @@
+package com.pocs.data.model.post
+
+data class PostUpdateBody(
+    val title: String,
+    val content: String,
+    val userId: Int,
+    val category: String
+)

--- a/data/src/main/java/com/pocs/data/repository/PostRepositoryImpl.kt
+++ b/data/src/main/java/com/pocs/data/repository/PostRepositoryImpl.kt
@@ -8,6 +8,7 @@ import com.pocs.data.mapper.toDto
 import com.pocs.data.mapper.toEntity
 import com.pocs.data.model.post.PostAddBody
 import com.pocs.data.model.post.PostDeleteBody
+import com.pocs.data.model.post.PostUpdateBody
 import com.pocs.data.paging.PostPagingSource
 import com.pocs.data.source.PostRemoteDataSource
 import com.pocs.domain.model.post.Post
@@ -69,13 +70,30 @@ class PostRepositoryImpl @Inject constructor(
     }
 
     override suspend fun updatePost(
-        id: Int,
+        postId: Int,
         title: String,
         content: String,
         userId: Int,
         category: PostCategory
     ): Result<Unit> {
-        TODO("Not yet implemented")
+        return try {
+            val result = dataSource.updatePost(
+                postId = postId,
+                postUpdateBody = PostUpdateBody(
+                    title = title,
+                    content = content,
+                    userId = userId,
+                    category = category.toDto()
+                )
+            )
+            if (result.isSuccess) {
+                Result.success(Unit)
+            } else {
+                throw Exception(result.message)
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
     }
 
     override suspend fun deletePost(

--- a/data/src/main/java/com/pocs/data/repository/PostRepositoryImpl.kt
+++ b/data/src/main/java/com/pocs/data/repository/PostRepositoryImpl.kt
@@ -77,7 +77,7 @@ class PostRepositoryImpl @Inject constructor(
         category: PostCategory
     ): Result<Unit> {
         return try {
-            val result = dataSource.updatePost(
+            val responce = dataSource.updatePost(
                 postId = postId,
                 postUpdateBody = PostUpdateBody(
                     title = title,
@@ -86,10 +86,10 @@ class PostRepositoryImpl @Inject constructor(
                     category = category.toDto()
                 )
             )
-            if (result.isSuccess) {
+            if (responce.code() == 302) {
                 Result.success(Unit)
             } else {
-                throw Exception(result.message)
+                throw Exception(responce.message())
             }
         } catch (e: Exception) {
             Result.failure(e)

--- a/data/src/main/java/com/pocs/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/pocs/data/repository/UserRepositoryImpl.kt
@@ -22,7 +22,7 @@ class UserRepositoryImpl @Inject constructor(
 
     // TODO: 로그인 기능이 구현되면 실제 로그인한 사용자의 정보로 초기화하기
     private val currentUser = UserDetail(
-        2,
+        1,
         "권김정",
         "abc@google.com",
         1971034,

--- a/data/src/main/java/com/pocs/data/source/PostRemoteDataSource.kt
+++ b/data/src/main/java/com/pocs/data/source/PostRemoteDataSource.kt
@@ -1,14 +1,12 @@
 package com.pocs.data.source
 
-import com.pocs.data.model.post.PostAddBody
-import com.pocs.data.model.post.PostDetailDto
-import com.pocs.data.model.post.PostListDto
 import com.pocs.data.model.ResponseBody
-import com.pocs.data.model.post.PostDeleteBody
+import com.pocs.data.model.post.*
 
 interface PostRemoteDataSource {
     suspend fun getAll(): ResponseBody<PostListDto>
     suspend fun getPostDetail(postId: Int): ResponseBody<PostDetailDto>
     suspend fun addPost(postAddBody: PostAddBody): ResponseBody<Unit>
     suspend fun deletePost(postId: Int, postDeleteBody: PostDeleteBody): ResponseBody<Unit>
+    suspend fun updatePost(postId: Int, postUpdateBody: PostUpdateBody): ResponseBody<Unit>
 }

--- a/data/src/main/java/com/pocs/data/source/PostRemoteDataSource.kt
+++ b/data/src/main/java/com/pocs/data/source/PostRemoteDataSource.kt
@@ -2,11 +2,12 @@ package com.pocs.data.source
 
 import com.pocs.data.model.ResponseBody
 import com.pocs.data.model.post.*
+import retrofit2.Response
 
 interface PostRemoteDataSource {
     suspend fun getAll(): ResponseBody<PostListDto>
     suspend fun getPostDetail(postId: Int): ResponseBody<PostDetailDto>
     suspend fun addPost(postAddBody: PostAddBody): ResponseBody<Unit>
     suspend fun deletePost(postId: Int, postDeleteBody: PostDeleteBody): ResponseBody<Unit>
-    suspend fun updatePost(postId: Int, postUpdateBody: PostUpdateBody): ResponseBody<Unit>
+    suspend fun updatePost(postId: Int, postUpdateBody: PostUpdateBody): Response<Unit>
 }

--- a/data/src/main/java/com/pocs/data/source/PostRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/pocs/data/source/PostRemoteDataSourceImpl.kt
@@ -5,6 +5,7 @@ import com.pocs.data.model.ResponseBody
 import com.pocs.data.model.post.PostAddBody
 import com.pocs.data.model.post.PostDeleteBody
 import com.pocs.data.model.post.PostUpdateBody
+import retrofit2.Response
 import javax.inject.Inject
 
 class PostRemoteDataSourceImpl @Inject constructor(
@@ -27,7 +28,7 @@ class PostRemoteDataSourceImpl @Inject constructor(
     override suspend fun updatePost(
         postId: Int,
         postUpdateBody: PostUpdateBody
-    ): ResponseBody<Unit> {
+    ): Response<Unit> {
         return api.updatePost(postId, postUpdateBody)
     }
 }

--- a/data/src/main/java/com/pocs/data/source/PostRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/pocs/data/source/PostRemoteDataSourceImpl.kt
@@ -4,6 +4,7 @@ import com.pocs.data.api.PostApi
 import com.pocs.data.model.ResponseBody
 import com.pocs.data.model.post.PostAddBody
 import com.pocs.data.model.post.PostDeleteBody
+import com.pocs.data.model.post.PostUpdateBody
 import javax.inject.Inject
 
 class PostRemoteDataSourceImpl @Inject constructor(
@@ -21,5 +22,12 @@ class PostRemoteDataSourceImpl @Inject constructor(
         postDeleteBody: PostDeleteBody
     ): ResponseBody<Unit> {
         return api.deletePost(postId, postDeleteBody)
+    }
+
+    override suspend fun updatePost(
+        postId: Int,
+        postUpdateBody: PostUpdateBody
+    ): ResponseBody<Unit> {
+        return api.updatePost(postId, postUpdateBody)
     }
 }

--- a/domain/src/main/java/com/pocs/domain/usecase/post/UpdatePostUseCase.kt
+++ b/domain/src/main/java/com/pocs/domain/usecase/post/UpdatePostUseCase.kt
@@ -2,22 +2,23 @@ package com.pocs.domain.usecase.post
 
 import com.pocs.domain.model.post.PostCategory
 import com.pocs.domain.repository.PostRepository
+import com.pocs.domain.repository.UserRepository
 import javax.inject.Inject
 
 class UpdatePostUseCase @Inject constructor(
-    private val repository: PostRepository
+    private val repository: PostRepository,
+    private val userRepository: UserRepository
 ) {
     suspend operator fun invoke(
         id: Int,
         title: String,
         content: String,
-        userId: Int,
         category: PostCategory
     ) = repository.updatePost(
         id = id,
         title = title,
         content = content,
-        userId = userId,
+        userId = userRepository.getCurrentUserDetail().id,
         category = category
     )
 }

--- a/presentation/src/androidTest/java/com/pocs/presentation/PostEditActivityTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/PostEditActivityTest.kt
@@ -8,8 +8,10 @@ import androidx.compose.ui.test.performClick
 import androidx.test.core.app.launchActivity
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.pocs.domain.usecase.post.UpdatePostUseCase
 import com.pocs.presentation.view.post.edit.PostEditActivity
 import com.pocs.presentation.view.post.edit.PostEditViewModel
+import com.pocs.test_library.fake.FakePostRepositoryImpl
 import com.pocs.test_library.mock.mockPostDetail2
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
@@ -31,7 +33,10 @@ class PostEditActivityTest {
     val composeRule = createEmptyComposeRule()
 
     @BindValue
-    val viewModel = PostEditViewModel()
+    val postRepository = FakePostRepositoryImpl()
+
+    @BindValue
+    val viewModel = PostEditViewModel(UpdatePostUseCase(postRepository))
 
     private lateinit var context: Context
 

--- a/presentation/src/androidTest/java/com/pocs/presentation/PostEditActivityTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/PostEditActivityTest.kt
@@ -63,7 +63,7 @@ class PostEditActivityTest {
     }
 
     @Test
-    fun shouldShownErrorMessage_AfterFailedToEditedPost() {
+    fun shouldShowErrorMessage_AfterFailedToEditedPost() {
         val post = mockPostDetail2
         val errorMessage = "ERROR"
         postRepository.updatePostResult = Result.failure(Exception(errorMessage))

--- a/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditViewModel.kt
@@ -3,18 +3,14 @@ package com.pocs.presentation.view.post.edit
 import androidx.compose.runtime.*
 import androidx.lifecycle.ViewModel
 import com.pocs.domain.model.post.PostCategory
-import com.pocs.domain.usecase.post.AddPostUseCase
 import com.pocs.domain.usecase.post.UpdatePostUseCase
 import com.pocs.presentation.model.post.PostEditUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @HiltViewModel
 class PostEditViewModel @Inject constructor(
-    private val updatePostUseCase : UpdatePostUseCase
+    private val updatePostUseCase: UpdatePostUseCase
 ) : ViewModel() {
 
     private lateinit var _uiState: MutableState<PostEditUiState>
@@ -51,9 +47,6 @@ class PostEditViewModel @Inject constructor(
             content = uiState.value.content,
             category = uiState.value.category
         )
-        withContext(Dispatchers.IO) {
-            delay(500)
-        }
         if (result.isFailure) {
             _uiState.value = uiState.value.copy(isInSaving = false)
         }

--- a/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditViewModel.kt
@@ -49,8 +49,6 @@ class PostEditViewModel @Inject constructor(
             id = uiState.value.id,
             title = uiState.value.title,
             content = uiState.value.content,
-            // TODO: 현재 접속중인 유저의 ID로 변경하기
-            userId = 1,
             category = uiState.value.category
         )
         withContext(Dispatchers.IO) {

--- a/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditViewModel.kt
@@ -3,6 +3,8 @@ package com.pocs.presentation.view.post.edit
 import androidx.compose.runtime.*
 import androidx.lifecycle.ViewModel
 import com.pocs.domain.model.post.PostCategory
+import com.pocs.domain.usecase.post.AddPostUseCase
+import com.pocs.domain.usecase.post.UpdatePostUseCase
 import com.pocs.presentation.model.post.PostEditUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
@@ -11,7 +13,9 @@ import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @HiltViewModel
-class PostEditViewModel @Inject constructor() : ViewModel() {
+class PostEditViewModel @Inject constructor(
+    private val updatePostUseCase : UpdatePostUseCase
+) : ViewModel() {
 
     private lateinit var _uiState: MutableState<PostEditUiState>
     val uiState: State<PostEditUiState> get() = _uiState
@@ -41,11 +45,17 @@ class PostEditViewModel @Inject constructor() : ViewModel() {
 
     private suspend fun savePost(): Result<Unit> {
         _uiState.value = uiState.value.copy(isInSaving = true)
-        // TODO: API 연결하여야 함
+        val result = updatePostUseCase(
+            id = uiState.value.id,
+            title = uiState.value.title,
+            content = uiState.value.content,
+            // TODO: 현재 접속중인 유저의 ID로 변경하기
+            userId = 1,
+            category = uiState.value.category
+        )
         withContext(Dispatchers.IO) {
             delay(500)
         }
-        val result = Result.success(Unit)
         if (result.isFailure) {
             _uiState.value = uiState.value.copy(isInSaving = false)
         }

--- a/test-library/src/main/java/com/pocs/test_library/fake/FakePostRepositoryImpl.kt
+++ b/test-library/src/main/java/com/pocs/test_library/fake/FakePostRepositoryImpl.kt
@@ -41,7 +41,7 @@ class FakePostRepositoryImpl @Inject constructor() : PostRepository {
         userId: Int,
         category: PostCategory
     ): Result<Unit> {
-        TODO("Not yet implemented")
+        return Result.success(Unit)
     }
 
     override suspend fun deletePost(postId: Int, userId: Int) = deletePostResult

--- a/test-library/src/main/java/com/pocs/test_library/fake/FakePostRepositoryImpl.kt
+++ b/test-library/src/main/java/com/pocs/test_library/fake/FakePostRepositoryImpl.kt
@@ -15,6 +15,8 @@ class FakePostRepositoryImpl @Inject constructor() : PostRepository {
 
     var deletePostResult = Result.success(Unit)
 
+    var updatePostResult = Result.success(Unit)
+
 //    suspend fun emit(pagingData: PagingData<Post>) {
 //        postFlow.emit(pagingData)
 //    }
@@ -41,7 +43,7 @@ class FakePostRepositoryImpl @Inject constructor() : PostRepository {
         userId: Int,
         category: PostCategory
     ): Result<Unit> {
-        return Result.success(Unit)
+        return updatePostResult
     }
 
     override suspend fun deletePost(postId: Int, userId: Int) = deletePostResult


### PR DESCRIPTION
<!-- 이곳에 PR 내용을 작성하세요 -->

resolves #36 
- Post 편집 API 연결 및 구현하였습니다.
- Post 편집 API 성공시 302 리다이렉션 코드가 전달되기 때문에 반환 값을 [ResponseBody]이 아닌 [Response]로 하였고, 그에 따라 중간중간에 다시 수정을 하였습니다.
- 메뉴의 편집기능의 확인을 위해서 current User의 userId 값을 2-> 1로 변경하였습니다.(ID가 다르면 메뉴에서 편집기능이 안보이기 때문)
- 그에 맞게 테스트 프로그램 또한 변경을 하였습니다.

![before](https://user-images.githubusercontent.com/58154638/182529503-ba49aa08-02ae-432b-b88d-59b3aeabe10b.jpg)
![middle](https://user-images.githubusercontent.com/58154638/182529507-70190039-63ab-44d0-a5e4-0d99af52cda5.jpg)
![after](https://user-images.githubusercontent.com/58154638/182529513-e3a581a6-4053-495b-94a8-e3156ff30241.jpg)

## Merge 전 체크리스트

- [X] 코딩 컨벤션을 지켰는가?
- [ ] Action에서 진행하는 테스트를 모두 통과했는가?
- [x] 수정 사항을 검증할 테스트를 추가하였는가?
- [x] 리뷰를 받았는가?