### PR TITLE
API 업데이트 대응

### DIFF
--- a/data/src/main/java/com/pocs/data/api/AuthApi.kt
+++ b/data/src/main/java/com/pocs/data/api/AuthApi.kt
@@ -3,6 +3,7 @@ package com.pocs.data.api
 import com.pocs.data.model.ResponseBody
 import com.pocs.data.model.auth.LoginRequestBody
 import com.pocs.data.model.auth.LoginResponseData
+import com.pocs.data.model.user.UserDto
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.Header
@@ -24,5 +25,5 @@ interface AuthApi {
     @POST("auth/validation")
     suspend fun isSessionValid(
         @Header("x-pocs-session-token") token: String
-    ): Response<ResponseBody<Unit>>
+    ): Response<ResponseBody<UserDto>>
 }

--- a/data/src/main/java/com/pocs/data/api/AuthApi.kt
+++ b/data/src/main/java/com/pocs/data/api/AuthApi.kt
@@ -3,7 +3,7 @@ package com.pocs.data.api
 import com.pocs.data.model.ResponseBody
 import com.pocs.data.model.auth.LoginRequestBody
 import com.pocs.data.model.auth.LoginResponseData
-import com.pocs.data.model.user.UserDto
+import com.pocs.data.model.auth.SessionValidResponseData
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.Header
@@ -25,5 +25,5 @@ interface AuthApi {
     @POST("auth/validation")
     suspend fun isSessionValid(
         @Header("x-pocs-session-token") token: String
-    ): Response<ResponseBody<UserDto>>
+    ): Response<ResponseBody<SessionValidResponseData>>
 }

--- a/data/src/main/java/com/pocs/data/di/RepositoryModule.kt
+++ b/data/src/main/java/com/pocs/data/di/RepositoryModule.kt
@@ -44,13 +44,11 @@ class RepositoryModule {
     @Provides
     fun provideAuthRepository(
         remoteDataSource: AuthRemoteDataSource,
-        localDataSource: AuthLocalDataSource,
-        userRepository: UserRepository
+        localDataSource: AuthLocalDataSource
     ): AuthRepository {
         return AuthRepositoryImpl(
             remoteDataSource = remoteDataSource,
-            localDataSource = localDataSource,
-            userRepository = userRepository
+            localDataSource = localDataSource
         )
     }
 }

