### PR TITLE
게시글 작성시 카테고리 고를 수 있는 기능 추가 및 잘못된 상태관리 수정

### DIFF
--- a/domain/src/main/java/com/pocs/domain/usecase/post/AddPostUseCase.kt
+++ b/domain/src/main/java/com/pocs/domain/usecase/post/AddPostUseCase.kt
@@ -2,15 +2,23 @@ package com.pocs.domain.usecase.post
 
 import com.pocs.domain.model.post.PostCategory
 import com.pocs.domain.repository.PostRepository
+import com.pocs.domain.usecase.auth.GetCurrentUserUseCase
 import javax.inject.Inject
 
 class AddPostUseCase @Inject constructor(
-    private val repository: PostRepository
+    private val repository: PostRepository,
+    private val getCurrentUserUseCase: GetCurrentUserUseCase
 ) {
     suspend operator fun invoke(
         title: String,
         content: String,
-        userId: Int,
         category: PostCategory
-    ) = repository.addPost(title = title, content = content, userId = userId, category = category)
+    ): Result<Unit> {
+        return repository.addPost(
+            title = title,
+            content = content,
+            userId = requireNotNull(getCurrentUserUseCase()?.id),
+            category = category
+        )
+    }
 }

--- a/presentation/src/androidTest/java/com/pocs/presentation/PostCreateActivityTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/PostCreateActivityTest.kt
@@ -10,7 +10,10 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocs.presentation.extension.RESULT_REFRESH
 import com.pocs.presentation.view.post.create.PostCreateActivity
+import com.pocs.test_library.fake.FakeAuthRepositoryImpl
+import com.pocs.test_library.mock.mockNormalUserDetail
 import com.pocs.test_library.mock.mockPostDetail2
