### PR TITLE
로그인 되어있는 상태에서 앱 실행시 로그인 화면 잠깐 보였다 사라지는 문제 해결

### DIFF
--- a/domain/src/main/java/com/pocs/domain/repository/AuthRepository.kt
+++ b/domain/src/main/java/com/pocs/domain/repository/AuthRepository.kt
@@ -5,10 +5,32 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
 interface AuthRepository {
+
+    /**
+     * 초기에는 `false`이며, 로컬 세션 토큰 유효성 검사와 유저 정보를 얻는 과정이 끝나면 `true`가 방출된다.
+     *
+     * 로컬 정보가 없다면 곧바로 `true`가 방출된다. 로컬 정보가 존재하여 로컬 세션 토큰 유효성 검사에 통과하면
+     * 유저 정보를 얻는다. 그리고 [getCurrentUser]를 통해 유저 정보가 방출되고나서 [isReady]에 `true`가 방출된다.
+     */
     fun isReady(): Flow<Boolean>
+
     suspend fun login(userName: String, password: String): Result<Unit>
+
     suspend fun logout(): Result<Unit>
+
+    /**
+     * 현재 로그인한 유저의 흐름을 얻는다.
+     *
+     * 로그인하지 않은 경우 흐름 값은 `null`이다. 이미 로그인한 상태에서 앱 실행시 세션 토큰과 유저 정보를 얻고 나면 곧바로
+     * 이곳에 얻은 유저 정보를 방출한다. 이는 [isReady]에 `true`가 방출되기 전에 수행된다.
+     */
     fun getCurrentUser(): StateFlow<UserDetail?>
+
+    /**
+     * 메모리에 존재하는 현재 유저의 정보를 동기화한다.
+     *
+     * 이는 유저가 개인 정보를 수정하고 나서 서버의 데이터와 현재 앱 실행중의 메모리 데이터를 동기화 하기 위해 사용한다.
+     */
     fun syncCurrentUser(
         name: String,
         email: String,

--- a/presentation/src/main/java/com/pocs/presentation/model/auth/LoginUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/auth/LoginUiState.kt
@@ -1,7 +1,7 @@
 package com.pocs.presentation.model.auth
 
 data class LoginUiState(
-    val isAuthReady: Boolean = false,
+    val hideSplashScreen: Boolean = false,
     val isLoggedIn: Boolean = false,
     val errorMessage: String? = null,
     val userName: String = "",

--- a/presentation/src/main/java/com/pocs/presentation/view/login/LoginActivity.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/login/LoginActivity.kt
@@ -61,9 +61,9 @@ class LoginActivity : AppCompatActivity() {
         content.viewTreeObserver.addOnPreDrawListener(
             object : ViewTreeObserver.OnPreDrawListener {
                 override fun onPreDraw(): Boolean {
-                    val isAuthReady = viewModel.uiState.value.isAuthReady
+                    val hideSplashScreen = viewModel.uiState.value.hideSplashScreen
 
-                    return if (isAuthReady) {
+                    return if (hideSplashScreen) {
                         content.viewTreeObserver.removeOnPreDrawListener(this)
                         true
                     } else {

--- a/presentation/src/main/java/com/pocs/presentation/view/login/LoginActivity.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/login/LoginActivity.kt
@@ -61,8 +61,9 @@ class LoginActivity : AppCompatActivity() {
         content.viewTreeObserver.addOnPreDrawListener(
             object : ViewTreeObserver.OnPreDrawListener {
                 override fun onPreDraw(): Boolean {
-                    return if (viewModel.uiState.value.isAuthReady) {
-                        viewModel.fetchCurrentUser()
+                    val isAuthReady = viewModel.uiState.value.isAuthReady
+
+                    return if (isAuthReady) {
                         content.viewTreeObserver.removeOnPreDrawListener(this)
                         true
                     } else {

--- a/presentation/src/main/java/com/pocs/presentation/view/login/LoginScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/login/LoginScreen.kt
@@ -61,8 +61,8 @@ fun LoginContent(
         Column(
             Modifier
                 .padding(innerPadding)
-                .padding(horizontal = 24.dp)
                 .verticalScroll(scrollState)
+                .padding(horizontal = 24.dp)
                 .fillMaxWidth()
                 .fillMaxHeight(),
             horizontalAlignment = Alignment.CenterHorizontally,

--- a/presentation/src/main/java/com/pocs/presentation/view/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/login/LoginViewModel.kt
@@ -2,11 +2,12 @@ package com.pocs.presentation.view.login
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.pocs.domain.usecase.auth.GetCurrentUserUseCase
+import com.pocs.domain.usecase.auth.GetCurrentUserStateFlowUseCase
 import com.pocs.domain.usecase.auth.IsAuthReadyUseCase
 import com.pocs.domain.usecase.auth.LoginUseCase
 import com.pocs.presentation.model.auth.LoginUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -14,25 +15,32 @@ import javax.inject.Inject
 @HiltViewModel
 class LoginViewModel @Inject constructor(
     isAuthReadyUseCase: IsAuthReadyUseCase,
-    private val getCurrentUserUseCase: GetCurrentUserUseCase,
+    getCurrentUserStateFlowUseCase: GetCurrentUserStateFlowUseCase,
     private val loginUseCase: LoginUseCase
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(LoginUiState(onUpdate = ::update))
     val uiState: StateFlow<LoginUiState> get() = _uiState.asStateFlow()
 
+    private var authReadyFetchJob: Job? = null
+
     init {
         viewModelScope.launch {
+            getCurrentUserStateFlowUseCase().collectLatest { currentUser ->
+                val isLoggedIn = currentUser != null
+                // 이미 로그인 되어있을 때는 `isAuthReady`를 갱신하지 않는다. 그 이유는 앱을 실행하고 곧바로 홈 화면으로
+                // 이동시 짧은 시간동안 로그인 화면이 등장하는 버그를 막기 위해서이다.
+                // https://github.com/hansung-pocs/blog-android/issues/150
+                if (isLoggedIn) {
+                    authReadyFetchJob?.cancel()
+                }
+                _uiState.update { it.copy(isLoggedIn = isLoggedIn) }
+            }
+        }
+        authReadyFetchJob = viewModelScope.launch {
             isAuthReadyUseCase().collectLatest { ready ->
                 _uiState.update { it.copy(isAuthReady = ready) }
             }
-        }
-    }
-
-    fun fetchCurrentUser() {
-        val currentUser = getCurrentUserUseCase()
-        _uiState.update {
-            it.copy(isLoggedIn = currentUser != null)
         }
     }
 

--- a/presentation/src/main/java/com/pocs/presentation/view/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/login/LoginViewModel.kt
@@ -22,24 +22,24 @@ class LoginViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(LoginUiState(onUpdate = ::update))
     val uiState: StateFlow<LoginUiState> get() = _uiState.asStateFlow()
 
-    private var authReadyFetchJob: Job? = null
+    private var splashScreenFetchJob: Job? = null
 
     init {
         viewModelScope.launch {
             getCurrentUserStateFlowUseCase().collectLatest { currentUser ->
                 val isLoggedIn = currentUser != null
-                // 이미 로그인 되어있을 때는 `isAuthReady`를 갱신하지 않는다. 그 이유는 앱을 실행하고 곧바로 홈 화면으로
-                // 이동시 짧은 시간동안 로그인 화면이 등장하는 버그를 막기 위해서이다.
+                // 이미 로그인 되어있을 때는 `hideSplashScreen`를 `true`로 갱신하지 않는다. 그 이유는 앱을 실행하고
+                // 곧바로 홈 화면으로 이동시 짧은 시간동안 로그인 화면이 등장하는 버그를 막기 위해서이다.
                 // https://github.com/hansung-pocs/blog-android/issues/150
                 if (isLoggedIn) {
-                    authReadyFetchJob?.cancel()
+                    splashScreenFetchJob?.cancel()
                 }
                 _uiState.update { it.copy(isLoggedIn = isLoggedIn) }
             }
         }
-        authReadyFetchJob = viewModelScope.launch {
-            isAuthReadyUseCase().collectLatest { ready ->
-                _uiState.update { it.copy(isAuthReady = ready) }
+        splashScreenFetchJob = viewModelScope.launch {
+            isAuthReadyUseCase().collectLatest { isAuthReady ->
+                _uiState.update { it.copy(hideSplashScreen = isAuthReady) }
             }
         }
     }

--- a/presentation/src/test/java/com/pocs/presentation/LoginViewModelTest.kt
+++ b/presentation/src/test/java/com/pocs/presentation/LoginViewModelTest.kt
@@ -1,6 +1,6 @@
 package com.pocs.presentation
 
-import com.pocs.domain.usecase.auth.GetCurrentUserUseCase
+import com.pocs.domain.usecase.auth.GetCurrentUserStateFlowUseCase
 import com.pocs.domain.usecase.auth.IsAuthReadyUseCase
 import com.pocs.domain.usecase.auth.LoginUseCase
 import com.pocs.presentation.view.login.LoginViewModel
@@ -37,9 +37,8 @@ class LoginViewModelTest {
     @Test
     fun shouldIsLoggedInIsTrue_WhenUserAlreadyLoggedIn() {
         authRepository.currentUser.value = mockNormalUserDetail
-        initViewModel()
 
-        viewModel.fetchCurrentUser()
+        initViewModel()
 
         assertTrue(viewModel.uiState.value.isLoggedIn)
     }
@@ -47,9 +46,8 @@ class LoginViewModelTest {
     @Test
     fun shouldIsLoggedInIsFalse_WhenUserDidNotLogin() {
         authRepository.currentUser.value = null
-        initViewModel()
 
-        viewModel.fetchCurrentUser()
+        initViewModel()
 
         assertFalse(viewModel.uiState.value.isLoggedIn)
     }
@@ -89,7 +87,7 @@ class LoginViewModelTest {
     }
 
     @Test
-    fun shouldIsAuthReadyIsTrue_WhenEmit() = runTest{
+    fun shouldIsAuthReadyIsTrue_WhenEmit() = runTest {
         initViewModel()
 
         authRepository.emit(isReady = true)
@@ -97,10 +95,21 @@ class LoginViewModelTest {
         assertTrue(viewModel.uiState.value.isAuthReady)
     }
 
+    // https://github.com/hansung-pocs/blog-android/issues/150 를 위한 테스트
+    @Test
+    fun shouldDoNotInitAuthReady_WhenCurrentUserExists() = runTest {
+        initViewModel()
+
+        authRepository.currentUser.value = mockNormalUserDetail
+        authRepository.emit(isReady = true)
+
+        assertFalse(viewModel.uiState.value.isAuthReady)
+    }
+
     private fun initViewModel() {
         viewModel = LoginViewModel(
             isAuthReadyUseCase = IsAuthReadyUseCase(authRepository),
-            getCurrentUserUseCase = GetCurrentUserUseCase(authRepository),
+            getCurrentUserStateFlowUseCase = GetCurrentUserStateFlowUseCase(authRepository),
             loginUseCase = LoginUseCase(authRepository)
         )
     }

--- a/presentation/src/test/java/com/pocs/presentation/LoginViewModelTest.kt
+++ b/presentation/src/test/java/com/pocs/presentation/LoginViewModelTest.kt
@@ -87,23 +87,23 @@ class LoginViewModelTest {
     }
 
     @Test
-    fun shouldIsAuthReadyIsTrue_WhenEmit() = runTest {
+    fun shouldHideSplashScreenIsTrue_WhenEmit() = runTest {
         initViewModel()
 
         authRepository.emit(isReady = true)
 
-        assertTrue(viewModel.uiState.value.isAuthReady)
+        assertTrue(viewModel.uiState.value.hideSplashScreen)
     }
 
     // https://github.com/hansung-pocs/blog-android/issues/150 를 위한 테스트
     @Test
-    fun shouldDoNotInitAuthReady_WhenCurrentUserExists() = runTest {
+    fun shouldHideSplashScreenIsFalse_WhenCurrentUserExistsAndThenAuthIsReady() = runTest {
         initViewModel()
 
         authRepository.currentUser.value = mockNormalUserDetail
         authRepository.emit(isReady = true)
 
-        assertFalse(viewModel.uiState.value.isAuthReady)
+        assertFalse(viewModel.uiState.value.hideSplashScreen)
     }
 
     private fun initViewModel() {


### PR DESCRIPTION
Fixes #150 

앱 실행 후 로그인 되어있는 것을 확인하면 `hideSplashScreen`을 그대로 `false`로 두도록 했습니다. 로그인 되어있는 것을 확인한다면 홈화면으로 전환되어 스플래시 화면이 사라지기 때문입니다.

https://user-images.githubusercontent.com/57604817/184300227-511c5f92-3774-4649-95c7-94c635490d1a.mov


## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [ ] Action에서 진행하는 테스트를 모두 통과했는가?
- [x] 수정 사항을 검증할 테스트를 추가하였는가?
- [ ] 리뷰를 받았는가?