### PR TITLE
포스트 수정 후 성공 조건을 302 코드가 왔을때로 수정

### DIFF
--- a/data/src/main/java/com/pocs/data/repository/PostRepositoryImpl.kt
+++ b/data/src/main/java/com/pocs/data/repository/PostRepositoryImpl.kt
@@ -87,7 +87,7 @@ class PostRepositoryImpl @Inject constructor(
                     category = category.toDto()
                 )
             )
-            if (response.isSuccessful) {
+            if (response.code() == 302) {
                 Result.success(Unit)
             } else {
                 throw Exception(response.errorMessage)


### PR DESCRIPTION
API 문서가 잘못되어 포스트 수정후 성공했을 때 204코드를 반환한다고 잘못되어있어 302코드인 경우를 성공조건으로 수정했습니다.

## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [x] Action에서 진행하는 테스트를 모두 통과했는가?
- [ ] 수정 사항을 검증할 테스트를 추가하였는가?
- [x] 리뷰를 받았는가?