### PR TITLE
유저 상세 화면에서 기수 "기" suffix 문자 제거

### DIFF
--- a/presentation/src/main/java/com/pocs/presentation/view/user/detail/UserDetailScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/user/detail/UserDetailScreen.kt
@@ -156,7 +156,7 @@ fun UserDetailContent(
             item {
                 UserInfo(
                     stringResource(R.string.generation),
-                    stringResource(R.string.user_generation_info, userDetail.generation)
+                    userDetail.generation.toString()
                 )
             }
             item {


### PR DESCRIPTION
Resolves #111

- 이전 : 기수 3기
- 현재 : 기수 3
## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [ ] Action에서 진행하는 테스트를 모두 통과했는가?
- [ ] 수정 사항을 검증할 테스트를 추가하였는가?
- [ ] 리뷰를 받았는가?