+import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Assert.assertEquals
@@ -29,6 +32,9 @@ class PostCreateActivityTest {
     @get:Rule(order = 1)
     val composeRule = createEmptyComposeRule()
 
+    @BindValue
+    val authRepository = FakeAuthRepositoryImpl()
+
     private lateinit var context: Context
 
     @Before
@@ -39,6 +45,7 @@ class PostCreateActivityTest {
 
     @Test
     fun shouldSetResultRefresh_AfterSuccessAddingNewPost() {
+        authRepository.currentUser.value = mockNormalUserDetail
         val post = mockPostDetail2
         val intent = PostCreateActivity.getIntent(context, post.category)
         val scenario = launchActivity<PostCreateActivity>(intent)

--- a/presentation/src/androidTest/java/com/pocs/presentation/PostEditActivityTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/PostEditActivityTest.kt
@@ -6,6 +6,8 @@ import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.test.core.app.launchActivity
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.pocs.domain.usecase.auth.GetCurrentUserTypeUseCase
+import com.pocs.domain.usecase.auth.IsCurrentUserAdminUseCase
 import com.pocs.domain.usecase.post.UpdatePostUseCase
 import com.pocs.presentation.extension.RESULT_REFRESH
 import com.pocs.presentation.view.post.edit.PostEditActivity
@@ -45,7 +47,8 @@ class PostEditActivityTest {
         UpdatePostUseCase(
             postRepository = postRepository,
             authRepository = authRepository
-        )
+        ),
+        IsCurrentUserAdminUseCase(GetCurrentUserTypeUseCase(authRepository))
     )
 
     private lateinit var context: Context

--- a/presentation/src/androidTest/java/com/pocs/presentation/PostEditScreenTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/PostEditScreenTest.kt
@@ -24,12 +24,14 @@ class PostEditScreenTest {
     val composeTestRule = createComposeRule()
 
     private val emptyUiState = PostEditUiState(
-        id = 1,
+        postId = 1,
         title = "",
         content = "",
         category = PostCategory.NOTICE,
+        isUserAdmin = true,
         onTitleChange = {},
         onContentChange = {},
+        onCategoryChange = {},
         onSave = { Result.success(Unit) }
     )
 

--- a/presentation/src/main/java/com/pocs/presentation/extension/PostCategoryExt.kt
+++ b/presentation/src/main/java/com/pocs/presentation/extension/PostCategoryExt.kt
@@ -1,0 +1,15 @@
+package com.pocs.presentation.extension
+
+import com.pocs.domain.model.post.PostCategory
+import com.pocs.presentation.R
+
+val PostCategory.koreanStringResource: Int
+    get() {
+        return when (this) {
+            PostCategory.NOTICE -> R.string.notice
+            PostCategory.STUDY -> R.string.study
+            PostCategory.MEMORY -> R.string.memory
+            PostCategory.KNOWHOW -> R.string.knowhow
+            PostCategory.REFERENCE -> R.string.reference
+        }
+    }

--- a/presentation/src/main/java/com/pocs/presentation/model/BasePostEditUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/BasePostEditUiState.kt
@@ -6,9 +6,11 @@ interface BasePostEditUiState {
     val title: String
     val content: String
     val category: PostCategory
+    val isUserAdmin: Boolean
     val isInSaving: Boolean
     val onTitleChange: (String) -> Unit
     val onContentChange: (String) -> Unit
+    val onCategoryChange: (PostCategory) -> Unit
     val onSave: suspend () -> Result<Unit>
 
     val canSave get() = title.isNotEmpty() && content.isNotEmpty()

--- a/presentation/src/main/java/com/pocs/presentation/model/post/PostCreateUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/post/PostCreateUiState.kt
@@ -7,8 +7,10 @@ data class PostCreateUiState(
     override val title: String = "",
     override val content: String = "",
     override val category: PostCategory,
+    override val isUserAdmin: Boolean,
     override val isInSaving: Boolean = false,
     override val onTitleChange: (String) -> Unit,
     override val onContentChange: (String) -> Unit,
+    override val onCategoryChange: (PostCategory) -> Unit,
     override val onSave: suspend () -> Result<Unit>
 ) : BasePostEditUiState

--- a/presentation/src/main/java/com/pocs/presentation/model/post/PostEditUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/post/PostEditUiState.kt
@@ -4,12 +4,14 @@ import com.pocs.domain.model.post.PostCategory
 import com.pocs.presentation.model.BasePostEditUiState
 
 data class PostEditUiState(
-    val id: Int,
+    val postId: Int,
     override val title: String,
     override val content: String,
     override val category: PostCategory,
+    override val isUserAdmin: Boolean,
     override val isInSaving: Boolean = false,
     override val onTitleChange: (String) -> Unit,
     override val onContentChange: (String) -> Unit,
+    override val onCategoryChange: (PostCategory) -> Unit,
     override val onSave: suspend () -> Result<Unit>
 ) : BasePostEditUiState

--- a/presentation/src/main/java/com/pocs/presentation/view/post/create/PostCreateScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/create/PostCreateScreen.kt
@@ -13,7 +13,6 @@ fun PostCreateScreen(
     onSuccessSave: () -> Unit
 ) {
     PostEditContent(
-        // TODO: 게시글 속성에 따라 "OOO 편집"과 같이 다르게 보이기
         title = stringResource(R.string.write_post),
         uiState = uiState,
         navigateUp = navigateUp,

--- a/presentation/src/main/java/com/pocs/presentation/view/post/create/PostCreateViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/create/PostCreateViewModel.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import com.pocs.domain.model.post.PostCategory
+import com.pocs.domain.usecase.auth.IsCurrentUserAdminUseCase
 import com.pocs.domain.usecase.post.AddPostUseCase
 import com.pocs.presentation.model.post.PostCreateUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -12,7 +13,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class PostCreateViewModel @Inject constructor(
-    private val addPostUseCase: AddPostUseCase
+    private val addPostUseCase: AddPostUseCase,
+    private val isCurrentUserAdminUseCase: IsCurrentUserAdminUseCase
 ) : ViewModel() {
 
     private lateinit var _uiState: MutableState<PostCreateUiState>
@@ -22,8 +24,10 @@ class PostCreateViewModel @Inject constructor(
         _uiState = mutableStateOf(
             PostCreateUiState(
                 category = category,
+                isUserAdmin = isCurrentUserAdminUseCase(),
                 onTitleChange = ::updateTitle,
                 onContentChange = ::updateContent,
+                onCategoryChange = ::updateCategory,
                 onSave = ::savePost
             )
         )
@@ -37,13 +41,15 @@ class PostCreateViewModel @Inject constructor(
         _uiState.value = uiState.value.copy(content = content)
     }
 
+    private fun updateCategory(category: PostCategory) {
+        _uiState.value = uiState.value.copy(category = category)
+    }
+
     private suspend fun savePost(): Result<Unit> {
         _uiState.value = uiState.value.copy(isInSaving = true)
         val result = addPostUseCase(
             title = uiState.value.title,
             content = uiState.value.content,
-            // TODO: 현재 접속중인 유저의 ID로 변경하기
-            userId = 1,
             category = uiState.value.category
         )
         _uiState.value = uiState.value.copy(isInSaving = false)

--- a/presentation/src/main/java/com/pocs/presentation/view/post/create/PostCreateViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/create/PostCreateViewModel.kt
@@ -17,10 +17,13 @@ class PostCreateViewModel @Inject constructor(
     private val isCurrentUserAdminUseCase: IsCurrentUserAdminUseCase
 ) : ViewModel() {
 
-    private lateinit var _uiState: MutableState<PostCreateUiState>
-    val uiState: State<PostCreateUiState> get() = _uiState
+    private var _uiState: MutableState<PostCreateUiState>? = null
+    val uiState: State<PostCreateUiState> get() = requireNotNull(_uiState)
 
     fun initUiState(category: PostCategory) {
+        if (_uiState != null) {
+            return
+        }
         _uiState = mutableStateOf(
             PostCreateUiState(
                 category = category,
@@ -34,25 +37,25 @@ class PostCreateViewModel @Inject constructor(
     }
 
     private fun updateTitle(title: String) {
-        _uiState.value = uiState.value.copy(title = title)
+        _uiState!!.value = uiState.value.copy(title = title)
     }
 
     private fun updateContent(content: String) {
-        _uiState.value = uiState.value.copy(content = content)
+        _uiState!!.value = uiState.value.copy(content = content)
     }
 
     private fun updateCategory(category: PostCategory) {
-        _uiState.value = uiState.value.copy(category = category)
+        _uiState!!.value = uiState.value.copy(category = category)
     }
 
     private suspend fun savePost(): Result<Unit> {
-        _uiState.value = uiState.value.copy(isInSaving = true)
+        _uiState!!.value = uiState.value.copy(isInSaving = true)
         val result = addPostUseCase(
             title = uiState.value.title,
             content = uiState.value.content,
             category = uiState.value.category
         )
-        _uiState.value = uiState.value.copy(isInSaving = false)
+        _uiState!!.value = uiState.value.copy(isInSaving = false)
         return result
     }
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditScreen.kt
@@ -27,7 +27,6 @@ import kotlinx.coroutines.launch
 @Composable
 fun PostEditScreen(uiState: PostEditUiState, navigateUp: () -> Unit, onSuccessSave: () -> Unit) {
     PostEditContent(
-        // TODO: 게시글 속성에 따라 "OOO 편집"과 같이 다르게 보이기
         title = stringResource(id = R.string.edit_post),
         uiState = uiState,
         navigateUp = navigateUp,
@@ -55,7 +54,7 @@ fun PostEditContent(
     Scaffold(
         snackbarHost = { SnackbarHost(hostState = snackBarHostState) },
         topBar = {
-            val cannotEditPostString = stringResource(R.string.cannot_edit_post)
+            val cannotEditPostString = stringResource(R.string.failed_to_save_post)
 
             EditContentAppBar(
                 title = title,

--- a/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditScreen.kt
@@ -1,7 +1,9 @@
 package com.pocs.presentation.view.post.edit
 
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -18,6 +20,7 @@ import com.pocs.domain.model.post.PostCategory
 import com.pocs.presentation.R
 import com.pocs.presentation.constant.MAX_POST_CONTENT_LEN
 import com.pocs.presentation.constant.MAX_POST_TITLE_LEN
+import com.pocs.presentation.extension.koreanStringResource
 import com.pocs.presentation.model.BasePostEditUiState
 import com.pocs.presentation.model.post.PostEditUiState
 import com.pocs.presentation.view.component.RecheckHandler
@@ -88,6 +91,11 @@ fun PostEditContent(
             val titleContentDescription = stringResource(R.string.title_text_field)
             val contentContentDescription = stringResource(R.string.content_text_field)
 
+            PostCategoryChips(
+                isUserAdmin = uiState.isUserAdmin,
+                selectedCategory = uiState.category,
+                onClick = uiState.onCategoryChange
+            )
             SimpleTextField(
                 hint = stringResource(R.string.title),
                 value = uiState.title,
@@ -110,6 +118,53 @@ fun PostEditContent(
                     .fillMaxWidth()
                     .fillMaxHeight()
                     .semantics { contentDescription = contentContentDescription }
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PostCategoryChips(
+    isUserAdmin: Boolean,
+    selectedCategory: PostCategory,
+    onClick: (PostCategory) -> Unit
+) {
+    val categories = remember {
+        val posts = PostCategory.values().toMutableList()
+        if (!isUserAdmin) {
+            posts.remove(PostCategory.NOTICE)
+        }
+        posts
+    }
+    val scrollState = rememberScrollState()
+
+    Row(
+        Modifier
+            .horizontalScroll(scrollState)
+            .padding(horizontal = 12.dp)
+    ) {
+        for (category in categories) {
+            val isSelected = selectedCategory == category
+
+            ElevatedAssistChip(
+                modifier = Modifier.padding(horizontal = 4.dp),
+                onClick = { onClick(category) },
+                label = {
+                    Text(text = stringResource(category.koreanStringResource))
+                },
+                colors = AssistChipDefaults.assistChipColors(
+                    containerColor = if (isSelected) {
+                        MaterialTheme.colorScheme.primaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.surface
+                    },
+                    labelColor = if (isSelected) {
+                        MaterialTheme.colorScheme.onPrimaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.onSurface
+                    },
+                )
             )
         }
     }
@@ -150,12 +205,14 @@ fun PostEditContentEmptyPreview() {
     PostEditContent(
         "게시글 수정",
         PostEditUiState(
-            id = 1,
+            postId = 1,
             title = "",
             content = "",
             category = PostCategory.STUDY,
+            isUserAdmin = true,
             onTitleChange = {},
             onContentChange = {},
+            onCategoryChange = {},
             onSave = { Result.success(Unit) }
         ),
         {}
@@ -168,12 +225,14 @@ fun PostEditContentPreview() {
     PostEditContent(
         "게시글 수정",
         PostEditUiState(
-            id = 1,
+            postId = 1,
             title = "공지입니다.",
             content = "안녕하세요.",
             category = PostCategory.STUDY,
+            isUserAdmin = true,
             onTitleChange = {},
             onContentChange = {},
+            onCategoryChange = {},
             onSave = { Result.success(Unit) }
         ),
         {}

--- a/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditScreen.kt
@@ -162,7 +162,7 @@ fun PostCategoryChips(
                     labelColor = if (isSelected) {
                         MaterialTheme.colorScheme.onPrimaryContainer
                     } else {
-                        MaterialTheme.colorScheme.onSurface
+                        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
                     },
                 )
             )

--- a/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditViewModel.kt
@@ -3,6 +3,7 @@ package com.pocs.presentation.view.post.edit
 import androidx.compose.runtime.*
 import androidx.lifecycle.ViewModel
 import com.pocs.domain.model.post.PostCategory
+import com.pocs.domain.usecase.auth.IsCurrentUserAdminUseCase
 import com.pocs.domain.usecase.post.UpdatePostUseCase
 import com.pocs.presentation.model.post.PostEditUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -10,7 +11,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class PostEditViewModel @Inject constructor(
-    private val updatePostUseCase: UpdatePostUseCase
+    private val updatePostUseCase: UpdatePostUseCase,
+    private val isCurrentUserAdminUseCase: IsCurrentUserAdminUseCase
 ) : ViewModel() {
 
     private lateinit var _uiState: MutableState<PostEditUiState>
@@ -20,12 +22,14 @@ class PostEditViewModel @Inject constructor(
         assert(id > 0)
         _uiState = mutableStateOf(
             PostEditUiState(
-                id = id,
+                postId = id,
                 title = title,
                 content = content,
                 category = category,
+                isUserAdmin = isCurrentUserAdminUseCase(),
                 onTitleChange = ::updateTitle,
                 onContentChange = ::updateContent,
+                onCategoryChange = ::updateCategory,
                 onSave = ::savePost
             )
         )
@@ -39,10 +43,14 @@ class PostEditViewModel @Inject constructor(
         _uiState.value = uiState.value.copy(content = content)
     }
 
+    private fun updateCategory(category: PostCategory) {
+        _uiState.value = uiState.value.copy(category = category)
+    }
+
     private suspend fun savePost(): Result<Unit> {
         _uiState.value = uiState.value.copy(isInSaving = true)
         val result = updatePostUseCase(
-            id = uiState.value.id,
+            id = uiState.value.postId,
             title = uiState.value.title,
             content = uiState.value.content,
             category = uiState.value.category

--- a/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditViewModel.kt
@@ -15,11 +15,14 @@ class PostEditViewModel @Inject constructor(
     private val isCurrentUserAdminUseCase: IsCurrentUserAdminUseCase
 ) : ViewModel() {
 
-    private lateinit var _uiState: MutableState<PostEditUiState>
-    val uiState: State<PostEditUiState> get() = _uiState
+    private var _uiState: MutableState<PostEditUiState>? = null
+    val uiState: State<PostEditUiState> get() = requireNotNull(_uiState)
 
     fun initUiState(id: Int, title: String, content: String, category: PostCategory) {
         assert(id > 0)
+        if (_uiState != null) {
+            return
+        }
         _uiState = mutableStateOf(
             PostEditUiState(
                 postId = id,
@@ -36,19 +39,19 @@ class PostEditViewModel @Inject constructor(
     }
 
     private fun updateTitle(title: String) {
-        _uiState.value = uiState.value.copy(title = title)
+        _uiState!!.value = uiState.value.copy(title = title)
     }
 
     private fun updateContent(content: String) {
-        _uiState.value = uiState.value.copy(content = content)
+        _uiState!!.value = uiState.value.copy(content = content)
     }
 
     private fun updateCategory(category: PostCategory) {
-        _uiState.value = uiState.value.copy(category = category)
+        _uiState!!.value = uiState.value.copy(category = category)
     }
 
     private suspend fun savePost(): Result<Unit> {
-        _uiState.value = uiState.value.copy(isInSaving = true)
+        _uiState!!.value = uiState.value.copy(isInSaving = true)
         val result = updatePostUseCase(
             id = uiState.value.postId,
             title = uiState.value.title,
@@ -56,7 +59,7 @@ class PostEditViewModel @Inject constructor(
             category = uiState.value.category
         )
         if (result.isFailure) {
-            _uiState.value = uiState.value.copy(isInSaving = false)
+            _uiState!!.value = uiState.value.copy(isInSaving = false)
         }
         return result
     }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -2,6 +2,10 @@
     <string name="app_name">presentation</string>
     <string name="notice">공지사항</string>
     <string name="article">게시글</string>
+    <string name="study">스터디</string>
+    <string name="memory">추억</string>
+    <string name="knowhow">노하우</string>
+    <string name="reference">레퍼런스</string>
     <string name="user_list">회원 목록</string>
     <string name="post_subtitle">%s · %s</string>
     <string name="middle_dot">\u0020·\u0020</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -71,7 +71,7 @@
     <string name="user_created">회원 생성됨</string>
     <string name="my_info_edited">내 정보 편집됨</string>
     <string name="empty_label">-</string>
-    <string name="cannot_edit_post">글을 편집할 수 없습니다.</string>
+    <string name="failed_to_save_post">글 저장 실패</string>
     <string name="sorting_by_created_at_descending">가입일 최근순</string>
     <string name="nickname">닉네임</string>
     <string name="password">비밀번호</string>

--- a/presentation/src/test/java/com/pocs/presentation/PostCreateViewModelTest.kt
+++ b/presentation/src/test/java/com/pocs/presentation/PostCreateViewModelTest.kt
@@ -1,0 +1,46 @@
+package com.pocs.presentation
+
+import com.pocs.domain.model.post.PostCategory
+import com.pocs.domain.model.user.UserType
+import com.pocs.domain.usecase.auth.GetCurrentUserTypeUseCase
+import com.pocs.domain.usecase.auth.GetCurrentUserUseCase
+import com.pocs.domain.usecase.auth.IsCurrentUserAdminUseCase
+import com.pocs.domain.usecase.post.AddPostUseCase
+import com.pocs.presentation.view.post.create.PostCreateViewModel
+import com.pocs.test_library.fake.FakeAuthRepositoryImpl
+import com.pocs.test_library.fake.FakePostRepositoryImpl
+import com.pocs.test_library.mock.mockNormalUserDetail
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PostCreateViewModelTest {
+
+    private val postRepository = FakePostRepositoryImpl()
+    private val authRepository = FakeAuthRepositoryImpl()
+
+    private val viewModel = PostCreateViewModel(
+        addPostUseCase = AddPostUseCase(postRepository, GetCurrentUserUseCase(authRepository)),
+        isCurrentUserAdminUseCase = IsCurrentUserAdminUseCase(
+            GetCurrentUserTypeUseCase(authRepository)
+        )
+    )
+
+    @Test
+    fun shouldIsUserAdminIsTrue_WhenCurrentUserIsAdmin() {
+        authRepository.currentUser.value = mockNormalUserDetail.copy(type = UserType.ADMIN)
+
+        viewModel.initUiState(PostCategory.NOTICE)
+
+        assertTrue(viewModel.uiState.value.isUserAdmin)
+    }
+
+    @Test
+    fun shouldIsUserAdminIsFalse_WhenCurrentUserIsNotAdmin() {
+        authRepository.currentUser.value = mockNormalUserDetail.copy(type = UserType.MEMBER)
+
+        viewModel.initUiState(PostCategory.KNOWHOW)
+
+        assertFalse(viewModel.uiState.value.isUserAdmin)
+    }
+}

--- a/presentation/src/test/java/com/pocs/presentation/PostEditViewModelTest.kt
+++ b/presentation/src/test/java/com/pocs/presentation/PostEditViewModelTest.kt
@@ -1,0 +1,45 @@
+package com.pocs.presentation
+
+import com.pocs.domain.model.post.PostCategory
+import com.pocs.domain.model.user.UserType
+import com.pocs.domain.usecase.auth.GetCurrentUserTypeUseCase
+import com.pocs.domain.usecase.auth.IsCurrentUserAdminUseCase
+import com.pocs.domain.usecase.post.UpdatePostUseCase
+import com.pocs.presentation.view.post.edit.PostEditViewModel
+import com.pocs.test_library.fake.FakeAuthRepositoryImpl
+import com.pocs.test_library.fake.FakePostRepositoryImpl
+import com.pocs.test_library.mock.mockNormalUserDetail
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PostEditViewModelTest {
+
+    private val postRepository = FakePostRepositoryImpl()
+    private val authRepository = FakeAuthRepositoryImpl()
+
+    private val viewModel = PostEditViewModel(
+        updatePostUseCase = UpdatePostUseCase(postRepository, authRepository),
+        isCurrentUserAdminUseCase = IsCurrentUserAdminUseCase(
+            GetCurrentUserTypeUseCase(authRepository)
+        )
+    )
+
+    @Test
+    fun shouldIsUserAdminIsTrue_WhenCurrentUserIsAdmin() {
+        authRepository.currentUser.value = mockNormalUserDetail.copy(type = UserType.ADMIN)
+
+        viewModel.initUiState(1, "", "", PostCategory.NOTICE)
+
+        assertTrue(viewModel.uiState.value.isUserAdmin)
+    }
+
+    @Test
+    fun shouldIsUserAdminIsFalse_WhenCurrentUserIsNotAdmin() {
+        authRepository.currentUser.value = mockNormalUserDetail.copy(type = UserType.MEMBER)
+
+        viewModel.initUiState(1, "", "", PostCategory.KNOWHOW)
+
+        assertFalse(viewModel.uiState.value.isUserAdmin)
+    }
+}

--- a/test-library/src/main/java/com/pocs/test_library/fake/FakePostRepositoryImpl.kt
+++ b/test-library/src/main/java/com/pocs/test_library/fake/FakePostRepositoryImpl.kt
@@ -33,7 +33,7 @@ class FakePostRepositoryImpl @Inject constructor() : PostRepository {
     }
 
     override suspend fun updatePost(
-        id: Int,
+        postId: Int,
         title: String,
         content: String,
         userId: Int,


### PR DESCRIPTION
Resolves #139 

추가로 PostEditViewModel과 PostCreateViewModel에서 잘못된 상태관리를 수정했습니다. 
수정 전에는 한 번 초기화 된 후 또 다시 초기화 될 수 있었습니다. 이때문에 화면 회전 혹은 시스템을 어두운 테마로 전환시 `initUiState`가 또 호출되어 다시 초기화 되었습니다. 
수정 후에는 다시 초기화 하지 못하도록하여 그대로 상태가 유지됩니다.

![image](https://user-images.githubusercontent.com/57604817/183958795-7b7c9ce6-3898-4023-8c63-3ff6d9e21947.png)


## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [ ] Action에서 진행하는 테스트를 모두 통과했는가?
- [x] 수정 사항을 검증할 테스트를 추가하였는가?
- [x] 리뷰를 받았는가?