--- a/data/src/main/java/com/pocs/data/mapper/UserCreateInfoMapper.kt
+++ b/data/src/main/java/com/pocs/data/mapper/UserCreateInfoMapper.kt
@@ -4,7 +4,7 @@ import com.pocs.data.model.admin.UserCreateInfoBody
 import com.pocs.domain.model.admin.UserCreateInfo
 
 fun UserCreateInfo.toDto() = UserCreateInfoBody(
-    nickname = nickname,
+    userName = userName,
     password = password,
     name = name,
     studentId = studentId,

--- a/data/src/main/java/com/pocs/data/model/admin/UserCreateInfoBody.kt
+++ b/data/src/main/java/com/pocs/data/model/admin/UserCreateInfoBody.kt
@@ -1,9 +1,7 @@
 package com.pocs.data.model.admin
 
-import com.google.gson.annotations.SerializedName
-
 data class UserCreateInfoBody(
-    @SerializedName("userName") val nickname: String,
+    val userName: String,
     val password: String,
     val name: String,
     val studentId: Int,

--- a/data/src/main/java/com/pocs/data/model/auth/AuthLocalData.kt
+++ b/data/src/main/java/com/pocs/data/model/auth/AuthLocalData.kt
@@ -3,6 +3,5 @@ package com.pocs.data.model.auth
 import java.io.Serializable
 
 data class AuthLocalData(
-    val sessionToken: String,
-    val userId: Int
+    val sessionToken: String
 ) : Serializable

--- a/data/src/main/java/com/pocs/data/model/auth/LoginResponseData.kt
+++ b/data/src/main/java/com/pocs/data/model/auth/LoginResponseData.kt
@@ -1,6 +1,8 @@
 package com.pocs.data.model.auth
 
+import com.pocs.data.model.user.UserDto
+
 data class LoginResponseData(
     val sessionToken: String,
-    val userId: Int
+    val user: UserDto
 )

--- a/data/src/main/java/com/pocs/data/model/auth/SessionValidResponseData.kt
+++ b/data/src/main/java/com/pocs/data/model/auth/SessionValidResponseData.kt
@@ -1,0 +1,7 @@
+package com.pocs.data.model.auth
+
+import com.pocs.data.model.user.UserDto
+
+data class SessionValidResponseData(
+    val user: UserDto
+)

--- a/data/src/main/java/com/pocs/data/model/post/PostWriterDto.kt
+++ b/data/src/main/java/com/pocs/data/model/post/PostWriterDto.kt
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName
 
 data class PostWriterDto(
     @SerializedName("userId") val id: Int,
-    @SerializedName("userName") val name: String,
+    val name: String,
     val email: String,
     val type: String
 )

--- a/data/src/main/java/com/pocs/data/model/user/UserDto.kt
+++ b/data/src/main/java/com/pocs/data/model/user/UserDto.kt
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName
 
 data class UserDto(
     @SerializedName("userId") val id: Int,
-    @SerializedName("userName") val name: String,
+    val name: String,
     val email: String,
     val studentId: Int,
     val type: String,

--- a/data/src/main/java/com/pocs/data/model/user/UserUpdateBody.kt
+++ b/data/src/main/java/com/pocs/data/model/user/UserUpdateBody.kt
@@ -2,7 +2,7 @@ package com.pocs.data.model.user
 
 data class UserUpdateBody(
     val password: String,
-    val userName: String,
+    val name: String,
     val email: String,
     val github: String?,
     val company: String?

--- a/data/src/main/java/com/pocs/data/repository/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/pocs/data/repository/AuthRepositoryImpl.kt
@@ -35,7 +35,7 @@ class AuthRepositoryImpl @Inject constructor(
                     val isSessionValid = response.isSuccessful
 
                     if (isSessionValid) {
-                        val userDto = response.body()!!.data
+                        val userDto = response.body()!!.data.user
                         currentUserState.value = userDto.toDetailEntity()
                         token = localData.sessionToken
                     } else {

--- a/data/src/main/java/com/pocs/data/repository/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/pocs/data/repository/AuthRepositoryImpl.kt
@@ -1,13 +1,13 @@
 package com.pocs.data.repository
 
 import com.pocs.data.extension.errorMessage
+import com.pocs.data.mapper.toDetailEntity
 import com.pocs.data.model.auth.AuthLocalData
 import com.pocs.data.model.auth.LoginRequestBody
 import com.pocs.data.source.AuthLocalDataSource
 import com.pocs.data.source.AuthRemoteDataSource
 import com.pocs.domain.model.user.UserDetail
 import com.pocs.domain.repository.AuthRepository
-import com.pocs.domain.repository.UserRepository
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -17,8 +17,7 @@ import javax.inject.Inject
 
 class AuthRepositoryImpl @Inject constructor(
     private val remoteDataSource: AuthRemoteDataSource,
-    private val localDataSource: AuthLocalDataSource,
-    private val userRepository: UserRepository
+    private val localDataSource: AuthLocalDataSource
 ) : AuthRepository {
 
     private val isReady = MutableStateFlow(false)
@@ -36,12 +35,9 @@ class AuthRepositoryImpl @Inject constructor(
                     val isSessionValid = response.isSuccessful
 
                     if (isSessionValid) {
-                        val userDetailResult = userRepository.getUserDetail(localData.userId)
-
-                        if (userDetailResult.isSuccess) {
-                            currentUserState.value = userDetailResult.getOrNull()!!
-                            token = localData.sessionToken
-                        }
+                        val userDto = response.body()!!.data
+                        currentUserState.value = userDto.toDetailEntity()
+                        token = localData.sessionToken
                     } else {
                         localDataSource.clear()
                     }
@@ -64,23 +60,12 @@ class AuthRepositoryImpl @Inject constructor(
 
             if (response.isSuccessful) {
                 val loginResponseData = response.body()!!.data
-                val userDetailResult = userRepository.getUserDetail(loginResponseData.userId)
 
-                if (userDetailResult.isSuccess) {
-                    val userDetail = userDetailResult.getOrNull()!!
+                currentUserState.value = loginResponseData.user.toDetailEntity()
+                token = loginResponseData.sessionToken
+                localDataSource.setData(AuthLocalData(sessionToken = token!!))
 
-                    currentUserState.value = userDetail
-                    token = loginResponseData.sessionToken
-                    localDataSource.setData(
-                        AuthLocalData(
-                            sessionToken = token!!,
-                            userId = userDetail.id
-                        )
-                    )
-
-                    return Result.success(Unit)
-                }
-                throw Exception("로그인에 성공하였으나 유저 정보를 얻지 못함: ${userDetailResult.exceptionOrNull()!!.message}")
+                return Result.success(Unit)
             } else {
                 throw Exception(response.errorMessage)
             }

--- a/data/src/main/java/com/pocs/data/source/AuthRemoteDataSource.kt
+++ b/data/src/main/java/com/pocs/data/source/AuthRemoteDataSource.kt
@@ -3,11 +3,12 @@ package com.pocs.data.source
 import com.pocs.data.model.ResponseBody
 import com.pocs.data.model.auth.LoginRequestBody
 import com.pocs.data.model.auth.LoginResponseData
+import com.pocs.data.model.auth.SessionValidResponseData
 import com.pocs.data.model.user.UserDto
 import retrofit2.Response
 
 interface AuthRemoteDataSource {
     suspend fun login(loginRequestBody: LoginRequestBody): Response<ResponseBody<LoginResponseData>>
     suspend fun logout(token: String): Response<ResponseBody<Unit>>
-    suspend fun isSessionValid(token: String): Response<ResponseBody<UserDto>>
+    suspend fun isSessionValid(token: String): Response<ResponseBody<SessionValidResponseData>>
 }

--- a/data/src/main/java/com/pocs/data/source/AuthRemoteDataSource.kt
+++ b/data/src/main/java/com/pocs/data/source/AuthRemoteDataSource.kt
@@ -3,10 +3,11 @@ package com.pocs.data.source
 import com.pocs.data.model.ResponseBody
 import com.pocs.data.model.auth.LoginRequestBody
 import com.pocs.data.model.auth.LoginResponseData
+import com.pocs.data.model.user.UserDto
 import retrofit2.Response
 
 interface AuthRemoteDataSource {
     suspend fun login(loginRequestBody: LoginRequestBody): Response<ResponseBody<LoginResponseData>>
     suspend fun logout(token: String): Response<ResponseBody<Unit>>
-    suspend fun isSessionValid(token: String): Response<ResponseBody<Unit>>
+    suspend fun isSessionValid(token: String): Response<ResponseBody<UserDto>>
 }

--- a/data/src/main/java/com/pocs/data/source/AuthRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/pocs/data/source/AuthRemoteDataSourceImpl.kt
@@ -3,6 +3,7 @@ package com.pocs.data.source
 import com.pocs.data.api.AuthApi
 import com.pocs.data.model.ResponseBody
 import com.pocs.data.model.auth.LoginRequestBody
+import com.pocs.data.model.auth.SessionValidResponseData
 import retrofit2.Response
 import javax.inject.Inject
 
@@ -14,5 +15,7 @@ class AuthRemoteDataSourceImpl @Inject constructor(
 
     override suspend fun logout(token: String) = api.logout(token)
 
-    override suspend fun isSessionValid(token: String) = api.isSessionValid(token)
+    override suspend fun isSessionValid(
+        token: String
+    ): Response<ResponseBody<SessionValidResponseData>> = api.isSessionValid(token)
 }

--- a/data/src/main/java/com/pocs/data/source/UserRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/pocs/data/source/UserRemoteDataSourceImpl.kt
@@ -21,7 +21,7 @@ class UserRemoteDataSourceImpl @Inject constructor(
         userId = id,
         userUpdateBody = UserUpdateBody(
             password = password,
-            userName = name,
+            name = name,
             email = email,
             github = github,
             company = company

--- a/data/src/test/java/com.pocs/data/AuthRepositoryTest.kt
+++ b/data/src/test/java/com.pocs/data/AuthRepositoryTest.kt
@@ -3,6 +3,7 @@ package com.pocs.data
 import com.pocs.data.mapper.toDetailEntity
 import com.pocs.data.model.auth.AuthLocalData
 import com.pocs.data.model.auth.LoginResponseData
+import com.pocs.data.model.auth.SessionValidResponseData
 import com.pocs.data.repository.AuthRepositoryImpl
 import com.pocs.test_library.fake.source.remote.FakeAuthRemoteDataSource
 import com.pocs.test_library.fake.source.local.FakeAuthLocalDataSource
@@ -58,7 +59,7 @@ class AuthRepositoryTest {
     fun currentUserExists_WhenUserAlreadyLoggedInBefore() {
         val userDto = mockUserDto
         localDataSource.authLocalData = AuthLocalData("abc")
-        remoteDataSource.isSessionValidResponse = successResponse(userDto)
+        remoteDataSource.isSessionValidResponse = successResponse(SessionValidResponseData(mockUserDto))
 
         initRepository()
 
@@ -123,7 +124,7 @@ class AuthRepositoryTest {
     @Test
     fun currentUserIsNull_WhenLoggedOut() = runTest {
         localDataSource.authLocalData = AuthLocalData("abc")
-        remoteDataSource.isSessionValidResponse = successResponse(mockUserDto)
+        remoteDataSource.isSessionValidResponse = successResponse(SessionValidResponseData(mockUserDto))
         remoteDataSource.logoutResponse = successResponse(Unit)
         initRepository()
 
@@ -137,7 +138,7 @@ class AuthRepositoryTest {
     @Test
     fun clearLocalAuthData_WhenLoggedOut() = runTest {
         localDataSource.authLocalData = AuthLocalData("abc")
-        remoteDataSource.isSessionValidResponse = successResponse(mockUserDto)
+        remoteDataSource.isSessionValidResponse = successResponse(SessionValidResponseData(mockUserDto))
         remoteDataSource.logoutResponse = successResponse(Unit)
         initRepository()
 

--- a/domain/src/main/java/com/pocs/domain/model/admin/UserCreateInfo.kt
+++ b/domain/src/main/java/com/pocs/domain/model/admin/UserCreateInfo.kt
@@ -3,7 +3,7 @@ package com.pocs.domain.model.admin
 import com.pocs.domain.model.user.UserType
 
 data class UserCreateInfo(
-    val nickname: String,
+    val userName: String,
     val password: String,
     val name: String,
     val studentId: Int,

--- a/presentation/src/main/java/com/pocs/presentation/constant/UserConstant.kt
+++ b/presentation/src/main/java/com/pocs/presentation/constant/UserConstant.kt
@@ -1,6 +1,6 @@
 package com.pocs.presentation.constant
 
-const val MAX_USER_NICKNAME_LEN = 15
+const val MAX_USER_ID_LEN = 15
 const val MAX_USER_NAME_LEN = 20
 const val MAX_USER_PASSWORD_LEN = 255
 const val MAX_USER_STUDENT_ID_LEN = 7

--- a/presentation/src/main/java/com/pocs/presentation/mapper/UserCreateInfoMapper.kt
+++ b/presentation/src/main/java/com/pocs/presentation/mapper/UserCreateInfoMapper.kt
@@ -4,7 +4,7 @@ import com.pocs.domain.model.admin.UserCreateInfo
 import com.pocs.presentation.model.admin.UserCreateInfoUiState
 
 fun UserCreateInfoUiState.toEntity() = UserCreateInfo(
-    nickname = nickname,
+    userName = userName,
     password = password,
     name = name,
     studentId = studentId.toInt(),

--- a/presentation/src/main/java/com/pocs/presentation/model/admin/AdminUserCreateUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/admin/AdminUserCreateUiState.kt
@@ -14,7 +14,7 @@ data class AdminUserCreateUiState(
 ) {
     val canSave
         get() : Boolean {
-            return createInfo.nickname.isNotEmpty()
+            return createInfo.userName.isNotEmpty()
                     && createInfo.password.isNotEmpty()
                     && createInfo.name.isNotEmpty()
                     && createInfo.studentId.isNotEmpty()

--- a/presentation/src/main/java/com/pocs/presentation/model/admin/UserCreateInfoUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/admin/UserCreateInfoUiState.kt
@@ -3,7 +3,7 @@ package com.pocs.presentation.model.admin
 import com.pocs.domain.model.user.UserType
 
 data class UserCreateInfoUiState(
-    val nickname: String = "",
+    val userName: String = "",
     val password: String = "",
     val name: String = "",
     val studentId: String = "",

--- a/presentation/src/main/java/com/pocs/presentation/view/admin/user/create/AdminUserCreateScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/admin/user/create/AdminUserCreateScreen.kt
@@ -67,15 +67,15 @@ fun AdminUserCreateScreen(
         ) {
             EditGroupLabel("필수")
             PocsOutlineTextField(
-                value = createInfo.nickname,
-                label = stringResource(R.string.nickname),
+                value = createInfo.userName,
+                label = stringResource(R.string.id),
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
-                maxLength = MAX_USER_NICKNAME_LEN,
-                onValueChange = { nickname ->
-                    uiState.updateCreateInfo { it.copy(nickname = nickname) }
+                maxLength = MAX_USER_ID_LEN,
+                onValueChange = { userName ->
+                    uiState.updateCreateInfo { it.copy(userName = userName) }
                 },
                 onClearClick = {
-                    uiState.updateCreateInfo { it.copy(nickname = "") }
+                    uiState.updateCreateInfo { it.copy(userName = "") }
                 }
             )
             PocsOutlineTextField(

--- a/presentation/src/main/java/com/pocs/presentation/view/login/LoginScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/login/LoginScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.pocs.presentation.R
-import com.pocs.presentation.constant.MAX_USER_NICKNAME_LEN
+import com.pocs.presentation.constant.MAX_USER_ID_LEN
 import com.pocs.presentation.model.auth.LoginUiState
 import com.pocs.presentation.view.component.button.PocsButton
 import com.pocs.presentation.view.component.textfield.PasswordOutlineTextField
@@ -78,7 +78,7 @@ fun LoginContent(
                 onClearClick = {
                     uiState.update { it.copy(userName = "") }
                 },
-                maxLength = MAX_USER_NICKNAME_LEN,
+                maxLength = MAX_USER_ID_LEN,
                 keyboardOptions = KeyboardOptions(
                     imeAction = ImeAction.Next
                 )

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -79,7 +79,6 @@
     <string name="empty_label">-</string>
     <string name="failed_to_save_post">글 저장 실패</string>
     <string name="sorting_by_created_at_descending">가입일 최근순</string>
-    <string name="nickname">닉네임</string>
     <string name="password">비밀번호</string>
     <string name="id">아이디</string>
     <string name="brows_as_non_member">비회원으로 둘러보기</string>

--- a/test-library/src/main/java/com/pocs/test_library/fake/source/remote/FakeAuthRemoteDataSource.kt
+++ b/test-library/src/main/java/com/pocs/test_library/fake/source/remote/FakeAuthRemoteDataSource.kt
@@ -3,38 +3,19 @@ package com.pocs.test_library.fake.source.remote
 import com.pocs.data.model.ResponseBody
 import com.pocs.data.model.auth.LoginRequestBody
 import com.pocs.data.model.auth.LoginResponseData
+import com.pocs.data.model.user.UserDto
 import com.pocs.data.source.AuthRemoteDataSource
+import com.pocs.test_library.mock.errorResponse
 import retrofit2.Response
 import javax.inject.Inject
 
 class FakeAuthRemoteDataSource @Inject constructor() : AuthRemoteDataSource {
 
-    var loginResponse: Response<ResponseBody<LoginResponseData>> = Response.success(
-        ResponseBody(
-            message = "",
-            status = 200,
-            serverTime = "",
-            data = LoginResponseData(sessionToken = "abc", userId = 1)
-        )
-    )
+    var loginResponse: Response<ResponseBody<LoginResponseData>> = errorResponse()
 
-    var logoutResponse: Response<ResponseBody<Unit>> = Response.success(
-        ResponseBody(
-            message = "",
-            status = 200,
-            serverTime = "",
-            data = Unit
-        )
-    )
+    var logoutResponse: Response<ResponseBody<Unit>> = errorResponse()
 
-    var isSessionValidResponse: Response<ResponseBody<Unit>> = Response.success(
-        ResponseBody(
-            message = "",
-            status = 200,
-            serverTime = "",
-            data = Unit
-        )
-    )
+    var isSessionValidResponse: Response<ResponseBody<UserDto>> = errorResponse()
 
     var isSessionValidInnerLambda: () -> Unit = {}
 
@@ -46,7 +27,7 @@ class FakeAuthRemoteDataSource @Inject constructor() : AuthRemoteDataSource {
         return logoutResponse
     }
 
-    override suspend fun isSessionValid(token: String): Response<ResponseBody<Unit>> {
+    override suspend fun isSessionValid(token: String): Response<ResponseBody<UserDto>> {
         isSessionValidInnerLambda()
         return isSessionValidResponse
     }

--- a/test-library/src/main/java/com/pocs/test_library/fake/source/remote/FakeAuthRemoteDataSource.kt
+++ b/test-library/src/main/java/com/pocs/test_library/fake/source/remote/FakeAuthRemoteDataSource.kt
@@ -3,6 +3,7 @@ package com.pocs.test_library.fake.source.remote
 import com.pocs.data.model.ResponseBody
 import com.pocs.data.model.auth.LoginRequestBody
 import com.pocs.data.model.auth.LoginResponseData
+import com.pocs.data.model.auth.SessionValidResponseData
 import com.pocs.data.model.user.UserDto
 import com.pocs.data.source.AuthRemoteDataSource
 import com.pocs.test_library.mock.errorResponse
@@ -15,7 +16,7 @@ class FakeAuthRemoteDataSource @Inject constructor() : AuthRemoteDataSource {
 
     var logoutResponse: Response<ResponseBody<Unit>> = errorResponse()
 
-    var isSessionValidResponse: Response<ResponseBody<UserDto>> = errorResponse()
+    var isSessionValidResponse: Response<ResponseBody<SessionValidResponseData>> = errorResponse()
 
     var isSessionValidInnerLambda: () -> Unit = {}
 
@@ -27,7 +28,7 @@ class FakeAuthRemoteDataSource @Inject constructor() : AuthRemoteDataSource {
         return logoutResponse
     }
 
-    override suspend fun isSessionValid(token: String): Response<ResponseBody<UserDto>> {
+    override suspend fun isSessionValid(token: String): Response<ResponseBody<SessionValidResponseData>> {
         isSessionValidInnerLambda()
         return isSessionValidResponse
     }

--- a/test-library/src/main/java/com/pocs/test_library/mock/User.kt
+++ b/test-library/src/main/java/com/pocs/test_library/mock/User.kt
@@ -1,5 +1,6 @@
 package com.pocs.test_library.mock
 
+import com.pocs.data.model.user.UserDto
 import com.pocs.domain.model.post.PostWriter
 import com.pocs.domain.model.user.User
 import com.pocs.domain.model.user.UserDetail
@@ -33,4 +34,17 @@ val mockKickedUserDetail = UserDetail(
     "https://github.com/",
     "2021-02-12",
     "2021-02-13",
+)
+
+val mockUserDto = UserDto(
+    2,
+    "권김정",
+    "abc@google.com",
+    1971034,
+    UserType.ADMIN.toString().lowercase(),
+    null,
+    30,
+    "https://github.com/aa",
+    "2021-02-12",
+    null,
 )


### PR DESCRIPTION
Resolves #162 

- 로그인 혹은 세션 검증 API 응답에 유저 정보를 주기로 벡엔드가 수정되어 로그인 혹은 세션 검증 후 중복되는 유저 정보 요청을 제거했습니다.
- userName을 ID로 사용하기로 결정하였기 때문에 이에 맞게 아래처럼 대응했습니다.
  - 유저 생성시 userName 입력 창은 "아이디" 라는 문구로 수정
  - 유저 정보 수정시 userName이 아닌 name을 수정하도록함
  - 유저 정보를 얻어올때 userName이 아닌 name을 얻도록 수정함

**아직 회원 정보를 수정하면 비밀번호가 바뀌는 버그는 존재합니다. 회원정보 수정하지 말아주세요**

## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [x] Action에서 진행하는 테스트를 모두 통과했는가?
- [ ] 수정 사항을 검증할 테스트를 추가하였는가?
- [ ] 리뷰를 받았는가?