### PR TITLE
회원 아이콘 다크모드 색상 문제 해결 및 전체 통일

### DIFF
--- a/presentation/src/main/java/com/pocs/presentation/view/user/detail/UserDetailScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/user/detail/UserDetailScreen.kt
@@ -264,7 +264,8 @@ fun UserAvatar(name: String, isKicked: Boolean) {
         // TODO: 회원 사진 정보가 생기면 넣기
         Icon(
             modifier = Modifier.size(120.dp),
-            imageVector = Icons.Filled.Person,
+            imageVector = Icons.Filled.AccountCircle,
+            tint = MaterialTheme.colorScheme.onBackground,
             contentDescription = stringResource(id = R.string.user_image)
         )
         Text(text = name, style = MaterialTheme.typography.titleMedium)

--- a/presentation/src/main/java/com/pocs/presentation/view/user/edit/UserEditScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/user/edit/UserEditScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -189,7 +190,8 @@ fun UserEditAvatar(onClick: () -> Unit) {
             modifier = Modifier
                 .size(120.dp)
                 .clickable(onClick = onClick),
-            imageVector = Icons.Filled.Person,
+            imageVector = Icons.Filled.AccountCircle,
+            tint = MaterialTheme.colorScheme.onBackground,
             contentDescription = stringResource(id = R.string.user_image)
         )
     }

--- a/presentation/src/main/res/drawable/ic_baseline_account_circle_24.xml
+++ b/presentation/src/main/res/drawable/ic_baseline_account_circle_24.xml
@@ -1,4 +1,4 @@
-<vector android:height="36dp" android:tint="#000000"
+<vector android:height="36dp" android:tint="?attr/colorOnBackground"
     android:viewportHeight="24" android:viewportWidth="24"
     android:width="36dp" xmlns:android="http://schemas.android.com/apk/res/android">
     <path android:fillColor="@android:color/white" android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10s10,-4.48 10,-10S17.52,2 12,2zM12,6c1.93,0 3.5,1.57 3.5,3.5S13.93,13 12,13s-3.5,-1.57 -3.5,-3.5S10.07,6 12,6zM12,20c-2.03,0 -4.43,-0.82 -6.14,-2.88C7.55,15.8 9.68,15 12,15s4.45,0.8 6.14,2.12C16.43,19.18 14.03,20 12,20z"/>

--- a/presentation/src/main/res/layout/item_user.xml
+++ b/presentation/src/main/res/layout/item_user.xml
@@ -29,7 +29,7 @@
                 android:layout_width="48dp"
                 android:layout_height="48dp"
                 android:contentDescription="@string/user_image"
-                android:src="@drawable/ic_baseline_people_24"
+                android:src="@drawable/ic_baseline_account_circle_24"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />


### PR DESCRIPTION
- 다크모드에서 회원 아이콘의 색상이 잘못된 문제를 수정했습니다.
- 모든 회원의 기본 아이콘을 통일 시켰습니다.

|홈 화면 전|홈 화면 후|
|---|---|
|![image](https://user-images.githubusercontent.com/57604817/183280664-0b7a872b-8cad-47a8-84a1-e7a810f5c7c7.png)|![image](https://user-images.githubusercontent.com/57604817/183280633-074423f4-6d33-4d2d-92b6-7d3165e9ff3b.png)|

|회원 목록|회원 디테일|회원 편집|
|---|---|---|
|![image](https://user-images.githubusercontent.com/57604817/183280725-e64d0b01-311e-4322-989c-6db4e2b5a7e3.png)|![image](https://user-images.githubusercontent.com/57604817/183280754-9b70036c-0852-4318-bb19-a974d36cf02f.png)|![image](https://user-images.githubusercontent.com/57604817/183280756-eba1cfa9-e52d-4969-b76a-bab0692544c3.png)|




## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [ ] Action에서 진행하는 테스트를 모두 통과했는가?
- [ ] 수정 사항을 검증할 테스트를 추가하였는가?
- [ ] 리뷰를 받았는가?