### PR TITLE
유저 목록 정렬 가입순 추가 및 레이아웃 향상

### DIFF
--- a/data/src/main/java/com/pocs/data/api/UserApi.kt
+++ b/data/src/main/java/com/pocs/data/api/UserApi.kt
@@ -11,7 +11,7 @@ import retrofit2.http.*
 interface UserApi {
     @GET("users")
     suspend fun getAll(
-        @Query("sort") sort: UserListSortingMethodDto
+        @Query("sort") sort: UserListSortingMethodDto?
     ): Response<ResponseBody<UserListDto>>
 
     @GET("users/{userId}")

--- a/data/src/main/java/com/pocs/data/mapper/UserListSortTypeMapper.kt
+++ b/data/src/main/java/com/pocs/data/mapper/UserListSortTypeMapper.kt
@@ -3,4 +3,11 @@ package com.pocs.data.mapper
 import com.pocs.data.model.user.UserListSortingMethodDto
 import com.pocs.domain.model.user.UserListSortingMethod
 
-fun UserListSortingMethod.toDto() = UserListSortingMethodDto.valueOf(this.toString())
+fun UserListSortingMethod.toDto(): UserListSortingMethodDto? {
+    // API에서 널인경우 가입일 내림차순으로 처리하고 있다.
+    return if (this == UserListSortingMethod.CREATED_AT) {
+        null
+    } else {
+        UserListSortingMethodDto.valueOf(this.toString())
+    }
+}

--- a/domain/src/main/java/com/pocs/domain/model/user/UserListSortingMethod.kt
+++ b/domain/src/main/java/com/pocs/domain/model/user/UserListSortingMethod.kt
@@ -1,6 +1,18 @@
 package com.pocs.domain.model.user
 
 enum class UserListSortingMethod {
+    /**
+     * 학번 오름차순
+     */
     STUDENT_ID,
-    GENERATION
+
+    /**
+     * 기수 내림차순
+     */
+    GENERATION,
+
+    /**
+     * 가입일 내림차순
+     */
+    CREATED_AT
 }

--- a/presentation/src/main/java/com/pocs/presentation/model/user/UserUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/user/UserUiState.kt
@@ -6,7 +6,7 @@ import com.pocs.domain.model.user.UserType
 import com.pocs.presentation.model.user.item.UserItemUiState
 
 data class UserUiState(
-    val sortingMethod: UserListSortingMethod = UserListSortingMethod.GENERATION,
+    val sortingMethod: UserListSortingMethod = UserListSortingMethod.CREATED_AT,
     val userPagingData: PagingData<UserItemUiState> = PagingData.empty(),
     val currentUserType: UserType
 )

--- a/presentation/src/main/java/com/pocs/presentation/view/admin/post/AdminPostFragment.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/admin/post/AdminPostFragment.kt
@@ -18,6 +18,7 @@ import com.pocs.presentation.R
 import com.pocs.presentation.databinding.FragmentPostBinding
 import com.pocs.presentation.extension.RefreshStateContract
 import com.pocs.presentation.extension.addDividerDecoration
+import com.pocs.presentation.extension.registerObserverForScrollToTop
 import com.pocs.presentation.extension.setListeners
 import com.pocs.presentation.model.admin.AdminPostUiState
 import com.pocs.presentation.model.post.item.PostItemUiState
@@ -55,7 +56,8 @@ class AdminPostFragment : Fragment(R.layout.fragment_post) {
             recyclerView.layoutManager = LinearLayoutManager(view.context)
             recyclerView.addDividerDecoration()
 
-            loadState.setListeners(adapter, refresh, recyclerView)
+            loadState.setListeners(adapter, refresh)
+            adapter.registerObserverForScrollToTop(recyclerView)
 
             fab.text = getString(R.string.write_notice)
             fab.setOnClickListener { startPostCreateActivity() }

--- a/presentation/src/main/java/com/pocs/presentation/view/admin/user/AdminUserFragment.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/admin/user/AdminUserFragment.kt
@@ -16,6 +16,7 @@ import com.google.android.material.snackbar.Snackbar
 import com.pocs.presentation.R
 import com.pocs.presentation.databinding.FragmentAdminUserBinding
 import com.pocs.presentation.extension.RefreshStateContract
+import com.pocs.presentation.extension.registerObserverForScrollToTop
 import com.pocs.presentation.extension.setListeners
 import com.pocs.presentation.model.admin.AdminUserUiState
 import com.pocs.presentation.paging.PagingLoadStateAdapter
@@ -55,7 +56,8 @@ class AdminUserFragment : Fragment(R.layout.fragment_admin_user) {
             )
             recyclerView.layoutManager = LinearLayoutManager(view.context)
 
-            loadState.setListeners(adapter, refresh, recyclerView)
+            loadState.setListeners(adapter, refresh)
+            adapter.registerObserverForScrollToTop(recyclerView)
 
             fab.setOnClickListener { startAdminUserCreateActivity() }
 

--- a/presentation/src/main/java/com/pocs/presentation/view/home/article/ArticleFragment.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/home/article/ArticleFragment.kt
@@ -18,6 +18,7 @@ import com.pocs.presentation.R
 import com.pocs.presentation.databinding.FragmentPostBinding
 import com.pocs.presentation.extension.RefreshStateContract
 import com.pocs.presentation.extension.addDividerDecoration
+import com.pocs.presentation.extension.registerObserverForScrollToTop
 import com.pocs.presentation.extension.setListeners
 import com.pocs.presentation.model.ArticleUiState
 import com.pocs.presentation.model.post.item.PostItemUiState
@@ -55,7 +56,8 @@ class ArticleFragment : Fragment(R.layout.fragment_post) {
             recyclerView.layoutManager = LinearLayoutManager(view.context)
             recyclerView.addDividerDecoration()
 
-            loadState.setListeners(adapter, refresh, recyclerView)
+            loadState.setListeners(adapter, refresh)
+            adapter.registerObserverForScrollToTop(recyclerView)
 
             fab.text = getString(R.string.write_post)
             fab.setOnClickListener { startPostCreateActivity() }

--- a/presentation/src/main/java/com/pocs/presentation/view/home/notice/NoticeFragment.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/home/notice/NoticeFragment.kt
@@ -18,6 +18,7 @@ import com.pocs.presentation.R
 import com.pocs.presentation.databinding.FragmentPostBinding
 import com.pocs.presentation.extension.RefreshStateContract
 import com.pocs.presentation.extension.addDividerDecoration
+import com.pocs.presentation.extension.registerObserverForScrollToTop
 import com.pocs.presentation.extension.setListeners
 import com.pocs.presentation.model.NoticeUiState
 import com.pocs.presentation.model.post.item.PostItemUiState
@@ -56,7 +57,8 @@ class NoticeFragment : Fragment(R.layout.fragment_post) {
             recyclerView.layoutManager = LinearLayoutManager(view.context)
             recyclerView.addDividerDecoration()
 
-            loadState.setListeners(adapter, refresh, recyclerView)
+            loadState.setListeners(adapter, refresh)
+            adapter.registerObserverForScrollToTop(recyclerView)
 
             fab.text = getString(R.string.write_notice)
             fab.setOnClickListener { startPostCreateActivity() }

--- a/presentation/src/main/java/com/pocs/presentation/view/post/by/user/PostByUserActivity.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/by/user/PostByUserActivity.kt
@@ -60,7 +60,7 @@ class PostByUserActivity : AppCompatActivity() {
             recyclerView.layoutManager = LinearLayoutManager(this@PostByUserActivity)
             recyclerView.addDividerDecoration()
 
-            loadState.setListeners(adapter, refresh, recyclerView)
+            loadState.setListeners(adapter, refresh)
         }
 
         lifecycleScope.launch {

--- a/presentation/src/main/java/com/pocs/presentation/view/user/UserFragment.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/user/UserFragment.kt
@@ -90,6 +90,7 @@ class UserFragment : Fragment(R.layout.fragment_user) {
             menuInflater.inflate(R.menu.menu_sorting_method_pop_up, menu)
             setOnMenuItemClickListener {
                 val newSortingMethod = when (it.itemId) {
+                    R.id.action_created_at_descending -> UserListSortingMethod.CREATED_AT
                     R.id.action_generation_descending -> UserListSortingMethod.GENERATION
                     R.id.action_student_id_ascending -> UserListSortingMethod.STUDENT_ID
                     else -> throw IllegalArgumentException()
@@ -103,6 +104,7 @@ class UserFragment : Fragment(R.layout.fragment_user) {
     private fun updateUi(uiState: UserUiState) {
         adapter.submitData(viewLifecycleOwner.lifecycle, uiState.userPagingData)
         val stringResource = when (uiState.sortingMethod) {
+            UserListSortingMethod.CREATED_AT -> R.string.sorting_by_created_at_descending
             UserListSortingMethod.STUDENT_ID -> R.string.sorting_by_student_id_ascending
             UserListSortingMethod.GENERATION -> R.string.sorting_by_generation_descending
         }

--- a/presentation/src/main/java/com/pocs/presentation/view/user/UserFragment.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/user/UserFragment.kt
@@ -18,6 +18,7 @@ import com.pocs.domain.model.user.UserListSortingMethod
 import com.pocs.presentation.R
 import com.pocs.presentation.databinding.FragmentUserBinding
 import com.pocs.presentation.extension.RefreshStateContract
+import com.pocs.presentation.extension.registerObserverForScrollToTop
 import com.pocs.presentation.extension.setListeners
 import com.pocs.presentation.model.user.UserUiState
 import com.pocs.presentation.paging.PagingLoadStateAdapter
@@ -55,7 +56,12 @@ class UserFragment : Fragment(R.layout.fragment_user) {
             )
             recyclerView.layoutManager = LinearLayoutManager(view.context)
 
-            loadState.setListeners(adapter, refresh, recyclerView)
+            loadState.setListeners(adapter, refresh)
+            adapter.registerObserverForScrollToTop(
+                recyclerView,
+                whenItemRangeMoved = true,
+                whenItemInsertedFirst = false
+            )
 
             sortBox.setOnClickListener { showSortingMethodPopUpMenu() }
 

--- a/presentation/src/main/res/layout/fragment_user.xml
+++ b/presentation/src/main/res/layout/fragment_user.xml
@@ -19,8 +19,8 @@
 
         <ImageView
             android:id="@+id/sortButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
             android:layout_marginHorizontal="16dp"
             android:layout_marginVertical="8dp"
             android:background="@android:color/transparent"
@@ -33,7 +33,7 @@
 
         <TextView
             android:id="@+id/sortText"
-            style="?attr/textAppearanceBodyMedium"
+            style="?attr/textAppearanceLabelMedium"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"

--- a/presentation/src/main/res/layout/fragment_user.xml
+++ b/presentation/src/main/res/layout/fragment_user.xml
@@ -8,36 +8,36 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/sortBox"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:alpha="0.8"
         android:background="?android:attr/selectableItemBackground"
         android:clickable="true"
         android:focusable="true"
-        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
-        <ImageButton
+        <ImageView
             android:id="@+id/sortButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_margin="16dp"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginVertical="8dp"
             android:background="@android:color/transparent"
             android:contentDescription="@string/sort_button"
             android:src="@drawable/ic_baseline_sort_24"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:tint="?attr/colorPrimary" />
+            app:tint="?attr/colorOnBackground" />
 
         <TextView
             android:id="@+id/sortText"
             style="?attr/textAppearanceBodyMedium"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
-            android:layout_weight="1"
-            android:alpha="0.8"
+            android:layout_marginEnd="16dp"
             android:textColor="?attr/colorOnBackground"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/presentation/src/main/res/menu/menu_sorting_method_pop_up.xml
+++ b/presentation/src/main/res/menu/menu_sorting_method_pop_up.xml
@@ -3,6 +3,9 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
+        android:id="@+id/action_created_at_descending"
+        android:title="@string/sorting_by_created_at_descending" />
+    <item
         android:id="@+id/action_generation_descending"
         android:title="@string/sorting_by_generation_descending" />
     <item

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -48,8 +48,8 @@
     <string name="title_text_field">제목 입력창</string>
     <string name="content_text_field">내용 입력창</string>
     <string name="sort_button">정렬 버튼</string>
-    <string name="sorting_by_generation_descending">기수 내림차순으로 정렬</string>
-    <string name="sorting_by_student_id_ascending">학번 오름차순으로 정렬</string>
+    <string name="sorting_by_generation_descending">기수 내림차순</string>
+    <string name="sorting_by_student_id_ascending">학번 오름차순</string>
     <string name="enter_password">비밀번호를 입력하세요</string>
     <string name="show_password">비밀번호 보이기</string>
     <string name="hide_password">비밀번호 숨기기</string>
@@ -72,6 +72,7 @@
     <string name="my_info_edited">내 정보 편집됨</string>
     <string name="empty_label">-</string>
     <string name="cannot_edit_post">글을 편집할 수 없습니다.</string>
+    <string name="sorting_by_created_at_descending">가입일 최근순</string>
     <string name="nickname">닉네임</string>
     <string name="password">비밀번호</string>
     <string-array name="admin_tab">


### PR DESCRIPTION
Resolves #124 

- 가입일순으로 정렬하는 기능을 누락해서 추가했습니다.(근데 API 보면 기본 쿼리값이 `null`일때 가입일 순으로 하고 있습니다. 이보다 createdAt을 전달할때 가입을 순으로 정렬하고 이것을 기본값으로 쓰는게 낫지 않을까 생각합니다.)
- 회원 정렬 방법이 바뀌었을 때 최상단으로 스크롤하도록 했습니다.
- 정렬 버튼 색상을 강조하지 않는 색으로 변경하고 클릭 가능한 부분을 좌우 꽉차지 않도록 수정했습니다.

![image](https://user-images.githubusercontent.com/57604817/183282571-c71c5050-72af-4d61-adc9-aa4b39d9e870.png)

## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [ ] Action에서 진행하는 테스트를 모두 통과했는가?
- [ ] 수정 사항을 검증할 테스트를 추가하였는가?
- [ ] 리뷰를 받았는가?