### PR TITLE
스플래시 스크린 Auth 초기화 될 때까지 보이도록 수정

### DIFF
--- a/data/src/main/java/com/pocs/data/di/NetworkModule.kt
+++ b/data/src/main/java/com/pocs/data/di/NetworkModule.kt
@@ -29,9 +29,9 @@ class NetworkModule {
     @Singleton
     fun provideHttpClient(): OkHttpClient {
         val client = OkHttpClient.Builder()
-            .readTimeout(10, TimeUnit.SECONDS)
-            .connectTimeout(10, TimeUnit.SECONDS)
-            .writeTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(5, TimeUnit.SECONDS)
+            .connectTimeout(5, TimeUnit.SECONDS)
+            .writeTimeout(5, TimeUnit.SECONDS)
             .addInterceptor(HttpLoggingInterceptor().apply {
                 this.level = HttpLoggingInterceptor.Level.BODY
             })

--- a/data/src/main/java/com/pocs/data/model/auth/AuthLocalData.kt
+++ b/data/src/main/java/com/pocs/data/model/auth/AuthLocalData.kt
@@ -3,6 +3,6 @@ package com.pocs.data.model.auth
 import java.io.Serializable
 
 data class AuthLocalData(
-    val token: String,
+    val sessionToken: String,
     val userId: Int
 ) : Serializable

--- a/data/src/main/java/com/pocs/data/repository/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/pocs/data/repository/AuthRepositoryImpl.kt
@@ -56,9 +56,7 @@ class AuthRepositoryImpl @Inject constructor(
     override fun isReady(): Flow<Boolean> = isReady
 
     override suspend fun login(userName: String, password: String): Result<Unit> {
-        if (token != null) {
-            throw IllegalStateException("이미 로그인한 상태에서 로그인을 시도했습니다.")
-        }
+        assert(token == null) { "이미 로그인한 상태에서 로그인을 시도했습니다." }
         try {
             val response = remoteDataSource.login(
                 LoginRequestBody(username = userName, password = password)
@@ -92,9 +90,7 @@ class AuthRepositoryImpl @Inject constructor(
     }
 
     override suspend fun logout(): Result<Unit> {
-        if (token == null) {
-            throw IllegalStateException("로그인하지 않은 상태로 로그아웃을 시도했습니다.")
-        }
+        assert(token != null) { "로그인하지 않은 상태로 로그아웃을 시도했습니다." }
         return try {
             val response = remoteDataSource.logout(token!!)
 

--- a/data/src/main/java/com/pocs/data/repository/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/pocs/data/repository/AuthRepositoryImpl.kt
@@ -35,18 +35,22 @@ class AuthRepositoryImpl @Inject constructor(
         val localData = localDataSource.getData()
         MainScope().launch {
             if (localData != null) {
-                val response = remoteDataSource.isSessionValid(localData.token)
-                val isSessionValid = response.isSuccessful
+                try {
+                    val response = remoteDataSource.isSessionValid(localData.token)
+                    val isSessionValid = response.isSuccessful
 
-                if (isSessionValid) {
-                    val userDetailResult = userRepository.getUserDetail(localData.userId)
+                    if (isSessionValid) {
+                        val userDetailResult = userRepository.getUserDetail(localData.userId)
 
-                    if (userDetailResult.isSuccess) {
-                        currentUserState.value = userDetailResult.getOrNull()!!
-                        token = localData.token
+                        if (userDetailResult.isSuccess) {
+                            currentUserState.value = userDetailResult.getOrNull()!!
+                            token = localData.token
+                        }
+                    } else {
+                        localDataSource.clear()
                     }
-                } else {
-                    localDataSource.clear()
+                } catch (e: Exception) {
+                    // 인터넷 연결이 끊김 등의 예외는 무시한다.
                 }
             }
             isReady.emit(true)

--- a/data/src/main/java/com/pocs/data/repository/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/pocs/data/repository/AuthRepositoryImpl.kt
@@ -28,15 +28,11 @@ class AuthRepositoryImpl @Inject constructor(
     private var token: String? = null
 
     init {
-        initAuth()
-    }
-
-    private fun initAuth() {
         val localData = localDataSource.getData()
         MainScope().launch {
             if (localData != null) {
                 try {
-                    val response = remoteDataSource.isSessionValid(localData.token)
+                    val response = remoteDataSource.isSessionValid(localData.sessionToken)
                     val isSessionValid = response.isSuccessful
 
                     if (isSessionValid) {
@@ -44,7 +40,7 @@ class AuthRepositoryImpl @Inject constructor(
 
                         if (userDetailResult.isSuccess) {
                             currentUserState.value = userDetailResult.getOrNull()!!
-                            token = localData.token
+                            token = localData.sessionToken
                         }
                     } else {
                         localDataSource.clear()
@@ -77,7 +73,12 @@ class AuthRepositoryImpl @Inject constructor(
 
                     currentUserState.value = userDetail
                     token = loginResponseData.sessionToken
-                    localDataSource.setData(AuthLocalData(token = token!!, userId = userDetail.id))
+                    localDataSource.setData(
+                        AuthLocalData(
+                            sessionToken = token!!,
+                            userId = userDetail.id
+                        )
+                    )
 
                     return Result.success(Unit)
                 }

--- a/data/src/test/java/com.pocs/data/AuthRepositoryTest.kt
+++ b/data/src/test/java/com.pocs/data/AuthRepositoryTest.kt
@@ -112,7 +112,7 @@ class AuthRepositoryTest {
 
         repository.login("id", "password")
 
-        assertEquals(token, localDataSource.authLocalData!!.token)
+        assertEquals(token, localDataSource.authLocalData!!.sessionToken)
         assertEquals(userDetail.id, localDataSource.authLocalData!!.userId)
     }
 

--- a/data/src/test/java/com.pocs/data/AuthRepositoryTest.kt
+++ b/data/src/test/java/com.pocs/data/AuthRepositoryTest.kt
@@ -22,6 +22,7 @@ import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
+import java.net.ConnectException
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltAndroidTest
@@ -176,6 +177,24 @@ class AuthRepositoryTest {
     @Test
     fun emitTrueFromIsReady_WhenThereIsNoLocalData() = runTest {
         localDataSource.authLocalData = null
+
+        initRepository()
+        var isReady = false
+        val job = launch(testDispatcher) {
+            repository.isReady().collectLatest {
+                isReady = it
+            }
+        }
+
+        assertTrue(isReady)
+
+        job.cancel()
+    }
+
+    @Test
+    fun emitTrueFromIsReady_WhenInternetIsNotConnected() = runTest {
+        remoteDataSource.isSessionValidInnerLambda = { throw ConnectException() }
+        localDataSource.authLocalData = AuthLocalData("abc", 1)
 
         initRepository()
         var isReady = false

--- a/domain/src/main/java/com/pocs/domain/repository/AuthRepository.kt
+++ b/domain/src/main/java/com/pocs/domain/repository/AuthRepository.kt
@@ -1,9 +1,11 @@
 package com.pocs.domain.repository
 
 import com.pocs.domain.model.user.UserDetail
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
 interface AuthRepository {
+    fun isReady(): Flow<Boolean>
     suspend fun login(userName: String, password: String): Result<Unit>
     suspend fun logout(): Result<Unit>
     fun getCurrentUser(): StateFlow<UserDetail?>

--- a/domain/src/main/java/com/pocs/domain/usecase/auth/IsAuthReadyUseCase.kt
+++ b/domain/src/main/java/com/pocs/domain/usecase/auth/IsAuthReadyUseCase.kt
@@ -1,0 +1,10 @@
+package com.pocs.domain.usecase.auth
+
+import com.pocs.domain.repository.AuthRepository
+import javax.inject.Inject
+
+class IsAuthReadyUseCase @Inject constructor(
+    private val authRepository: AuthRepository
+) {
+    operator fun invoke() = authRepository.isReady()
+}

--- a/presentation/src/main/java/com/pocs/presentation/model/auth/LoginUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/auth/LoginUiState.kt
@@ -1,6 +1,7 @@
 package com.pocs.presentation.model.auth
 
 data class LoginUiState(
+    val isAuthReady: Boolean = false,
     val isLoggedIn: Boolean = false,
     val errorMessage: String? = null,
     val userName: String = "",

--- a/presentation/src/main/java/com/pocs/presentation/view/login/LoginActivity.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/login/LoginActivity.kt
@@ -3,6 +3,8 @@ package com.pocs.presentation.view.login
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.view.View
+import android.view.ViewTreeObserver
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -32,6 +34,8 @@ class LoginActivity : AppCompatActivity() {
 
         WindowCompat.setDecorFitsSystemWindows(window, true)
 
+        showSplashUntilAuthIsReady()
+
         if (viewModel.uiState.value.isLoggedIn) {
             navigateToHomeActivity()
         }
@@ -50,6 +54,23 @@ class LoginActivity : AppCompatActivity() {
                 )
             }
         }
+    }
+
+    private fun showSplashUntilAuthIsReady() {
+        val content: View = findViewById(android.R.id.content)
+        content.viewTreeObserver.addOnPreDrawListener(
+            object : ViewTreeObserver.OnPreDrawListener {
+                override fun onPreDraw(): Boolean {
+                    return if (viewModel.uiState.value.isAuthReady) {
+                        viewModel.fetchCurrentUser()
+                        content.viewTreeObserver.removeOnPreDrawListener(this)
+                        true
+                    } else {
+                        false
+                    }
+                }
+            }
+        )
     }
 
     private fun updateUi(uiState: LoginUiState) {

--- a/presentation/src/main/java/com/pocs/presentation/view/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/login/LoginViewModel.kt
@@ -3,6 +3,7 @@ package com.pocs.presentation.view.login
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.pocs.domain.usecase.auth.GetCurrentUserUseCase
+import com.pocs.domain.usecase.auth.IsAuthReadyUseCase
 import com.pocs.domain.usecase.auth.LoginUseCase
 import com.pocs.presentation.model.auth.LoginUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -12,7 +13,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class LoginViewModel @Inject constructor(
-    getCurrentUserUseCase: GetCurrentUserUseCase,
+    isAuthReadyUseCase: IsAuthReadyUseCase,
+    private val getCurrentUserUseCase: GetCurrentUserUseCase,
     private val loginUseCase: LoginUseCase
 ) : ViewModel() {
 
@@ -21,10 +23,16 @@ class LoginViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            val currentUser = getCurrentUserUseCase()
-            _uiState.update {
-                it.copy(isLoggedIn = currentUser != null)
+            isAuthReadyUseCase().collectLatest { ready ->
+                _uiState.update { it.copy(isAuthReady = ready) }
             }
+        }
+    }
+
+    fun fetchCurrentUser() {
+        val currentUser = getCurrentUserUseCase()
+        _uiState.update {
+            it.copy(isLoggedIn = currentUser != null)
         }
     }
 

--- a/presentation/src/test/java/com/pocs/presentation/LoginViewModelTest.kt
+++ b/presentation/src/test/java/com/pocs/presentation/LoginViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.pocs.presentation
 
 import com.pocs.domain.usecase.auth.GetCurrentUserUseCase
+import com.pocs.domain.usecase.auth.IsAuthReadyUseCase
 import com.pocs.domain.usecase.auth.LoginUseCase
 import com.pocs.presentation.view.login.LoginViewModel
 import com.pocs.test_library.fake.FakeAuthRepositoryImpl
@@ -9,6 +10,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.*
@@ -35,8 +37,9 @@ class LoginViewModelTest {
     @Test
     fun shouldIsLoggedInIsTrue_WhenUserAlreadyLoggedIn() {
         authRepository.currentUser.value = mockNormalUserDetail
-
         initViewModel()
+
+        viewModel.fetchCurrentUser()
 
         assertTrue(viewModel.uiState.value.isLoggedIn)
     }
@@ -44,8 +47,9 @@ class LoginViewModelTest {
     @Test
     fun shouldIsLoggedInIsFalse_WhenUserDidNotLogin() {
         authRepository.currentUser.value = null
-
         initViewModel()
+
+        viewModel.fetchCurrentUser()
 
         assertFalse(viewModel.uiState.value.isLoggedIn)
     }
@@ -84,8 +88,18 @@ class LoginViewModelTest {
         assertEquals(errorMessage, viewModel.uiState.value.errorMessage)
     }
 
+    @Test
+    fun shouldIsAuthReadyIsTrue_WhenEmit() = runTest{
+        initViewModel()
+
+        authRepository.emit(isReady = true)
+
+        assertTrue(viewModel.uiState.value.isAuthReady)
+    }
+
     private fun initViewModel() {
         viewModel = LoginViewModel(
+            isAuthReadyUseCase = IsAuthReadyUseCase(authRepository),
             getCurrentUserUseCase = GetCurrentUserUseCase(authRepository),
             loginUseCase = LoginUseCase(authRepository)
         )

--- a/test-library/src/main/java/com/pocs/test_library/fake/FakeAuthRepositoryImpl.kt
+++ b/test-library/src/main/java/com/pocs/test_library/fake/FakeAuthRepositoryImpl.kt
@@ -2,17 +2,24 @@ package com.pocs.test_library.fake
 
 import com.pocs.domain.model.user.UserDetail
 import com.pocs.domain.repository.AuthRepository
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.*
 import javax.inject.Inject
 
 class FakeAuthRepositoryImpl @Inject constructor() : AuthRepository {
+
+    private var isReadyFlow = MutableSharedFlow<Boolean>()
 
     var currentUser = MutableStateFlow<UserDetail?>(null)
 
     var loginResult = Result.success(Unit)
 
     var logoutResult = Result.success(Unit)
+
+    suspend fun emit(isReady: Boolean) {
+        isReadyFlow.emit(isReady)
+    }
+
+    override fun isReady(): Flow<Boolean> = isReadyFlow
 
     override suspend fun login(userName: String, password: String): Result<Unit> {
         return loginResult

--- a/test-library/src/main/java/com/pocs/test_library/fake/source/remote/FakeAuthRemoteDataSource.kt
+++ b/test-library/src/main/java/com/pocs/test_library/fake/source/remote/FakeAuthRemoteDataSource.kt
@@ -4,8 +4,6 @@ import com.pocs.data.model.ResponseBody
 import com.pocs.data.model.auth.LoginRequestBody
 import com.pocs.data.model.auth.LoginResponseData
 import com.pocs.data.source.AuthRemoteDataSource
-import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.ResponseBody.Companion.toResponseBody
 import retrofit2.Response
 import javax.inject.Inject
 
@@ -38,6 +36,8 @@ class FakeAuthRemoteDataSource @Inject constructor() : AuthRemoteDataSource {
         )
     )
 
+    var isSessionValidInnerLambda: () -> Unit = {}
+
     override suspend fun login(loginRequestBody: LoginRequestBody): Response<ResponseBody<LoginResponseData>> {
         return loginResponse
     }
@@ -47,6 +47,7 @@ class FakeAuthRemoteDataSource @Inject constructor() : AuthRemoteDataSource {
     }
 
     override suspend fun isSessionValid(token: String): Response<ResponseBody<Unit>> {
+        isSessionValidInnerLambda()
         return isSessionValidResponse
     }
 }


### PR DESCRIPTION
Resolves #144 

AuthRepository에 `isReady`라는 속성을 두어 초기화 되었음을 나타내는 flow를 추가했습니다. 이 플로우를 로그인 뷰 모델에서 collect하여 isReady가 true로 온다면 스플래시 스크린을 제거합니다.
https://developer.android.com/guide/topics/ui/splash-screen#suspend-drawing 을 참고하여 해결했습니다. 

## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [ ] Action에서 진행하는 테스트를 모두 통과했는가?
- [x] 수정 사항을 검증할 테스트를 추가하였는가?
- [ ] 리뷰를 받았는가?