### PR TITLE
HomeActivity를 launch 엑티비티로 수정

### DIFF
--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -5,6 +5,16 @@
     <application>
         <activity
             android:name=".view.login.LoginActivity"
+            android:exported="true" />
+        <activity
+            android:name=".view.admin.AdminActivity"
+            android:exported="false" />
+        <activity
+            android:name=".view.admin.user.create.AdminUserCreateActivity"
+            android:exported="false"
+            android:windowSoftInputMode="adjustResize" />
+        <activity
+            android:name=".view.home.HomeActivity"
             android:exported="true"
             android:label="@string/app_name"
             android:theme="@style/Theme.PocsBlog"
@@ -15,16 +25,6 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity
-            android:name=".view.admin.AdminActivity"
-            android:exported="false" />
-        <activity
-            android:name=".view.admin.user.create.AdminUserCreateActivity"
-            android:exported="false"
-            android:windowSoftInputMode="adjustResize" />
-        <activity
-            android:name=".view.home.HomeActivity"
-            android:exported="false" />
         <activity
             android:name=".view.post.by.user.PostByUserActivity"
             android:exported="false"

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <application>
         <activity
             android:name=".view.login.LoginActivity"
-            android:exported="true"
+            android:exported="false"
             android:windowSoftInputMode="adjustResize" />
         <activity
             android:name=".view.admin.AdminActivity"

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -5,7 +5,8 @@
     <application>
         <activity
             android:name=".view.login.LoginActivity"
-            android:exported="true" />
+            android:exported="true"
+            android:windowSoftInputMode="adjustResize" />
         <activity
             android:name=".view.admin.AdminActivity"
             android:exported="false" />
@@ -17,8 +18,7 @@
             android:name=".view.home.HomeActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.PocsBlog"
-            android:windowSoftInputMode="adjustResize">
+            android:theme="@style/Theme.PocsBlog">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/presentation/src/main/java/com/pocs/presentation/model/auth/LoginUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/auth/LoginUiState.kt
@@ -1,7 +1,6 @@
 package com.pocs.presentation.model.auth
 
 data class LoginUiState(
-    val hideSplashScreen: Boolean = false,
     val isLoggedIn: Boolean = false,
     val errorMessage: String? = null,
     val userName: String = "",

--- a/presentation/src/main/java/com/pocs/presentation/model/post/HomeUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/post/HomeUiState.kt
@@ -1,5 +1,7 @@
 package com.pocs.presentation.model.post
 
 data class HomeUiState(
-    val isCurrentUserAdmin: Boolean
+    val isCurrentUserAdmin: Boolean,
+    val replaceToLoginActivity: Boolean = false,
+    val hideSplashScreen: Boolean = false
 )

--- a/presentation/src/main/java/com/pocs/presentation/view/home/HomeActivity.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/home/HomeActivity.kt
@@ -45,7 +45,7 @@ class HomeActivity : ViewBindingActivity<ActivityHomeBinding>() {
         WindowCompat.setDecorFitsSystemWindows(window, false)
         super.onCreate(savedInstanceState)
 
-        showSplashUntilAppReady()
+        showSplashUntilAppIsReady()
 
         setSupportActionBar(binding.toolbar)
 
@@ -59,7 +59,7 @@ class HomeActivity : ViewBindingActivity<ActivityHomeBinding>() {
         }
     }
 
-    private fun showSplashUntilAppReady() {
+    private fun showSplashUntilAppIsReady() {
         binding.root.viewTreeObserver.addOnPreDrawListener(
             object : ViewTreeObserver.OnPreDrawListener {
                 override fun onPreDraw(): Boolean {

--- a/presentation/src/main/java/com/pocs/presentation/view/home/HomeActivity.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/home/HomeActivity.kt
@@ -60,14 +60,13 @@ class HomeActivity : ViewBindingActivity<ActivityHomeBinding>() {
     }
 
     private fun showSplashUntilAppReady() {
-        val content: View = findViewById(android.R.id.content)
-        content.viewTreeObserver.addOnPreDrawListener(
+        binding.root.viewTreeObserver.addOnPreDrawListener(
             object : ViewTreeObserver.OnPreDrawListener {
                 override fun onPreDraw(): Boolean {
                     val hideSplashScreen = viewModel.uiState.value.hideSplashScreen
 
                     return if (hideSplashScreen) {
-                        content.viewTreeObserver.removeOnPreDrawListener(this)
+                        binding.root.viewTreeObserver.removeOnPreDrawListener(this)
                         true
                     } else {
                         false

--- a/presentation/src/main/java/com/pocs/presentation/view/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/home/HomeViewModel.kt
@@ -15,7 +15,7 @@ import javax.inject.Inject
 class HomeViewModel @Inject constructor(
     isAuthReadyUseCase: IsAuthReadyUseCase,
     isCurrentUserAdminUseCase: IsCurrentUserAdminUseCase,
-    private val getCurrentUserUseCase: GetCurrentUserUseCase,
+    getCurrentUserUseCase: GetCurrentUserUseCase,
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<HomeUiState> = MutableStateFlow(

--- a/presentation/src/main/java/com/pocs/presentation/view/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/home/HomeViewModel.kt
@@ -1,21 +1,47 @@
 package com.pocs.presentation.view.home
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.pocs.domain.usecase.auth.GetCurrentUserUseCase
+import com.pocs.domain.usecase.auth.IsAuthReadyUseCase
 import com.pocs.domain.usecase.auth.IsCurrentUserAdminUseCase
 import com.pocs.presentation.model.post.HomeUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
-    isCurrentUserAdminUseCase: IsCurrentUserAdminUseCase
+    isAuthReadyUseCase: IsAuthReadyUseCase,
+    isCurrentUserAdminUseCase: IsCurrentUserAdminUseCase,
+    private val getCurrentUserUseCase: GetCurrentUserUseCase,
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<HomeUiState> = MutableStateFlow(
         HomeUiState(isCurrentUserAdmin = isCurrentUserAdminUseCase())
     )
     val uiState: StateFlow<HomeUiState> get() = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            isAuthReadyUseCase().collectLatest { isAuthReady ->
+                if (isAuthReady) {
+                    val loggedIn = getCurrentUserUseCase() != null
+
+                    _uiState.update {
+                        if (loggedIn) {
+                            it.copy(hideSplashScreen = true)
+                        } else {
+                            // 로그인 화면으로 전환하는 경우 `hideSplashScreen`를 `true`로 갱신하지 않는다.
+                            // 그 이유는 앱을 실행하고 곧바로 로그인 화면으로 이동시 짧은 시간동안 홈 화면이 등장하는
+                            // 버그를 막기 위해서이다.
+                            // https://github.com/hansung-pocs/blog-android/issues/150
+                            it.copy(replaceToLoginActivity = true)
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/login/LoginActivity.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/login/LoginActivity.kt
@@ -3,8 +3,6 @@ package com.pocs.presentation.view.login
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.view.View
-import android.view.ViewTreeObserver
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -34,18 +32,6 @@ class LoginActivity : AppCompatActivity() {
 
         WindowCompat.setDecorFitsSystemWindows(window, true)
 
-        showSplashUntilAuthIsReady()
-
-        if (viewModel.uiState.value.isLoggedIn) {
-            navigateToHomeActivity()
-        }
-
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.uiState.collect(::updateUi)
-            }
-        }
-
         setContent {
             Mdc3Theme(this) {
                 LoginScreen(
@@ -54,24 +40,12 @@ class LoginActivity : AppCompatActivity() {
                 )
             }
         }
-    }
 
-    private fun showSplashUntilAuthIsReady() {
-        val content: View = findViewById(android.R.id.content)
-        content.viewTreeObserver.addOnPreDrawListener(
-            object : ViewTreeObserver.OnPreDrawListener {
-                override fun onPreDraw(): Boolean {
-                    val hideSplashScreen = viewModel.uiState.value.hideSplashScreen
-
-                    return if (hideSplashScreen) {
-                        content.viewTreeObserver.removeOnPreDrawListener(this)
-                        true
-                    } else {
-                        false
-                    }
-                }
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect(::updateUi)
             }
-        )
+        }
     }
 
     private fun updateUi(uiState: LoginUiState) {

--- a/presentation/src/main/java/com/pocs/presentation/view/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/login/LoginViewModel.kt
@@ -3,18 +3,15 @@ package com.pocs.presentation.view.login
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.pocs.domain.usecase.auth.GetCurrentUserStateFlowUseCase
-import com.pocs.domain.usecase.auth.IsAuthReadyUseCase
 import com.pocs.domain.usecase.auth.LoginUseCase
 import com.pocs.presentation.model.auth.LoginUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class LoginViewModel @Inject constructor(
-    isAuthReadyUseCase: IsAuthReadyUseCase,
     getCurrentUserStateFlowUseCase: GetCurrentUserStateFlowUseCase,
     private val loginUseCase: LoginUseCase
 ) : ViewModel() {
@@ -22,24 +19,11 @@ class LoginViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(LoginUiState(onUpdate = ::update))
     val uiState: StateFlow<LoginUiState> get() = _uiState.asStateFlow()
 
-    private var splashScreenFetchJob: Job? = null
-
     init {
         viewModelScope.launch {
             getCurrentUserStateFlowUseCase().collectLatest { currentUser ->
                 val isLoggedIn = currentUser != null
-                // 이미 로그인 되어있을 때는 `hideSplashScreen`를 `true`로 갱신하지 않는다. 그 이유는 앱을 실행하고
-                // 곧바로 홈 화면으로 이동시 짧은 시간동안 로그인 화면이 등장하는 버그를 막기 위해서이다.
-                // https://github.com/hansung-pocs/blog-android/issues/150
-                if (isLoggedIn) {
-                    splashScreenFetchJob?.cancel()
-                }
                 _uiState.update { it.copy(isLoggedIn = isLoggedIn) }
-            }
-        }
-        splashScreenFetchJob = viewModelScope.launch {
-            isAuthReadyUseCase().collectLatest { isAuthReady ->
-                _uiState.update { it.copy(hideSplashScreen = isAuthReady) }
             }
         }
     }

--- a/presentation/src/test/java/com/pocs/presentation/HomeViewModelTest.kt
+++ b/presentation/src/test/java/com/pocs/presentation/HomeViewModelTest.kt
@@ -2,19 +2,40 @@ package com.pocs.presentation
 
 import com.pocs.domain.model.user.UserType
 import com.pocs.domain.usecase.auth.GetCurrentUserTypeUseCase
+import com.pocs.domain.usecase.auth.GetCurrentUserUseCase
+import com.pocs.domain.usecase.auth.IsAuthReadyUseCase
 import com.pocs.domain.usecase.auth.IsCurrentUserAdminUseCase
 import com.pocs.presentation.view.home.HomeViewModel
 import com.pocs.test_library.fake.FakeAuthRepositoryImpl
 import com.pocs.test_library.mock.mockNormalUserDetail
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class HomeViewModelTest {
 
     private val authRepository = FakeAuthRepositoryImpl()
 
     private lateinit var viewModel: HomeViewModel
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
 
     @Test
     fun shouldIsCurrentUserAdminIsTrue_WhenCurrentUserIsAdmin() {
@@ -32,9 +53,32 @@ class HomeViewModelTest {
         assertFalse(viewModel.uiState.value.isCurrentUserAdmin)
     }
 
+    // https://github.com/hansung-pocs/blog-android/issues/150 를 위한 테스트
+    @Test
+    fun shouldHideSplashScreenIsFalse_WhenCurrentUserIsNull() = runTest {
+        initViewModel()
+
+        authRepository.currentUser.value = null
+        authRepository.emit(isReady = true)
+
+        assertFalse(viewModel.uiState.value.hideSplashScreen)
+    }
+
+    @Test
+    fun shouldHideSplashScreenIsTrue_WhenCurrentUserExists() = runTest {
+        initViewModel()
+
+        authRepository.currentUser.value = mockNormalUserDetail
+        authRepository.emit(isReady = true)
+
+        assertTrue(viewModel.uiState.value.hideSplashScreen)
+    }
+
     private fun initViewModel() {
         viewModel = HomeViewModel(
-            IsCurrentUserAdminUseCase(GetCurrentUserTypeUseCase(authRepository))
+            IsAuthReadyUseCase(authRepository),
+            IsCurrentUserAdminUseCase(GetCurrentUserTypeUseCase(authRepository)),
+            GetCurrentUserUseCase(authRepository)
         )
     }
 }

--- a/presentation/src/test/java/com/pocs/presentation/LoginViewModelTest.kt
+++ b/presentation/src/test/java/com/pocs/presentation/LoginViewModelTest.kt
@@ -1,7 +1,6 @@
 package com.pocs.presentation
 
 import com.pocs.domain.usecase.auth.GetCurrentUserStateFlowUseCase
-import com.pocs.domain.usecase.auth.IsAuthReadyUseCase
 import com.pocs.domain.usecase.auth.LoginUseCase
 import com.pocs.presentation.view.login.LoginViewModel
 import com.pocs.test_library.fake.FakeAuthRepositoryImpl
@@ -10,7 +9,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.*
@@ -86,29 +84,8 @@ class LoginViewModelTest {
         assertEquals(errorMessage, viewModel.uiState.value.errorMessage)
     }
 
-    @Test
-    fun shouldHideSplashScreenIsTrue_WhenEmit() = runTest {
-        initViewModel()
-
-        authRepository.emit(isReady = true)
-
-        assertTrue(viewModel.uiState.value.hideSplashScreen)
-    }
-
-    // https://github.com/hansung-pocs/blog-android/issues/150 를 위한 테스트
-    @Test
-    fun shouldHideSplashScreenIsFalse_WhenCurrentUserExistsAndThenAuthIsReady() = runTest {
-        initViewModel()
-
-        authRepository.currentUser.value = mockNormalUserDetail
-        authRepository.emit(isReady = true)
-
-        assertFalse(viewModel.uiState.value.hideSplashScreen)
-    }
-
     private fun initViewModel() {
         viewModel = LoginViewModel(
-            isAuthReadyUseCase = IsAuthReadyUseCase(authRepository),
             getCurrentUserStateFlowUseCase = GetCurrentUserStateFlowUseCase(authRepository),
             loginUseCase = LoginUseCase(authRepository)
         )


### PR DESCRIPTION
HomeActivity를 launch 엑티비티로 수정했습니다. 시나리오는 다음과 같습니다

- 로그인 안하고 앱 실행: HomeActivity -> LoginActivity
- 로그인하고 앱 실행: HomeActivity

추후에 **로그인한 상태로 앱을 이용**하는 경우가 더욱 많을 것이라 생각되어 수정했습니다.
이렇게 수정하면 **로그인한 상태로 앱을 이용**하는 경우 약간이나마 **앱 실행 속도가 빨라**집니다. 그 이유는 기존에 LoginActivity -> HomeActivity으로 전환이 필요했던것에 비해 **곧바로 HomeActivity를 띄워 전환 과정이 생략**되었기 때문입니다.

하지만 **로그인 하지 않은 상태로 앱을 실행하면 약간의 실행속도 느려짐**이 있습니다. 그래도 release 모드로 테스트해본 결과 **2초로 문제 없는 수준**입니다. 

## 테스트 결과

**로그인한 상태로 앱 실행시 속도** -> 0.7초
![image](https://user-images.githubusercontent.com/57604817/184341637-db68f536-5fec-4ccb-8865-925e438863c4.png)

**로그인 안하고 앱 실행 속도** -> 1.2초
![image](https://user-images.githubusercontent.com/57604817/184341727-91d01c01-d80b-4429-a076-8b7834b7027c.png)

테스트 환경
- API Level: 28
- 기기: 갤럭시s8
- release mode


## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [ ] Action에서 진행하는 테스트를 모두 통과했는가?
- [ ] 수정 사항을 검증할 테스트를 추가하였는가?
- [ ] 리뷰를 받았는가?