### PR TITLE
댓글 UI 구현

### DIFF
--- a/domain/src/main/java/com/pocs/domain/model/comment/Comment.kt
+++ b/domain/src/main/java/com/pocs/domain/model/comment/Comment.kt
@@ -1,0 +1,13 @@
+package com.pocs.domain.model.comment
+
+data class Comment(
+    val id: Int,
+    val parentId: Int?,
+    val childrenCount: Int,
+    val postId: Int,
+    val writer: CommentWriter,
+    val content: String,
+    val createdAt: String,
+    val updatedAt: String? = null,
+    val canceledAt: String? = null
+)

--- a/domain/src/main/java/com/pocs/domain/model/comment/CommentWriter.kt
+++ b/domain/src/main/java/com/pocs/domain/model/comment/CommentWriter.kt
@@ -1,0 +1,6 @@
+package com.pocs.domain.model.comment
+
+data class CommentWriter(
+    val userId: Int,
+    val name: String
+)

--- a/domain/src/main/java/com/pocs/domain/usecase/comment/GetCommentsUseCase.kt
+++ b/domain/src/main/java/com/pocs/domain/usecase/comment/GetCommentsUseCase.kt
@@ -1,0 +1,34 @@
+package com.pocs.domain.usecase.comment
+
+import com.pocs.domain.model.comment.Comment
+import com.pocs.domain.model.comment.CommentWriter
+import kotlinx.coroutines.delay
+import javax.inject.Inject
+
+// TODO: 임시 목업 객체임. API 완성되면 data 모듈단에서 구현후 이곳에 연결해야함.
+class GetCommentsUseCase @Inject constructor() {
+
+    suspend operator fun invoke(postId: Int): Result<List<Comment>> {
+        delay(1000)
+        val mockComment = Comment(
+            id = 10,
+            parentId = null,
+            childrenCount = 0,
+            postId = postId,
+            writer = CommentWriter(
+                userId = 1,
+                name = "홍길동"
+            ),
+            content = "댓글 내용입니다.",
+            createdAt = "2022-09-02 13:09",
+            updatedAt = null
+        )
+        return Result.success(
+            listOf(
+                mockComment,
+                mockComment.copy(id = 11, childrenCount = 1),
+                mockComment.copy(id = 12, parentId = 11)
+            )
+        )
+    }
+}

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -70,6 +70,8 @@ dependencies {
     // compose
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.material3:material3:1.0.0-alpha15"
+    // TODO: ModalBottomSheet가 material3에 추가되면 아래 의존성 제거하기
+    implementation 'androidx.compose.material:material:1.2.0'
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
     debugImplementation "androidx.customview:customview:1.2.0-alpha01"
     debugImplementation "androidx.customview:customview-poolingcontainer:1.0.0"

--- a/presentation/src/androidTest/java/com/pocs/presentation/PostDetailActivityTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/PostDetailActivityTest.kt
@@ -1,6 +1,7 @@
 package com.pocs.presentation
 
 import android.content.Context
+import androidx.annotation.StringRes
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.core.app.launchActivity
@@ -52,6 +53,8 @@ class PostDetailActivityTest {
 
     private lateinit var context: Context
 
+    private fun getString(@StringRes resId: Int) = context.getString(resId)
+
     @Before
     fun setUp() {
         hiltRule.inject()
@@ -84,7 +87,7 @@ class PostDetailActivityTest {
         val intent = PostDetailActivity.getIntent(context, postDetail.id)
         launchActivity<PostDetailActivity>(intent)
 
-        openDropdownMenu()
+        clickMoreInfoButton()
 
         findDeleteText().assertIsDisplayed()
     }
@@ -100,7 +103,7 @@ class PostDetailActivityTest {
         val intent = PostDetailActivity.getIntent(context, postDetail.id)
         launchActivity<PostDetailActivity>(intent)
 
-        openDropdownMenu()
+        clickMoreInfoButton()
 
         findEditText().assertDoesNotExist()
     }
@@ -116,24 +119,24 @@ class PostDetailActivityTest {
         val intent = PostDetailActivity.getIntent(context, postDetail.id)
         launchActivity<PostDetailActivity>(intent)
 
-        openDropdownMenu()
+        clickMoreInfoButton()
 
         findEditText().assertIsDisplayed()
     }
 
-    private fun openDropdownMenu() {
-        composeRule.onNodeWithContentDescription("더보기 버튼").performClick()
+    private fun clickMoreInfoButton() {
+        findMoreInfoButton().performClick()
     }
 
     private fun findEditText(): SemanticsNodeInteraction {
-        return composeRule.onNodeWithText("편집")
+        return composeRule.onNodeWithTag(getString(R.string.edit))
     }
 
     private fun findDeleteText(): SemanticsNodeInteraction {
-        return composeRule.onNodeWithText("삭제")
+        return composeRule.onNodeWithTag(getString(R.string.delete))
     }
 
     private fun findMoreInfoButton(): SemanticsNodeInteraction {
-        return composeRule.onNodeWithContentDescription("더보기 버튼")
+        return composeRule.onNodeWithContentDescription(getString(R.string.more_info_button))
     }
 }

--- a/presentation/src/androidTest/java/com/pocs/presentation/PostDetailActivityTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/PostDetailActivityTest.kt
@@ -6,6 +6,8 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.core.app.launchActivity
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import com.pocs.domain.model.user.UserType
+import com.pocs.domain.usecase.auth.GetCurrentUserUseCase
+import com.pocs.domain.usecase.comment.GetCommentsUseCase
 import com.pocs.domain.usecase.post.CanDeletePostUseCase
 import com.pocs.domain.usecase.post.CanEditPostUseCase
 import com.pocs.domain.usecase.post.DeletePostUseCase
@@ -43,7 +45,9 @@ class PostDetailActivityTest {
         GetPostDetailUseCase(postRepository),
         DeletePostUseCase(postRepository = postRepository, authRepository = authRepository),
         CanEditPostUseCase(authRepository),
-        CanDeletePostUseCase(authRepository)
+        CanDeletePostUseCase(authRepository),
+        GetCommentsUseCase(),
+        GetCurrentUserUseCase(authRepository)
     )
 
     private lateinit var context: Context

--- a/presentation/src/androidTest/java/com/pocs/presentation/PostDetailActivityTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/PostDetailActivityTest.kt
@@ -55,46 +55,7 @@ class PostDetailActivityTest {
     }
 
     @Test
-    fun shouldShowDeletedKeyword_WhenPostWasDeleted() {
-        val postDetail = mockPostDetail1
-        postRepository.postDetailResult = Result.success(postDetail)
-
-        val intent = PostDetailActivity.getIntent(context, postDetail.id, isDeleted = true)
-        launchActivity<PostDetailActivity>(intent)
-
-        onView(withText(R.string.deleted)).check(matches(isDisplayed()))
-    }
-
-    @Test
-    fun shouldNotShowDeletedKeyword_WhenPostWasNotDeleted() {
-        val postDetail = mockPostDetail1
-        postRepository.postDetailResult = Result.success(postDetail)
-
-        val intent = PostDetailActivity.getIntent(context, postDetail.id, isDeleted = false)
-        launchActivity<PostDetailActivity>(intent)
-
-        onView(withText(R.string.deleted)).check(matches(not(isDisplayed())))
-    }
-
-    @Test
-    fun shouldNotShowMoreInfoOptionButton_WhenPostWasDeleted() {
-        val postDetail = mockPostDetail1
-        postRepository.postDetailResult = Result.success(postDetail)
-        authRepository.currentUser.value = mockNormalUserDetail.copy(
-            id = postDetail.writer.id,
-            type = UserType.ADMIN
-        )
-
-        val intent = PostDetailActivity.getIntent(context, postDetail.id, isDeleted = true)
-        launchActivity<PostDetailActivity>(intent)
-
-        onView(withContentDescription(R.string.more_info_button)).check { _, noViewFoundException ->
-            assertNotNull(noViewFoundException)
-        }
-    }
-
-    @Test
-    fun shouldNotShowMoreInfoOptionButton_WhenPostWasNotDeleted_AndUserIsNotAdminAndIsNotWriter() {
+    fun shouldNotShowMoreInfoOptionButton_WhenUserIsNotAdminAndIsNotWriter() {
         val postDetail = mockPostDetail1
         postRepository.postDetailResult = Result.success(postDetail)
         authRepository.currentUser.value = mockNormalUserDetail.copy(
@@ -102,7 +63,7 @@ class PostDetailActivityTest {
             type = UserType.MEMBER
         )
 
-        val intent = PostDetailActivity.getIntent(context, postDetail.id, isDeleted = false)
+        val intent = PostDetailActivity.getIntent(context, postDetail.id)
         launchActivity<PostDetailActivity>(intent)
 
         onView(withContentDescription(R.string.more_info_button)).check { _, noViewFoundException ->
@@ -111,7 +72,7 @@ class PostDetailActivityTest {
     }
 
     @Test
-    fun shouldShowDeleteOption_WhenPostWasNotDeleted_AndUserIsWriter() {
+    fun shouldShowDeleteOption_WhenUserIsWriter() {
         val postDetail = mockPostDetail1
         postRepository.postDetailResult = Result.success(postDetail)
         authRepository.currentUser.value = mockNormalUserDetail.copy(
@@ -119,7 +80,7 @@ class PostDetailActivityTest {
             type = UserType.MEMBER
         )
 
-        val intent = PostDetailActivity.getIntent(context, postDetail.id, isDeleted = false)
+        val intent = PostDetailActivity.getIntent(context, postDetail.id)
         launchActivity<PostDetailActivity>(intent).onActivity {
             it.openOptionsMenu()
         }
@@ -128,7 +89,7 @@ class PostDetailActivityTest {
     }
 
     @Test
-    fun shouldNotShowEditOption_WhenPostWasNotDeleted_AndUserIsNotWriter() {
+    fun shouldNotShowEditOption_WhenUserIsNotWriter() {
         val postDetail = mockPostDetail1
         postRepository.postDetailResult = Result.success(postDetail)
         authRepository.currentUser.value = mockNormalUserDetail.copy(
@@ -136,7 +97,7 @@ class PostDetailActivityTest {
             type = UserType.ADMIN
         )
 
-        val intent = PostDetailActivity.getIntent(context, postDetail.id, isDeleted = false)
+        val intent = PostDetailActivity.getIntent(context, postDetail.id)
         launchActivity<PostDetailActivity>(intent).onActivity {
             it.openOptionsMenu()
         }
@@ -147,7 +108,7 @@ class PostDetailActivityTest {
     }
 
     @Test
-    fun shouldShowEditOption_WhenPostWasNotDeleted_AndUserIsWriter() {
+    fun shouldShowEditOption_WhenUserIsWriter() {
         val postDetail = mockPostDetail1
         postRepository.postDetailResult = Result.success(postDetail)
         authRepository.currentUser.value = mockNormalUserDetail.copy(
@@ -155,7 +116,7 @@ class PostDetailActivityTest {
             type = UserType.MEMBER
         )
 
-        val intent = PostDetailActivity.getIntent(context, postDetail.id, isDeleted = false)
+        val intent = PostDetailActivity.getIntent(context, postDetail.id)
         launchActivity<PostDetailActivity>(intent).onActivity {
             it.openOptionsMenu()
         }

--- a/presentation/src/androidTest/java/com/pocs/presentation/PostDetailActivityTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/PostDetailActivityTest.kt
@@ -1,10 +1,9 @@
 package com.pocs.presentation
 
 import android.content.Context
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.core.app.launchActivity
-import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import com.pocs.domain.model.user.UserType
 import com.pocs.domain.usecase.post.CanDeletePostUseCase
@@ -20,8 +19,6 @@ import com.pocs.test_library.mock.mockPostDetail1
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
-import org.hamcrest.Matchers.not
-import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -31,6 +28,9 @@ class PostDetailActivityTest {
 
     @get:Rule(order = 0)
     val hiltRule = HiltAndroidRule(this)
+
+    @get:Rule(order = 1)
+    val composeRule = createComposeRule()
 
     @BindValue
     val postRepository = FakePostRepositoryImpl()
@@ -66,9 +66,7 @@ class PostDetailActivityTest {
         val intent = PostDetailActivity.getIntent(context, postDetail.id)
         launchActivity<PostDetailActivity>(intent)
 
-        onView(withContentDescription(R.string.more_info_button)).check { _, noViewFoundException ->
-            assertNotNull(noViewFoundException)
-        }
+        findMoreInfoButton().assertDoesNotExist()
     }
 
     @Test
@@ -79,13 +77,12 @@ class PostDetailActivityTest {
             id = postDetail.writer.id,
             type = UserType.MEMBER
         )
-
         val intent = PostDetailActivity.getIntent(context, postDetail.id)
-        launchActivity<PostDetailActivity>(intent).onActivity {
-            it.openOptionsMenu()
-        }
+        launchActivity<PostDetailActivity>(intent)
 
-        onView(withText(R.string.delete)).check(matches(isDisplayed()))
+        openDropdownMenu()
+
+        findDeleteText().assertIsDisplayed()
     }
 
     @Test
@@ -96,15 +93,12 @@ class PostDetailActivityTest {
             id = 96412433,
             type = UserType.ADMIN
         )
-
         val intent = PostDetailActivity.getIntent(context, postDetail.id)
-        launchActivity<PostDetailActivity>(intent).onActivity {
-            it.openOptionsMenu()
-        }
+        launchActivity<PostDetailActivity>(intent)
 
-        onView(withText(R.string.edit)).check { _, noViewFoundException ->
-            assertNotNull(noViewFoundException)
-        }
+        openDropdownMenu()
+
+        findEditText().assertDoesNotExist()
     }
 
     @Test
@@ -115,12 +109,27 @@ class PostDetailActivityTest {
             id = postDetail.writer.id,
             type = UserType.MEMBER
         )
-
         val intent = PostDetailActivity.getIntent(context, postDetail.id)
-        launchActivity<PostDetailActivity>(intent).onActivity {
-            it.openOptionsMenu()
-        }
+        launchActivity<PostDetailActivity>(intent)
 
-        onView(withText(R.string.edit)).check(matches(isDisplayed()))
+        openDropdownMenu()
+
+        findEditText().assertIsDisplayed()
+    }
+
+    private fun openDropdownMenu() {
+        composeRule.onNodeWithContentDescription("더보기 버튼").performClick()
+    }
+
+    private fun findEditText(): SemanticsNodeInteraction {
+        return composeRule.onNodeWithText("편집")
+    }
+
+    private fun findDeleteText(): SemanticsNodeInteraction {
+        return composeRule.onNodeWithText("삭제")
+    }
+
+    private fun findMoreInfoButton(): SemanticsNodeInteraction {
+        return composeRule.onNodeWithContentDescription("더보기 버튼")
     }
 }

--- a/presentation/src/androidTest/java/com/pocs/presentation/PostDetailScreenTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/PostDetailScreenTest.kt
@@ -11,8 +11,6 @@ import com.pocs.presentation.mapper.toUiState
 import com.pocs.presentation.model.comment.CommentsUiState
 import com.pocs.presentation.model.post.PostDetailUiState
 import com.pocs.presentation.view.component.bottomsheet.CommentModalController
-import com.pocs.presentation.view.component.bottomsheet.commentTextFieldDescription
-import com.pocs.presentation.view.component.commentAddButtonDescription
 import com.pocs.presentation.view.post.detail.PostDetailContent
 import com.pocs.test_library.mock.mockCommentItemUiState
 import com.pocs.test_library.mock.mockPostDetail1
@@ -139,9 +137,9 @@ class PostDetailScreenTest {
                 )
             }
 
-            onNodeWithContentDescription(commentAddButtonDescription).performClick()
+            onNodeWithContentDescription(getString(R.string.comment_add_button)).performClick()
 
-            onNodeWithContentDescription(commentTextFieldDescription).assertIsDisplayed()
+            onNodeWithContentDescription(getString(R.string.comment_text_field)).assertIsDisplayed()
         }
     }
 
@@ -168,7 +166,7 @@ class PostDetailScreenTest {
             assertNull(commentModalController.parentId)
             assertNull(commentModalController.commentToBeUpdated)
 
-            onNodeWithContentDescription(commentAddButtonDescription).performClick()
+            onNodeWithContentDescription(getString(R.string.comment_add_button)).performClick()
             mainClock.advanceTimeByFrame()
 
             assertNull(commentModalController.parentId)
@@ -241,7 +239,6 @@ class PostDetailScreenTest {
 
 //    아래의 테스트는 https://issuetracker.google.com/issues/229378536 문제로 인해 잠시 보류한다.
 //    발생하는 문제는 텍스트 셀렉션이 out of bounds 하는 것이다.
-//
 //    @Test
 //    fun commentTextFieldHasText_WhenClickEditComment() {
 //        composeRule.run {
@@ -270,7 +267,7 @@ class PostDetailScreenTest {
 //            onNodeWithContentDescription("댓글 정보 버튼").performClick()
 //            onNodeWithText("편집").performClick()
 //
-//            onNode(hasContentDescription(commentTextFieldDescription) and hasText(comment.content))
+//            onNode(hasContentDescription(getString(R.string.comment_text_field)) and hasText(comment.content))
 //                .assertIsDisplayed()
 //        }
 //    }
@@ -292,9 +289,9 @@ class PostDetailScreenTest {
                 )
             }
 
-            onNodeWithContentDescription(commentAddButtonDescription).performClick()
-            onNodeWithContentDescription(commentTextFieldDescription).performTextInput("hi")
-            onNodeWithContentDescription(commentAddButtonDescription).performClick()
+            onNodeWithContentDescription(getString(R.string.comment_add_button)).performClick()
+            onNodeWithContentDescription(getString(R.string.comment_text_field)).performTextInput("hi")
+            onNodeWithContentDescription(getString(R.string.comment_add_button)).performClick()
 
             onNodeWithText(getString(R.string.stop)).assertIsDisplayed()
         }
@@ -317,12 +314,12 @@ class PostDetailScreenTest {
                 )
             }
 
-            onNodeWithContentDescription(commentAddButtonDescription).performClick()
-            onNodeWithContentDescription(commentTextFieldDescription).performTextInput("hi")
-            onNodeWithContentDescription(commentAddButtonDescription).performClick()
+            onNodeWithContentDescription(getString(R.string.comment_add_button)).performClick()
+            onNodeWithContentDescription(getString(R.string.comment_text_field)).performTextInput("hi")
+            onNodeWithContentDescription(getString(R.string.comment_add_button)).performClick()
             onNodeWithText(getString(R.string.stop)).performClick()
 
-            onNodeWithContentDescription(commentTextFieldDescription).assertIsNotDisplayed()
+            onNodeWithContentDescription(getString(R.string.comment_text_field)).assertIsNotDisplayed()
         }
     }
 
@@ -346,9 +343,9 @@ class PostDetailScreenTest {
                 )
             }
 
-            onNodeWithContentDescription(commentAddButtonDescription).performClick()
-            onNodeWithContentDescription(commentTextFieldDescription).performTextInput("hi")
-            onNodeWithContentDescription(commentAddButtonDescription).performClick()
+            onNodeWithContentDescription(getString(R.string.comment_add_button)).performClick()
+            onNodeWithContentDescription(getString(R.string.comment_text_field)).performTextInput("hi")
+            onNodeWithContentDescription(getString(R.string.comment_add_button)).performClick()
             onNodeWithText(getString(R.string.stop)).performClick()
 
             assertTrue(controller.isCleared)
@@ -376,15 +373,69 @@ class PostDetailScreenTest {
             }
 
             val text = "hello"
-            onNodeWithContentDescription(commentAddButtonDescription).performClick()
-            onNodeWithContentDescription(commentTextFieldDescription).performTextInput(text)
-            onNodeWithContentDescription(commentAddButtonDescription).performClick()
+            onNodeWithContentDescription(getString(R.string.comment_add_button)).performClick()
+            onNodeWithContentDescription(getString(R.string.comment_text_field)).performTextInput(text)
+            onNodeWithContentDescription(getString(R.string.comment_add_button)).performClick()
 
             onNodeWithText(text).assertIsNotDisplayed()
 
             onNodeWithText(getString(R.string.keep_writing)).performClick()
 
             onNodeWithText(text).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun shouldShowRecheckDialog_WhenCllickDeleteCommentButton() {
+        composeRule.run {
+            setContent {
+                val snackbarHostState = remember { SnackbarHostState() }
+
+                PostDetailContent(
+                    uiState = uiState,
+                    snackbarHostState = snackbarHostState,
+                    onEditClick = {},
+                    onDeleteClick = {},
+                    onCommentDelete = {},
+                    onCommentCreated = { _, _ -> },
+                    onCommentUpdated = { _, _ -> }
+                )
+            }
+
+            onNodeWithContentDescription(getString(R.string.comment_info_button)).performClick()
+            onNodeWithText(getString(R.string.delete)).performClick()
+
+            onNodeWithText(getString(R.string.are_you_sure_you_want_to_delete)).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun shouldHideCommentBottomSheet_WhenClickSendButton() {
+        composeRule.run {
+            val controller = CommentModalController()
+
+            setContent {
+                val snackbarHostState = remember { SnackbarHostState() }
+
+                PostDetailContent(
+                    commentModalController = controller,
+                    uiState = uiState,
+                    snackbarHostState = snackbarHostState,
+                    onEditClick = {},
+                    onDeleteClick = {},
+                    onCommentDelete = {},
+                    onCommentCreated = { _, _ -> },
+                    onCommentUpdated = { _, _ -> }
+                )
+            }
+
+            val text = "hello"
+            onNodeWithContentDescription(getString(R.string.comment_add_button)).performClick()
+            onNodeWithContentDescription(getString(R.string.comment_text_field)).performTextInput(text)
+            onNodeWithContentDescription(getString(R.string.send_comment)).performClick()
+
+            onNodeWithText(text).assertDoesNotExist()
+            assertTrue(controller.isCleared)
         }
     }
 }

--- a/presentation/src/androidTest/java/com/pocs/presentation/PostDetailScreenTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/PostDetailScreenTest.kt
@@ -1,0 +1,132 @@
+package com.pocs.presentation
+
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.remember
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.pocs.presentation.mapper.toUiState
+import com.pocs.presentation.model.comment.CommentsUiState
+import com.pocs.presentation.model.post.PostDetailUiState
+import com.pocs.presentation.view.component.bottomsheet.commentTextFieldDescription
+import com.pocs.presentation.view.component.commentAddButtonDescription
+import com.pocs.presentation.view.post.detail.PostDetailContent
+import com.pocs.test_library.mock.mockCommentItemUiState
+import com.pocs.test_library.mock.mockPostDetail1
+import org.junit.Rule
+import org.junit.Test
+
+class PostDetailScreenTest {
+
+    @get:Rule(order = 0)
+    val composeRule = createComposeRule()
+
+    private val commentItem = mockCommentItemUiState
+
+    private val commentsUiState = CommentsUiState.Success(listOf(commentItem))
+
+    private val uiState = PostDetailUiState.Success(
+        postDetail = mockPostDetail1.toUiState(),
+        canEditPost = true,
+        canDeletePost = true,
+        comments = commentsUiState
+    )
+
+    @Test
+    fun shouldShowReplyCommentBottomSheet_WhenClickComment() {
+        composeRule.run {
+            setContent {
+                val snackbarHostState = remember { SnackbarHostState() }
+
+                PostDetailContent(
+                    uiState = uiState,
+                    snackbarHostState = snackbarHostState,
+                    onEditClick = {},
+                    onDeleteClick = {},
+                    onCommentDelete = {},
+                    onCommentCreated = { _, _ -> },
+                    onCommentUpdated = { _, _ -> }
+                )
+            }
+
+            onNodeWithText(commentItem.content).performClick()
+
+            onNodeWithText("답글 추가…").assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun shouldShowReplyCommentBottomSheet_WhenClickReplyIcon() {
+        composeRule.run {
+            setContent {
+                val snackbarHostState = remember { SnackbarHostState() }
+
+                PostDetailContent(
+                    uiState = uiState,
+                    snackbarHostState = snackbarHostState,
+                    onEditClick = {},
+                    onDeleteClick = {},
+                    onCommentDelete = {},
+                    onCommentCreated = { _, _ -> },
+                    onCommentUpdated = { _, _ -> }
+                )
+            }
+
+            onNodeWithContentDescription("대댓글 갯수").performClick()
+
+            onNodeWithText("답글 추가…").assertIsDisplayed()
+        }
+    }
+
+
+    @Test
+    fun shouldShowReplyCommentBottomSheet_WhenClickReplyComment() {
+        composeRule.run {
+            val comment = commentItem.copy(parentId = 2)
+
+            setContent {
+                val snackbarHostState = remember { SnackbarHostState() }
+
+                PostDetailContent(
+                    uiState = uiState.copy(
+                        comments = commentsUiState.copy(
+                            comments = listOf(comment)
+                        )
+                    ),
+                    snackbarHostState = snackbarHostState,
+                    onEditClick = {},
+                    onDeleteClick = {},
+                    onCommentDelete = {},
+                    onCommentCreated = { _, _ -> },
+                    onCommentUpdated = { _, _ -> }
+                )
+            }
+
+            onNodeWithText(comment.content).performClick()
+
+            onNodeWithText("답글 추가…").assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun shouldShowCommentBottomSheet_WhenClickAddCommentButton() {
+        composeRule.run {
+            setContent {
+                val snackbarHostState = remember { SnackbarHostState() }
+
+                PostDetailContent(
+                    uiState = uiState,
+                    snackbarHostState = snackbarHostState,
+                    onEditClick = {},
+                    onDeleteClick = {},
+                    onCommentDelete = {},
+                    onCommentCreated = { _, _ -> },
+                    onCommentUpdated = { _, _ -> }
+                )
+            }
+
+            onNodeWithContentDescription(commentAddButtonDescription).performClick()
+
+            onNodeWithContentDescription(commentTextFieldDescription).assertIsDisplayed()
+        }
+    }
+}

--- a/presentation/src/androidTest/java/com/pocs/presentation/PostDetailScreenTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/PostDetailScreenTest.kt
@@ -7,11 +7,13 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import com.pocs.presentation.mapper.toUiState
 import com.pocs.presentation.model.comment.CommentsUiState
 import com.pocs.presentation.model.post.PostDetailUiState
+import com.pocs.presentation.view.component.bottomsheet.CommentModalController
 import com.pocs.presentation.view.component.bottomsheet.commentTextFieldDescription
 import com.pocs.presentation.view.component.commentAddButtonDescription
 import com.pocs.presentation.view.post.detail.PostDetailContent
 import com.pocs.test_library.mock.mockCommentItemUiState
 import com.pocs.test_library.mock.mockPostDetail1
+import org.junit.Assert.*
 import org.junit.Rule
 import org.junit.Test
 
@@ -127,6 +129,249 @@ class PostDetailScreenTest {
             onNodeWithContentDescription(commentAddButtonDescription).performClick()
 
             onNodeWithContentDescription(commentTextFieldDescription).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun shouldControllerValuesAreNull_WhenClickAddCommentButton() {
+        composeRule.run {
+            val commentModalController = CommentModalController()
+
+            setContent {
+                val snackbarHostState = remember { SnackbarHostState() }
+
+                PostDetailContent(
+                    uiState = uiState,
+                    snackbarHostState = snackbarHostState,
+                    commentModalController = commentModalController,
+                    onEditClick = {},
+                    onDeleteClick = {},
+                    onCommentDelete = {},
+                    onCommentCreated = { _, _ -> },
+                    onCommentUpdated = { _, _ -> }
+                )
+            }
+
+            assertNull(commentModalController.parentId)
+            assertNull(commentModalController.commentToBeUpdated)
+
+            onNodeWithContentDescription(commentAddButtonDescription).performClick()
+            mainClock.advanceTimeByFrame()
+
+            assertNull(commentModalController.parentId)
+            assertNull(commentModalController.commentToBeUpdated)
+        }
+    }
+
+    @Test
+    fun shouldExistControllerParentId_WhenClickComment() {
+        composeRule.run {
+            val commentModalController = CommentModalController()
+            val comment = commentItem.copy(parentId = null)
+
+            setContent {
+                val snackbarHostState = remember { SnackbarHostState() }
+
+                PostDetailContent(
+                    commentModalController = commentModalController,
+                    uiState = uiState.copy(
+                        comments = commentsUiState.copy(comments = listOf(comment))
+                    ),
+                    snackbarHostState = snackbarHostState,
+                    onEditClick = {},
+                    onDeleteClick = {},
+                    onCommentDelete = {},
+                    onCommentCreated = { _, _ -> },
+                    onCommentUpdated = { _, _ -> }
+                )
+            }
+
+            assertNull(commentModalController.parentId)
+
+            onNodeWithText(comment.content).performClick()
+
+            assertEquals(comment.id, commentModalController.parentId)
+        }
+    }
+
+    @Test
+    fun replyParentIdIsSameWithControllerParentId_WhenClickReplyComment() {
+        composeRule.run {
+            val commentModalController = CommentModalController()
+            val parentId = 23
+            val replyComment = commentItem.copy(parentId = parentId)
+
+            setContent {
+                val snackbarHostState = remember { SnackbarHostState() }
+
+                PostDetailContent(
+                    commentModalController = commentModalController,
+                    uiState = uiState.copy(
+                        comments = commentsUiState.copy(comments = listOf(replyComment))
+                    ),
+                    snackbarHostState = snackbarHostState,
+                    onEditClick = {},
+                    onDeleteClick = {},
+                    onCommentDelete = {},
+                    onCommentCreated = { _, _ -> },
+                    onCommentUpdated = { _, _ -> }
+                )
+            }
+
+            assertNull(commentModalController.parentId)
+
+            onNodeWithText(replyComment.content).performClick()
+
+            assertEquals(replyComment.parentId, commentModalController.parentId)
+        }
+    }
+
+//    아래의 테스트는 https://issuetracker.google.com/issues/229378536 문제로 인해 잠시 보류한다.
+//    발생하는 문제는 텍스트 셀렉션이 out of bounds 하는 것이다.
+//
+//    @Test
+//    fun commentTextFieldHasText_WhenClickEditComment() {
+//        composeRule.run {
+//            val commentModalController = CommentModalController()
+//            val comment = commentItem.copy(parentId = null, canEdit = true, content = "abc")
+//
+//            setContent {
+//                val snackbarHostState = remember { SnackbarHostState() }
+//
+//                PostDetailContent(
+//                    commentModalController = commentModalController,
+//                    uiState = uiState.copy(
+//                        comments = commentsUiState.copy(comments = listOf(comment))
+//                    ),
+//                    snackbarHostState = snackbarHostState,
+//                    onEditClick = {},
+//                    onDeleteClick = {},
+//                    onCommentDelete = {},
+//                    onCommentCreated = { _, _ -> },
+//                    onCommentUpdated = { _, _ -> }
+//                )
+//            }
+//
+//            assertNull(commentModalController.commentToBeUpdated)
+//
+//            onNodeWithContentDescription("댓글 정보 버튼").performClick()
+//            onNodeWithText("편집").performClick()
+//
+//            onNode(hasContentDescription(commentTextFieldDescription) and hasText(comment.content))
+//                .assertIsDisplayed()
+//        }
+//    }
+
+    @Test
+    fun shouldShowRecheckDialog_WhenClickOutOfCommentBottomSheet() {
+        composeRule.run {
+            setContent {
+                val snackbarHostState = remember { SnackbarHostState() }
+
+                PostDetailContent(
+                    uiState = uiState,
+                    snackbarHostState = snackbarHostState,
+                    onEditClick = {},
+                    onDeleteClick = {},
+                    onCommentDelete = {},
+                    onCommentCreated = { _, _ -> },
+                    onCommentUpdated = { _, _ -> }
+                )
+            }
+
+            onNodeWithContentDescription(commentAddButtonDescription).performClick()
+            onNodeWithContentDescription(commentTextFieldDescription).performTextInput("hi")
+            onNodeWithContentDescription(commentAddButtonDescription).performClick()
+
+            onNodeWithText("그만두기").assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun shouldHideCommentBottomSheet_WhenClickStopButtonOfRecheckDialog() {
+        composeRule.run {
+            setContent {
+                val snackbarHostState = remember { SnackbarHostState() }
+
+                PostDetailContent(
+                    uiState = uiState,
+                    snackbarHostState = snackbarHostState,
+                    onEditClick = {},
+                    onDeleteClick = {},
+                    onCommentDelete = {},
+                    onCommentCreated = { _, _ -> },
+                    onCommentUpdated = { _, _ -> }
+                )
+            }
+
+            onNodeWithContentDescription(commentAddButtonDescription).performClick()
+            onNodeWithContentDescription(commentTextFieldDescription).performTextInput("hi")
+            onNodeWithContentDescription(commentAddButtonDescription).performClick()
+            onNodeWithText("그만두기").performClick()
+
+            onNodeWithContentDescription(commentTextFieldDescription).assertIsNotDisplayed()
+        }
+    }
+
+    @Test
+    fun shouldClearController_WhenStoppingAddComment() {
+        composeRule.run {
+            val controller = CommentModalController()
+
+            setContent {
+                val snackbarHostState = remember { SnackbarHostState() }
+
+                PostDetailContent(
+                    commentModalController = controller,
+                    uiState = uiState,
+                    snackbarHostState = snackbarHostState,
+                    onEditClick = {},
+                    onDeleteClick = {},
+                    onCommentDelete = {},
+                    onCommentCreated = { _, _ -> },
+                    onCommentUpdated = { _, _ -> }
+                )
+            }
+
+            onNodeWithContentDescription(commentAddButtonDescription).performClick()
+            onNodeWithContentDescription(commentTextFieldDescription).performTextInput("hi")
+            onNodeWithContentDescription(commentAddButtonDescription).performClick()
+            onNodeWithText("그만두기").performClick()
+
+            assertTrue(controller.isCleared)
+        }
+    }
+
+    @Test
+    fun shouldShowBottomSheet_WhenClickContinueButtonOfRecheckDialog() {
+        composeRule.run {
+            val controller = CommentModalController()
+
+            setContent {
+                val snackbarHostState = remember { SnackbarHostState() }
+
+                PostDetailContent(
+                    commentModalController = controller,
+                    uiState = uiState,
+                    snackbarHostState = snackbarHostState,
+                    onEditClick = {},
+                    onDeleteClick = {},
+                    onCommentDelete = {},
+                    onCommentCreated = { _, _ -> },
+                    onCommentUpdated = { _, _ -> }
+                )
+            }
+
+            val text = "hello"
+            onNodeWithContentDescription(commentAddButtonDescription).performClick()
+            onNodeWithContentDescription(commentTextFieldDescription).performTextInput(text)
+            onNodeWithContentDescription(commentAddButtonDescription).performClick()
+
+            onNodeWithText(text).assertIsNotDisplayed()
+
+            onNodeWithText("계속작성").performClick()
+
+            onNodeWithText(text).assertIsDisplayed()
         }
     }
 }

--- a/presentation/src/androidTest/java/com/pocs/presentation/PostDetailScreenTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/PostDetailScreenTest.kt
@@ -1,9 +1,12 @@
 package com.pocs.presentation
 
+import android.content.Context
+import androidx.annotation.StringRes
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.platform.app.InstrumentationRegistry
 import com.pocs.presentation.mapper.toUiState
 import com.pocs.presentation.model.comment.CommentsUiState
 import com.pocs.presentation.model.post.PostDetailUiState
@@ -14,6 +17,7 @@ import com.pocs.presentation.view.post.detail.PostDetailContent
 import com.pocs.test_library.mock.mockCommentItemUiState
 import com.pocs.test_library.mock.mockPostDetail1
 import org.junit.Assert.*
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
@@ -32,6 +36,15 @@ class PostDetailScreenTest {
         canDeletePost = true,
         comments = commentsUiState
     )
+
+    private lateinit var context: Context
+
+    private fun getString(@StringRes resId: Int) = context.getString(resId)
+
+    @Before
+    fun setUp() {
+        context = InstrumentationRegistry.getInstrumentation().targetContext
+    }
 
     @Test
     fun shouldShowReplyCommentBottomSheet_WhenClickComment() {
@@ -52,7 +65,7 @@ class PostDetailScreenTest {
 
             onNodeWithText(commentItem.content).performClick()
 
-            onNodeWithText("답글 추가…").assertIsDisplayed()
+            onNodeWithText(getString(R.string.add_reply)).assertIsDisplayed()
         }
     }
 
@@ -73,9 +86,9 @@ class PostDetailScreenTest {
                 )
             }
 
-            onNodeWithContentDescription("대댓글 갯수").performClick()
+            onNodeWithContentDescription(getString(R.string.reply_count)).performClick()
 
-            onNodeWithText("답글 추가…").assertIsDisplayed()
+            onNodeWithText(getString(R.string.add_reply)).assertIsDisplayed()
         }
     }
 
@@ -105,7 +118,7 @@ class PostDetailScreenTest {
 
             onNodeWithText(comment.content).performClick()
 
-            onNodeWithText("답글 추가…").assertIsDisplayed()
+            onNodeWithText(getString(R.string.add_reply)).assertIsDisplayed()
         }
     }
 
@@ -283,7 +296,7 @@ class PostDetailScreenTest {
             onNodeWithContentDescription(commentTextFieldDescription).performTextInput("hi")
             onNodeWithContentDescription(commentAddButtonDescription).performClick()
 
-            onNodeWithText("그만두기").assertIsDisplayed()
+            onNodeWithText(getString(R.string.stop)).assertIsDisplayed()
         }
     }
 
@@ -307,7 +320,7 @@ class PostDetailScreenTest {
             onNodeWithContentDescription(commentAddButtonDescription).performClick()
             onNodeWithContentDescription(commentTextFieldDescription).performTextInput("hi")
             onNodeWithContentDescription(commentAddButtonDescription).performClick()
-            onNodeWithText("그만두기").performClick()
+            onNodeWithText(getString(R.string.stop)).performClick()
 
             onNodeWithContentDescription(commentTextFieldDescription).assertIsNotDisplayed()
         }
@@ -336,7 +349,7 @@ class PostDetailScreenTest {
             onNodeWithContentDescription(commentAddButtonDescription).performClick()
             onNodeWithContentDescription(commentTextFieldDescription).performTextInput("hi")
             onNodeWithContentDescription(commentAddButtonDescription).performClick()
-            onNodeWithText("그만두기").performClick()
+            onNodeWithText(getString(R.string.stop)).performClick()
 
             assertTrue(controller.isCleared)
         }
@@ -369,7 +382,7 @@ class PostDetailScreenTest {
 
             onNodeWithText(text).assertIsNotDisplayed()
 
-            onNodeWithText("계속작성").performClick()
+            onNodeWithText(getString(R.string.keep_writing)).performClick()
 
             onNodeWithText(text).assertIsDisplayed()
         }

--- a/presentation/src/androidTest/java/com/pocs/presentation/comment/CommentTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/comment/CommentTest.kt
@@ -1,0 +1,114 @@
+package com.pocs.presentation.comment
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import com.pocs.presentation.view.component.Comment
+import com.pocs.test_library.mock.mockComment
+import org.junit.Rule
+import org.junit.Test
+
+class CommentTest {
+
+    @get:Rule(order = 0)
+    val composeRule = createComposeRule()
+
+    @Test
+    fun shouldShowReplyIcon_WhenItIsComment() {
+        composeRule.run {
+            setContent {
+                Comment(
+                    uiState = mockComment.copy(parentId = null),
+                    onClick = {}, onMoreButtonClick = {}, onReplyIconClick = {}
+                )
+            }
+
+            onNodeWithContentDescription("대댓글 갯수").assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun shouldNotShowReplyIcon_WhenItIsReply() {
+        composeRule.run {
+            setContent {
+                Comment(
+                    uiState = mockComment.copy(parentId = 2),
+                    onClick = {}, onMoreButtonClick = {}, onReplyIconClick = {}
+                )
+            }
+
+            onNodeWithContentDescription("대댓글 갯수").assertDoesNotExist()
+        }
+    }
+
+    @Test
+    fun shouldShowReplyCount_WhenItHasRepliesOverOne() {
+        composeRule.run {
+            setContent {
+                Comment(
+                    uiState = mockComment.copy(parentId = null, childrenCount = 1),
+                    onClick = {}, onMoreButtonClick = {}, onReplyIconClick = {}
+                )
+            }
+
+            onNodeWithText("1").assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun shouldNotShowReplyCount_WhenItDoesNotHaveReply() {
+        composeRule.run {
+            setContent {
+                Comment(
+                    uiState = mockComment.copy(parentId = null, childrenCount = 0),
+                    onClick = {}, onMoreButtonClick = {}, onReplyIconClick = {}
+                )
+            }
+
+            onNodeWithText("0").assertDoesNotExist()
+        }
+    }
+
+    @Test
+    fun shouldShowMoreInfoButton_WhenCanEdit() {
+        composeRule.run {
+            setContent {
+                Comment(
+                    uiState = mockComment.copy(canEdit = true, canDelete = false),
+                    onClick = {}, onMoreButtonClick = {}, onReplyIconClick = {}
+                )
+            }
+
+            onNodeWithContentDescription("더보기 버튼").assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun shouldShowMoreInfoButton_WhenCanDelete() {
+        composeRule.run {
+            setContent {
+                Comment(
+                    uiState = mockComment.copy(canEdit = false, canDelete = true),
+                    onClick = {}, onMoreButtonClick = {}, onReplyIconClick = {}
+                )
+            }
+
+            onNodeWithContentDescription("더보기 버튼").assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun shouldNotShowMoreInfoButton_WhenCanNotEditAndDelete() {
+        composeRule.run {
+            setContent {
+                Comment(
+                    uiState = mockComment.copy(canEdit = false, canDelete = false),
+                    onClick = {}, onMoreButtonClick = {}, onReplyIconClick = {}
+                )
+            }
+
+            onNodeWithContentDescription("더보기 버튼").assertDoesNotExist()
+        }
+    }
+}

--- a/presentation/src/androidTest/java/com/pocs/presentation/comment/CommentTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/comment/CommentTest.kt
@@ -1,11 +1,17 @@
 package com.pocs.presentation.comment
 
+import com.pocs.presentation.R
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
+import androidx.test.platform.app.InstrumentationRegistry
 import com.pocs.presentation.view.component.Comment
 import com.pocs.test_library.mock.mockCommentItemUiState
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
@@ -13,6 +19,15 @@ class CommentTest {
 
     @get:Rule(order = 0)
     val composeRule = createComposeRule()
+
+    private lateinit var context: Context
+
+    private fun getString(@StringRes resId: Int) = context.getString(resId)
+
+    @Before
+    fun setUp() {
+        context = InstrumentationRegistry.getInstrumentation().targetContext
+    }
 
     @Test
     fun shouldShowReplyIcon_WhenItIsComment() {
@@ -24,7 +39,7 @@ class CommentTest {
                 )
             }
 
-            onNodeWithContentDescription("대댓글 갯수").assertIsDisplayed()
+            findReplyLabelButton().assertIsDisplayed()
         }
     }
 
@@ -38,7 +53,7 @@ class CommentTest {
                 )
             }
 
-            onNodeWithContentDescription("대댓글 갯수").assertDoesNotExist()
+            findReplyLabelButton().assertDoesNotExist()
         }
     }
 
@@ -80,7 +95,7 @@ class CommentTest {
                 )
             }
 
-            onNodeWithContentDescription("더보기 버튼").assertIsDisplayed()
+            findCommentInfoButton().assertIsDisplayed()
         }
     }
 
@@ -94,7 +109,7 @@ class CommentTest {
                 )
             }
 
-            onNodeWithContentDescription("더보기 버튼").assertIsDisplayed()
+            findCommentInfoButton().assertIsDisplayed()
         }
     }
 
@@ -108,7 +123,15 @@ class CommentTest {
                 )
             }
 
-            onNodeWithContentDescription("더보기 버튼").assertDoesNotExist()
+            findCommentInfoButton().assertDoesNotExist()
         }
+    }
+
+    private fun findReplyLabelButton(): SemanticsNodeInteraction {
+        return composeRule.onNodeWithContentDescription(getString(R.string.reply_count))
+    }
+
+    private fun findCommentInfoButton(): SemanticsNodeInteraction {
+        return composeRule.onNodeWithContentDescription(getString(R.string.comment_info_button))
     }
 }

--- a/presentation/src/androidTest/java/com/pocs/presentation/comment/CommentTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/comment/CommentTest.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import com.pocs.presentation.view.component.Comment
-import com.pocs.test_library.mock.mockComment
+import com.pocs.test_library.mock.mockCommentItemUiState
 import org.junit.Rule
 import org.junit.Test
 
@@ -19,7 +19,7 @@ class CommentTest {
         composeRule.run {
             setContent {
                 Comment(
-                    uiState = mockComment.copy(parentId = null),
+                    uiState = mockCommentItemUiState.copy(parentId = null),
                     onClick = {}, onMoreButtonClick = {}, onReplyIconClick = {}
                 )
             }
@@ -33,7 +33,7 @@ class CommentTest {
         composeRule.run {
             setContent {
                 Comment(
-                    uiState = mockComment.copy(parentId = 2),
+                    uiState = mockCommentItemUiState.copy(parentId = 2),
                     onClick = {}, onMoreButtonClick = {}, onReplyIconClick = {}
                 )
             }
@@ -47,7 +47,7 @@ class CommentTest {
         composeRule.run {
             setContent {
                 Comment(
-                    uiState = mockComment.copy(parentId = null, childrenCount = 1),
+                    uiState = mockCommentItemUiState.copy(parentId = null, childrenCount = 1),
                     onClick = {}, onMoreButtonClick = {}, onReplyIconClick = {}
                 )
             }
@@ -61,7 +61,7 @@ class CommentTest {
         composeRule.run {
             setContent {
                 Comment(
-                    uiState = mockComment.copy(parentId = null, childrenCount = 0),
+                    uiState = mockCommentItemUiState.copy(parentId = null, childrenCount = 0),
                     onClick = {}, onMoreButtonClick = {}, onReplyIconClick = {}
                 )
             }
@@ -75,7 +75,7 @@ class CommentTest {
         composeRule.run {
             setContent {
                 Comment(
-                    uiState = mockComment.copy(canEdit = true, canDelete = false),
+                    uiState = mockCommentItemUiState.copy(canEdit = true, canDelete = false),
                     onClick = {}, onMoreButtonClick = {}, onReplyIconClick = {}
                 )
             }
@@ -89,7 +89,7 @@ class CommentTest {
         composeRule.run {
             setContent {
                 Comment(
-                    uiState = mockComment.copy(canEdit = false, canDelete = true),
+                    uiState = mockCommentItemUiState.copy(canEdit = false, canDelete = true),
                     onClick = {}, onMoreButtonClick = {}, onReplyIconClick = {}
                 )
             }
@@ -103,7 +103,7 @@ class CommentTest {
         composeRule.run {
             setContent {
                 Comment(
-                    uiState = mockComment.copy(canEdit = false, canDelete = false),
+                    uiState = mockCommentItemUiState.copy(canEdit = false, canDelete = false),
                     onClick = {}, onMoreButtonClick = {}, onReplyIconClick = {}
                 )
             }

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -53,7 +53,8 @@
         <activity
             android:name=".view.post.detail.PostDetailActivity"
             android:exported="false"
-            android:theme="@style/Theme.PocsBlog" />
+            android:theme="@style/Theme.PocsBlog"
+            android:windowSoftInputMode="adjustResize" />
         <activity
             android:name=".view.setting.SettingActivity"
             android:exported="false" />

--- a/presentation/src/main/java/com/pocs/presentation/extension/DateExt.kt
+++ b/presentation/src/main/java/com/pocs/presentation/extension/DateExt.kt
@@ -40,3 +40,10 @@ fun String.toFormattedDateString(): String {
     }
     throw IllegalArgumentException("DatePattern들 중에 포함되지 않는 문자열입니다.")
 }
+
+fun createFormattedDateText(createdAt: String, updatedAt: String?): String {
+    if (updatedAt != null) {
+        return "${updatedAt.toFormattedDateString()}(수정됨)"
+    }
+    return createdAt.toFormattedDateString()
+}

--- a/presentation/src/main/java/com/pocs/presentation/extension/DateExt.kt
+++ b/presentation/src/main/java/com/pocs/presentation/extension/DateExt.kt
@@ -6,6 +6,7 @@ import org.joda.time.format.DateTimeFormat
 
 enum class DatePattern(val value: String) {
     COMPACT("yyyy-MM-dd"),
+    MEDIUM("yyyy-MM-dd HH:mm"),
     FULL("yyyy-MM-dd HH:mm:ss")
 }
 
@@ -30,7 +31,7 @@ fun String.toFormattedDateString(): String {
                     }
                 }
             }
-            if (pattern == DatePattern.FULL) {
+            if (pattern != DatePattern.COMPACT) {
                 result += date.toLocalDateTime().toString(" H:mm")
             }
             return result

--- a/presentation/src/main/java/com/pocs/presentation/mapper/CommentMapper.kt
+++ b/presentation/src/main/java/com/pocs/presentation/mapper/CommentMapper.kt
@@ -1,0 +1,18 @@
+package com.pocs.presentation.mapper
+
+import com.pocs.domain.model.comment.Comment
+import com.pocs.presentation.extension.toFormattedDateString
+import com.pocs.presentation.model.comment.item.CommentItemUiState
+
+fun Comment.toUiState(currentUserId: Int) = CommentItemUiState(
+    id = id,
+    parentId = parentId,
+    childrenCount = childrenCount,
+    postId = postId,
+    writer = writer.toUiState(),
+    isMyComment = currentUserId == writer.userId,
+    content = content,
+    createdAt = createdAt.toFormattedDateString(),
+    updatedAt = updatedAt?.toFormattedDateString(),
+    canceledAt = canceledAt
+)

--- a/presentation/src/main/java/com/pocs/presentation/mapper/CommentMapper.kt
+++ b/presentation/src/main/java/com/pocs/presentation/mapper/CommentMapper.kt
@@ -4,13 +4,18 @@ import com.pocs.domain.model.comment.Comment
 import com.pocs.presentation.extension.createFormattedDateText
 import com.pocs.presentation.model.comment.item.CommentItemUiState
 
-fun Comment.toUiState(currentUserId: Int?) = CommentItemUiState(
-    id = id,
-    parentId = parentId,
-    childrenCount = childrenCount,
-    postId = postId,
-    writer = writer.toUiState(),
-    isMyComment = currentUserId == writer.userId,
-    content = content,
-    date = createFormattedDateText(createdAt, updatedAt)
-)
+fun Comment.toUiState(currentUserId: Int?, isAdmin: Boolean): CommentItemUiState {
+    val isMine = currentUserId == writer.userId
+
+    return CommentItemUiState(
+        id = id,
+        parentId = parentId,
+        childrenCount = childrenCount,
+        postId = postId,
+        writer = writer.toUiState(),
+        canEdit = isMine,
+        canDelete = isMine || isAdmin,
+        content = content,
+        date = createFormattedDateText(createdAt, updatedAt)
+    )
+}

--- a/presentation/src/main/java/com/pocs/presentation/mapper/CommentMapper.kt
+++ b/presentation/src/main/java/com/pocs/presentation/mapper/CommentMapper.kt
@@ -1,7 +1,7 @@
 package com.pocs.presentation.mapper
 
 import com.pocs.domain.model.comment.Comment
-import com.pocs.presentation.extension.toFormattedDateString
+import com.pocs.presentation.extension.createFormattedDateText
 import com.pocs.presentation.model.comment.item.CommentItemUiState
 
 fun Comment.toUiState(currentUserId: Int) = CommentItemUiState(
@@ -12,6 +12,5 @@ fun Comment.toUiState(currentUserId: Int) = CommentItemUiState(
     writer = writer.toUiState(),
     isMyComment = currentUserId == writer.userId,
     content = content,
-    createdAt = createdAt.toFormattedDateString(),
-    updatedAt = updatedAt?.toFormattedDateString()
+    date = createFormattedDateText(createdAt, updatedAt)
 )

--- a/presentation/src/main/java/com/pocs/presentation/mapper/CommentMapper.kt
+++ b/presentation/src/main/java/com/pocs/presentation/mapper/CommentMapper.kt
@@ -13,6 +13,5 @@ fun Comment.toUiState(currentUserId: Int) = CommentItemUiState(
     isMyComment = currentUserId == writer.userId,
     content = content,
     createdAt = createdAt.toFormattedDateString(),
-    updatedAt = updatedAt?.toFormattedDateString(),
-    canceledAt = canceledAt
+    updatedAt = updatedAt?.toFormattedDateString()
 )

--- a/presentation/src/main/java/com/pocs/presentation/mapper/CommentMapper.kt
+++ b/presentation/src/main/java/com/pocs/presentation/mapper/CommentMapper.kt
@@ -4,7 +4,7 @@ import com.pocs.domain.model.comment.Comment
 import com.pocs.presentation.extension.createFormattedDateText
 import com.pocs.presentation.model.comment.item.CommentItemUiState
 
-fun Comment.toUiState(currentUserId: Int) = CommentItemUiState(
+fun Comment.toUiState(currentUserId: Int?) = CommentItemUiState(
     id = id,
     parentId = parentId,
     childrenCount = childrenCount,

--- a/presentation/src/main/java/com/pocs/presentation/mapper/CommentWriterMapper.kt
+++ b/presentation/src/main/java/com/pocs/presentation/mapper/CommentWriterMapper.kt
@@ -1,0 +1,9 @@
+package com.pocs.presentation.mapper
+
+import com.pocs.domain.model.comment.CommentWriter
+import com.pocs.presentation.model.comment.item.CommentWriterUiState
+
+fun CommentWriter.toUiState() = CommentWriterUiState(
+    userId = userId,
+    name = name
+)

--- a/presentation/src/main/java/com/pocs/presentation/mapper/PostDetailMapper.kt
+++ b/presentation/src/main/java/com/pocs/presentation/mapper/PostDetailMapper.kt
@@ -1,7 +1,7 @@
 package com.pocs.presentation.mapper
 
 import com.pocs.domain.model.post.PostDetail
-import com.pocs.presentation.extension.toFormattedDateString
+import com.pocs.presentation.extension.createFormattedDateText
 import com.pocs.presentation.model.post.item.PostDetailItemUiState
 
 fun PostDetail.toUiState() = PostDetailItemUiState(
@@ -9,6 +9,6 @@ fun PostDetail.toUiState() = PostDetailItemUiState(
     title = title,
     content = content,
     writer = writer.toUiState(),
-    date = createdAt.toFormattedDateString(),
+    date = createFormattedDateText(createdAt, updatedAt),
     category = category
 )

--- a/presentation/src/main/java/com/pocs/presentation/model/comment/CommentsUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/comment/CommentsUiState.kt
@@ -4,7 +4,7 @@ import com.pocs.presentation.model.comment.item.CommentItemUiState
 
 sealed class CommentsUiState {
 
-    class Success(
+    data class Success(
         val comments: List<CommentItemUiState> = emptyList(),
     ) : CommentsUiState()
 

--- a/presentation/src/main/java/com/pocs/presentation/model/comment/CommentsUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/comment/CommentsUiState.kt
@@ -1,0 +1,14 @@
+package com.pocs.presentation.model.comment
+
+import com.pocs.presentation.model.comment.item.CommentItemUiState
+
+sealed class CommentsUiState {
+
+    class Success(
+        val comments: List<CommentItemUiState> = emptyList(),
+    ) : CommentsUiState()
+
+    class Failure(val message: String?) : CommentsUiState()
+
+    object Loading : CommentsUiState()
+}

--- a/presentation/src/main/java/com/pocs/presentation/model/comment/item/CommentItemUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/comment/item/CommentItemUiState.kt
@@ -9,11 +9,8 @@ data class CommentItemUiState(
     val isMyComment: Boolean,
     val content: String,
     private val createdAt: String,
-    private val updatedAt: String? = null,
-    private val canceledAt: String? = null
+    private val updatedAt: String? = null
 ) {
-    val isDeleted: Boolean get() = canceledAt != null
-
     val time: String
         get() {
             if (updatedAt != null) {

--- a/presentation/src/main/java/com/pocs/presentation/model/comment/item/CommentItemUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/comment/item/CommentItemUiState.kt
@@ -8,14 +8,5 @@ data class CommentItemUiState(
     val writer: CommentWriterUiState,
     val isMyComment: Boolean,
     val content: String,
-    private val createdAt: String,
-    private val updatedAt: String? = null
-) {
-    val time: String
-        get() {
-            if (updatedAt != null) {
-                return "$updatedAt(수정됨)"
-            }
-            return createdAt
-        }
-}
+    val date: String
+)

--- a/presentation/src/main/java/com/pocs/presentation/model/comment/item/CommentItemUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/comment/item/CommentItemUiState.kt
@@ -6,7 +6,10 @@ data class CommentItemUiState(
     val childrenCount: Int,
     val postId: Int,
     val writer: CommentWriterUiState,
-    val isMyComment: Boolean,
+    val canEdit: Boolean,
+    val canDelete: Boolean,
     val content: String,
     val date: String
-)
+) {
+    val showMoreInfoButton: Boolean get() = canDelete || canEdit
+}

--- a/presentation/src/main/java/com/pocs/presentation/model/comment/item/CommentItemUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/comment/item/CommentItemUiState.kt
@@ -1,0 +1,24 @@
+package com.pocs.presentation.model.comment.item
+
+data class CommentItemUiState(
+    val id: Int,
+    val parentId: Int?,
+    val childrenCount: Int,
+    val postId: Int,
+    val writer: CommentWriterUiState,
+    val isMyComment: Boolean,
+    val content: String,
+    private val createdAt: String,
+    private val updatedAt: String? = null,
+    private val canceledAt: String? = null
+) {
+    val isDeleted: Boolean get() = canceledAt != null
+
+    val time: String
+        get() {
+            if (updatedAt != null) {
+                return "$updatedAt(수정됨)"
+            }
+            return createdAt
+        }
+}

--- a/presentation/src/main/java/com/pocs/presentation/model/comment/item/CommentWriterUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/comment/item/CommentWriterUiState.kt
@@ -1,0 +1,6 @@
+package com.pocs.presentation.model.comment.item
+
+data class CommentWriterUiState(
+    val userId: Int,
+    val name: String
+)

--- a/presentation/src/main/java/com/pocs/presentation/model/post/PostDetailUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/post/PostDetailUiState.kt
@@ -7,7 +7,6 @@ sealed class PostDetailUiState {
         val postDetail: PostDetailItemUiState,
         val canEditPost: Boolean,
         val canDeletePost: Boolean,
-        val isDeleted: Boolean,
         val isSuccessToDelete: Boolean = false,
         val errorMessage: String? = null
     ) : PostDetailUiState()

--- a/presentation/src/main/java/com/pocs/presentation/model/post/PostDetailUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/post/PostDetailUiState.kt
@@ -7,8 +7,8 @@ sealed class PostDetailUiState {
         val postDetail: PostDetailItemUiState,
         val canEditPost: Boolean,
         val canDeletePost: Boolean,
-        val isSuccessToDelete: Boolean = false,
-        val errorMessage: String? = null
+        val isDeleteSuccess: Boolean = false,
+        val userMessage: String? = null
     ) : PostDetailUiState()
 
     data class Failure(val message: String?) : PostDetailUiState()

--- a/presentation/src/main/java/com/pocs/presentation/model/post/PostDetailUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/post/PostDetailUiState.kt
@@ -1,5 +1,6 @@
 package com.pocs.presentation.model.post
 
+import com.pocs.presentation.model.comment.CommentsUiState
 import com.pocs.presentation.model.post.item.PostDetailItemUiState
 
 sealed class PostDetailUiState {
@@ -8,7 +9,8 @@ sealed class PostDetailUiState {
         val canEditPost: Boolean,
         val canDeletePost: Boolean,
         val isDeleteSuccess: Boolean = false,
-        val userMessage: String? = null
+        val userMessage: String? = null,
+        val comments: CommentsUiState = CommentsUiState.Loading
     ) : PostDetailUiState()
 
     data class Failure(val message: String?) : PostDetailUiState()

--- a/presentation/src/main/java/com/pocs/presentation/view/admin/post/AdminPostFragment.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/admin/post/AdminPostFragment.kt
@@ -83,8 +83,7 @@ class AdminPostFragment : ViewBindingFragment<FragmentPostBinding>() {
     private fun onClickPost(postItemUiState: PostItemUiState) {
         val intent = PostDetailActivity.getIntent(
             requireContext(),
-            id = postItemUiState.id,
-            isDeleted = postItemUiState.isDeleted
+            id = postItemUiState.id
         )
         launcher?.launch(intent)
     }

--- a/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
@@ -88,7 +88,7 @@ fun CommentAddButton(onClick: () -> Unit) {
 }
 
 @Composable
-private fun Comment(
+fun Comment(
     uiState: CommentItemUiState,
     onClick: () -> Unit,
     onReplyIconClick: () -> Unit,

--- a/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
@@ -111,10 +111,10 @@ private fun Comment(
                     MaterialTheme.colorScheme.background
                 }
             )
-            .padding(start = if (isReply) 8.dp else 0.dp)
+            .padding(start = if (isReply) 20.dp else 0.dp)
     ) {
         Row(
-            modifier = Modifier.padding(top = 16.dp, start = 20.dp),
+            modifier = Modifier.padding(top = 20.dp, start = 20.dp),
             verticalAlignment = Alignment.Top
         ) {
             val onBackgroundColor = MaterialTheme.colorScheme.onBackground
@@ -144,7 +144,7 @@ private fun Comment(
             }
         }
         if (isReply) {
-            Box(modifier = Modifier.height(12.dp))
+            Box(modifier = Modifier.height(16.dp))
         } else {
             Row(
                 Modifier
@@ -174,7 +174,7 @@ private fun CommentLabel(
 
     Box(
         contentAlignment = Alignment.CenterStart,
-        modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 16.dp)
+        modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 20.dp)
     ) {
         Icon(
             modifier = Modifier

--- a/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
@@ -1,0 +1,191 @@
+package com.pocs.presentation.view.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.outlined.Comment
+import androidx.compose.material.ripple.rememberRipple
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.pocs.presentation.R
+import com.pocs.presentation.model.comment.item.CommentItemUiState
+import com.pocs.presentation.model.comment.item.CommentWriterUiState
+
+typealias CommentCallback = (CommentItemUiState) -> Unit
+
+@Composable
+fun Comments(
+    modifier: Modifier = Modifier,
+    comments: List<CommentItemUiState>,
+    onCommentClick: CommentCallback,
+    onSubCommentIconClick: CommentCallback,
+    onMoreButtonClick: CommentCallback
+) {
+    LazyColumn(modifier = modifier) {
+        items(count = comments.size) { index ->
+            val comment = comments[index]
+
+            Column {
+                Comment(
+                    uiState = comment,
+                    onClick = { onCommentClick(comment) },
+                    onSubCommentIconClick = { onSubCommentIconClick(comment) },
+                    onMoreButtonClick = { onMoreButtonClick(comment) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun Comment(
+    uiState: CommentItemUiState,
+    onClick: () -> Unit,
+    onSubCommentIconClick: () -> Unit,
+    onMoreButtonClick: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(
+                onClick = onClick,
+                indication = rememberRipple(bounded = true),
+                interactionSource = remember { MutableInteractionSource() }
+            )
+    ) {
+        Row(
+            modifier = Modifier.padding(top = 16.dp, start = 20.dp),
+            verticalAlignment = Alignment.Top
+        ) {
+            val onBackgroundColor = MaterialTheme.colorScheme.onBackground
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = uiState.writer.name + stringResource(R.string.middle_dot) + uiState.time,
+                    style = MaterialTheme.typography.labelMedium.copy(
+                        color = onBackgroundColor.copy(alpha = 0.6f)
+                    )
+                )
+                Box(Modifier.height(8.dp))
+                Text(
+                    text = uiState.content,
+                    style = MaterialTheme.typography.titleMedium.copy(color = onBackgroundColor)
+                )
+            }
+            if (uiState.isMyComment) {
+                IconButton(onClick = onMoreButtonClick) {
+                    Icon(
+                        modifier = Modifier.size(16.dp),
+                        imageVector = Icons.Default.MoreVert,
+                        tint = onBackgroundColor.copy(alpha = 0.6f),
+                        contentDescription = stringResource(R.string.more_info_button)
+                    )
+                }
+            }
+        }
+        Row(
+            Modifier
+                .fillMaxWidth()
+                .padding(start = 10.dp)
+        ) {
+            CommentLabel(
+                imageVector = Icons.Outlined.Comment,
+                onClick = onSubCommentIconClick,
+                label = uiState.childrenCount.toString(),
+                contentDescription = stringResource(R.string.child_comment_count)
+            )
+        }
+        PocsDivider()
+    }
+}
+
+@Composable
+private fun CommentLabel(
+    imageVector: ImageVector,
+    label: String,
+    contentDescription: String,
+    onClick: () -> Unit
+) {
+    val color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
+
+    IconButton(onClick = onClick) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                modifier = Modifier.size(16.dp),
+                imageVector = imageVector,
+                contentDescription = contentDescription,
+                tint = color
+            )
+            Box(modifier = Modifier.width(4.dp))
+            Text(
+                text = label, style = MaterialTheme.typography.labelMedium.copy(color = color)
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun CommentsPreview() {
+    val mockComment = CommentItemUiState(
+        id = 10,
+        parentId = null,
+        childrenCount = 2,
+        postId = 1,
+        isMyComment = true,
+        writer = CommentWriterUiState(
+            userId = 1,
+            name = "홍길동"
+        ),
+        content = "댓글 내용입니다.",
+        createdAt = "오늘",
+        updatedAt = null,
+        canceledAt = null
+    )
+    Comments(
+        comments = listOf(mockComment, mockComment, mockComment, mockComment),
+        onCommentClick = {},
+        onSubCommentIconClick = {},
+        onMoreButtonClick = {}
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun CommentPreview() {
+    Comment(
+        uiState = CommentItemUiState(
+            id = 10,
+            parentId = null,
+            childrenCount = 2,
+            postId = 1,
+            isMyComment = true,
+            writer = CommentWriterUiState(
+                userId = 1,
+                name = "홍길동"
+            ),
+            content = "댓글 내용입니다.",
+            createdAt = "오늘",
+            updatedAt = "오늘",
+            canceledAt = null
+        ),
+        onClick = {},
+        onMoreButtonClick = {},
+        onSubCommentIconClick = {}
+    )
+}

--- a/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
@@ -154,8 +154,7 @@ fun CommentsPreview() {
         ),
         content = "댓글 내용입니다.",
         createdAt = "오늘",
-        updatedAt = null,
-        canceledAt = null
+        updatedAt = null
     )
     Comments(
         comments = listOf(mockComment, mockComment, mockComment, mockComment),
@@ -181,8 +180,7 @@ fun CommentPreview() {
             ),
             content = "댓글 내용입니다.",
             createdAt = "오늘",
-            updatedAt = "오늘",
-            canceledAt = null
+            updatedAt = "오늘"
         ),
         onClick = {},
         onMoreButtonClick = {},

--- a/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
@@ -21,6 +21,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.pocs.presentation.R
@@ -65,6 +67,8 @@ fun LazyListScope.commentItems(
     }
 }
 
+const val commentAddButtonDescription = "CommentAddButton"
+
 @Composable
 fun CommentAddButton(onClick: () -> Unit) {
     Box(
@@ -77,6 +81,7 @@ fun CommentAddButton(onClick: () -> Unit) {
                 role = Role.Button,
             )
             .padding(horizontal = 20.dp, vertical = 16.dp)
+            .semantics { contentDescription = commentAddButtonDescription }
     ) {
         Text(
             text = stringResource(id = R.string.add_comment),

--- a/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
@@ -160,7 +160,7 @@ fun Comment(
                     imageVector = Icons.Outlined.Comment,
                     onClick = onReplyIconClick,
                     label = if (uiState.childrenCount == 0) null else uiState.childrenCount.toString(),
-                    contentDescription = stringResource(R.string.child_comment_count)
+                    contentDescription = stringResource(R.string.reply_count)
                 )
             }
         }

--- a/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
@@ -67,10 +67,10 @@ fun LazyListScope.commentItems(
     }
 }
 
-const val commentAddButtonDescription = "CommentAddButton"
-
 @Composable
 fun CommentAddButton(onClick: () -> Unit) {
+    val commentAddButtonDescription = stringResource(id = R.string.comment_add_button)
+
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -81,7 +81,9 @@ fun CommentAddButton(onClick: () -> Unit) {
                 role = Role.Button,
             )
             .padding(horizontal = 20.dp, vertical = 16.dp)
-            .semantics { contentDescription = commentAddButtonDescription }
+            .semantics {
+                contentDescription = commentAddButtonDescription
+            }
     ) {
         Text(
             text = stringResource(id = R.string.add_comment),

--- a/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
@@ -74,7 +74,7 @@ private fun Comment(
 
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = uiState.writer.name + stringResource(R.string.middle_dot) + uiState.time,
+                    text = uiState.writer.name + stringResource(R.string.middle_dot) + uiState.date,
                     style = MaterialTheme.typography.labelMedium.copy(
                         color = onBackgroundColor.copy(alpha = 0.6f)
                     )
@@ -153,8 +153,7 @@ fun CommentsPreview() {
             name = "홍길동"
         ),
         content = "댓글 내용입니다.",
-        createdAt = "오늘",
-        updatedAt = null
+        date = "오늘"
     )
     Comments(
         comments = listOf(mockComment, mockComment, mockComment, mockComment),
@@ -179,8 +178,7 @@ fun CommentPreview() {
                 name = "홍길동"
             ),
             content = "댓글 내용입니다.",
-            createdAt = "오늘",
-            updatedAt = "오늘"
+            date = "오늘"
         ),
         onClick = {},
         onMoreButtonClick = {},

--- a/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
@@ -132,7 +132,7 @@ private fun Comment(
                     style = MaterialTheme.typography.bodyMedium.copy(color = onBackgroundColor)
                 )
             }
-            if (uiState.isMyComment) {
+            if (uiState.showMoreInfoButton) {
                 IconButton(onClick = onMoreButtonClick) {
                     Icon(
                         modifier = Modifier.size(16.dp),
@@ -226,7 +226,8 @@ fun CommentsPreview() {
         parentId = null,
         childrenCount = 0,
         postId = 1,
-        isMyComment = true,
+        canEdit = true,
+        canDelete = true,
         writer = CommentWriterUiState(
             userId = 1,
             name = "홍길동"
@@ -262,7 +263,8 @@ fun CommentPreview() {
             parentId = null,
             childrenCount = 2,
             postId = 1,
-            isMyComment = true,
+            canEdit = true,
+            canDelete = true,
             writer = CommentWriterUiState(
                 userId = 1,
                 name = "홍길동"

--- a/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
@@ -143,7 +143,7 @@ fun Comment(
                         modifier = Modifier.size(16.dp),
                         imageVector = Icons.Default.MoreVert,
                         tint = onBackgroundColor.copy(alpha = 0.6f),
-                        contentDescription = stringResource(R.string.more_info_button)
+                        contentDescription = stringResource(R.string.comment_info_button)
                     )
                 }
             }

--- a/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
@@ -66,6 +66,28 @@ fun LazyListScope.commentItems(
 }
 
 @Composable
+fun CommentAddButton(onClick: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(
+                onClick = onClick,
+                interactionSource = remember { MutableInteractionSource() },
+                indication = rememberRipple(bounded = true),
+                role = Role.Button,
+            )
+            .padding(horizontal = 20.dp, vertical = 16.dp)
+    ) {
+        Text(
+            text = stringResource(id = R.string.add_comment),
+            style = MaterialTheme.typography.bodyMedium.copy(
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f)
+            )
+        )
+    }
+}
+
+@Composable
 private fun Comment(
     uiState: CommentItemUiState,
     onClick: () -> Unit,

--- a/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
@@ -129,8 +129,8 @@ fun Comment(
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = uiState.writer.name + stringResource(R.string.middle_dot) + uiState.date,
-                    style = MaterialTheme.typography.labelMedium.copy(
-                        color = onBackgroundColor.copy(alpha = 0.6f)
+                    style = MaterialTheme.typography.bodySmall.copy(
+                        color = onBackgroundColor.copy(alpha = 0.5f)
                     )
                 )
                 Box(Modifier.height(8.dp))
@@ -144,7 +144,7 @@ fun Comment(
                     Icon(
                         modifier = Modifier.size(16.dp),
                         imageVector = Icons.Default.MoreVert,
-                        tint = onBackgroundColor.copy(alpha = 0.6f),
+                        tint = onBackgroundColor.copy(alpha = 0.5f),
                         contentDescription = stringResource(R.string.comment_info_button)
                     )
                 }
@@ -176,7 +176,7 @@ private fun CommentLabel(
     contentDescription: String,
     onClick: () -> Unit
 ) {
-    val color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
+    val color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f)
     val interactionSource = remember { MutableInteractionSource() }
 
     Box(
@@ -204,7 +204,7 @@ private fun CommentLabel(
                 .padding(start = 24.dp)
                 .defaultMinSize(minWidth = 32.dp),
             text = label ?: "",
-            style = MaterialTheme.typography.labelMedium.copy(color = color)
+            style = MaterialTheme.typography.bodySmall.copy(color = color)
         )
     }
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/component/LoadingContent.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/LoadingContent.kt
@@ -8,10 +8,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 
 @Composable
-fun LoadingContent() {
+fun LoadingContent(modifier: Modifier = Modifier) {
     Box(
         contentAlignment = Alignment.Center,
-        modifier = Modifier.fillMaxSize()
+        modifier = modifier.fillMaxSize()
     ) {
         CircularProgressIndicator()
     }

--- a/presentation/src/main/java/com/pocs/presentation/view/component/PocsDivider.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/PocsDivider.kt
@@ -8,6 +8,11 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun PocsDivider(startIndent: Dp = 0.dp) {
-    Divider(startIndent = startIndent, modifier = Modifier.alpha(0.2f))
+fun PocsDivider(startIndent: Dp = 0.dp, thickness: Dp = 1.dp) {
+    Divider(startIndent = startIndent, modifier = Modifier.alpha(0.2f), thickness = thickness)
+}
+
+@Composable
+fun ThickDivider() {
+    Divider(modifier = Modifier.alpha(0.1f), thickness = 16.dp)
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/component/PocsDivider.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/PocsDivider.kt
@@ -9,5 +9,5 @@ import androidx.compose.ui.unit.dp
 
 @Composable
 fun PocsDivider(startIndent: Dp = 0.dp) {
-    Divider(startIndent = startIndent, modifier = Modifier.alpha(0.4f))
+    Divider(startIndent = startIndent, modifier = Modifier.alpha(0.2f))
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/component/RecheckHandler.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/RecheckHandler.kt
@@ -40,6 +40,7 @@ fun RecheckDialog(
     onDismissRequest: () -> Unit,
     title: String? = null,
     text: String? = null,
+    dismissText: String? = null,
     confirmText: String? = null
 ) {
     AlertDialog(
@@ -55,7 +56,9 @@ fun RecheckDialog(
         },
         onDismissRequest = onDismissRequest,
         dismissButton = {
-            TextButton(onClick = onDismissRequest) { Text(stringResource(R.string.cancel)) }
+            TextButton(onClick = onDismissRequest) {
+                Text(dismissText ?: stringResource(R.string.cancel))
+            }
         },
         confirmButton = {
             TextButton(onClick = onOkClick) { Text(confirmText ?: stringResource(R.string.ok)) }

--- a/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
@@ -27,6 +27,7 @@ import com.pocs.presentation.R
 import com.pocs.presentation.model.comment.item.CommentItemUiState
 import com.pocs.presentation.view.component.RecheckDialog
 import com.pocs.presentation.view.component.textfield.SimpleTextField
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
@@ -140,6 +141,7 @@ fun CommentModalBottomSheet(
             .filter { it == ModalBottomSheetValue.Expanded }
             .collectLatest {
                 focusRequester.requestFocus()
+                delay(50)
                 keyboardController?.show()
             }
     }

--- a/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
@@ -82,10 +82,8 @@ fun CommentModalBottomSheet(
     var comment by remember { mutableStateOf("") }
 
     BackHandler(bottomSheetState.isVisible) {
-        if (bottomSheetState.isVisible) {
-            coroutineScope.launch {
-                bottomSheetState.hide()
-            }
+        coroutineScope.launch {
+            bottomSheetState.hide()
         }
     }
 
@@ -102,7 +100,9 @@ fun CommentModalBottomSheet(
         sheetState = bottomSheetState,
         sheetContent = {
             CommentTextField(
-                modifier = Modifier.heightIn(max = 260.dp).verticalScrollDisabled(),
+                modifier = Modifier
+                    .heightIn(max = 260.dp)
+                    .verticalScrollDisabled(),
                 comment = comment,
                 onCommentChange = { comment = it },
                 focusRequester = focusRequester,

--- a/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
@@ -88,9 +88,9 @@ fun CommentModalBottomSheet(
         animationSpec = TweenSpec(durationMillis = 75, easing = FastOutSlowInEasing)
     )
     val textFieldValueState = remember {
-        mutableStateOf(TextFieldValue()).apply {
+        mutableStateOf(TextFieldValue()).also {
             controller.init(
-                textFieldValueState = this@apply,
+                textFieldValueState = it,
                 bottomSheetState = bottomSheetState
             )
         }
@@ -230,7 +230,7 @@ class CommentModalController {
     suspend fun showForUpdate(comment: CommentItemUiState) {
         this.commentToBeUpdated = comment
 
-        textFieldValueState.value = textFieldValueState.value.copy(
+        textFieldValueState.value = TextFieldValue(
             text = comment.content,
             selection = TextRange(comment.content.length)
         )
@@ -247,7 +247,7 @@ class CommentModalController {
     }
 
     fun clear() {
-        textFieldValueState.value = textFieldValueState.value.copy(text = "")
+        textFieldValueState.value = TextFieldValue(text = "")
         parentId = null
         commentToBeUpdated = null
     }

--- a/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
@@ -175,6 +175,7 @@ fun CommentModalBottomSheet(
 
                     coroutineScope.launch {
                         controller.hide()
+                        keyboardController?.hide()
                     }
                 },
                 hint = stringResource(

--- a/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
@@ -18,6 +18,8 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
@@ -32,6 +34,8 @@ typealias CommentCreateCallback = (parentId: Int?, content: String) -> Unit
 
 typealias CommentUpdateCallback = (id: Int, content: String) -> Unit
 
+const val commentTextFieldDescription = "CommentTextField"
+
 @Composable
 private fun CommentTextField(
     modifier: Modifier = Modifier,
@@ -45,7 +49,10 @@ private fun CommentTextField(
     SimpleTextField(
         modifier = modifier
             .fillMaxWidth()
-            .focusRequester(focusRequester),
+            .focusRequester(focusRequester)
+            .semantics {
+                contentDescription = commentTextFieldDescription
+            },
         hint = hint,
         value = value,
         onValueChange = onValueChange,
@@ -130,7 +137,6 @@ fun CommentModalBottomSheet(
                             controller.clear()
                         }
 
-                        focusRequester.freeFocus()
                         keyboardController?.hide()
 
                         didSend = false

--- a/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
@@ -99,7 +99,6 @@ fun CommentModalBottomSheet(
     }
 
     var showRecheckDialog by remember { mutableStateOf(false) }
-    var didSend by remember { mutableStateOf(false) }
     val canSend by rememberUpdatedState(
         if (controller.isUpdate) {
             textFieldValueState.value.text != controller.commentToBeUpdated!!.content
@@ -129,6 +128,11 @@ fun CommentModalBottomSheet(
     BackHandler(bottomSheetState.isVisible) {
         coroutineScope.launch {
             bottomSheetState.hide()
+            if (canSend) {
+                showRecheckDialog = true
+            } else {
+                controller.clear()
+            }
         }
     }
 
@@ -145,15 +149,12 @@ fun CommentModalBottomSheet(
         sheetState = bottomSheetState,
         sheetBackgroundColor = MaterialTheme.colorScheme.surface,
         onDismiss = {
-            if (!didSend && canSend) {
+            keyboardController?.hide()
+            if (canSend) {
                 showRecheckDialog = true
             } else {
                 controller.clear()
             }
-
-            keyboardController?.hide()
-
-            didSend = false
         },
         sheetContent = {
             CommentTextField(
@@ -163,8 +164,6 @@ fun CommentModalBottomSheet(
                 focusRequester = focusRequester,
                 showSendIcon = canSend,
                 onSend = {
-                    didSend = true
-
                     val commentToBeUpdated = controller.commentToBeUpdated
 
                     if (commentToBeUpdated != null) {

--- a/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
@@ -220,8 +220,10 @@ class CommentModalController {
         this.bottomSheetState = bottomSheetState
     }
 
-    suspend fun showForCreate(parentId: Int? = null) {
-        this.parentId = parentId
+    suspend fun showForCreate(parentComment: CommentItemUiState? = null) {
+        if (parentComment != null) {
+            parentId = parentComment.parentId ?: parentComment.id
+        }
         show()
     }
 

--- a/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
@@ -1,6 +1,7 @@
 package com.pocs.presentation.view.component.bottomsheet
 
 import androidx.activity.compose.BackHandler
+import androidx.annotation.VisibleForTesting
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.TweenSpec
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -251,4 +252,10 @@ class CommentModalController {
         parentId = null
         commentToBeUpdated = null
     }
+
+    @VisibleForTesting
+    val isCleared: Boolean
+        get() = textFieldValueState.value.text.isEmpty()
+                && parentId == null
+                && commentToBeUpdated == null
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
@@ -20,14 +20,13 @@ import androidx.compose.ui.platform.SoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.pocs.presentation.R
-import com.pocs.presentation.model.comment.item.CommentItemUiState
 import com.pocs.presentation.view.component.textfield.SimpleTextField
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 import kotlin.math.abs
 
-typealias CommentSendCallback = (parentComment: CommentItemUiState?, comment: String) -> Unit
+typealias CommentSendCallback = (parentId: Int?, content: String) -> Unit
 
 @Composable
 private fun CommentTextField(
@@ -107,7 +106,7 @@ fun CommentModalBottomSheet(
                 onCommentChange = { comment = it },
                 focusRequester = focusRequester,
                 onSend = {
-                    onSend(commentModalController.parentComment, it)
+                    onSend(commentModalController.parentId, it)
                     coroutineScope.launch {
                         commentModalController.hide()
                     }
@@ -133,20 +132,20 @@ class CommentModalController(
     private val focusRequester: FocusRequester
 ) {
 
-    private var _parentComment: CommentItemUiState? = null
-    val parentComment: CommentItemUiState? get() = _parentComment
+    private var _parentId: Int? = null
+    val parentId: Int? get() = _parentId
 
-    val isReply: Boolean get() = parentComment != null
+    val isReply: Boolean get() = parentId != null
 
-    suspend fun show(parentComment: CommentItemUiState? = null) {
-        _parentComment = parentComment
+    suspend fun show(parentId: Int? = null) {
+        _parentId = parentId
         focusRequester.requestFocus()
         modalBottomSheetState.snapTo(ModalBottomSheetValue.Expanded)
         keyboardController?.show()
     }
 
     suspend fun hide() {
-        _parentComment = null
+        _parentId = null
         focusRequester.freeFocus()
         modalBottomSheetState.snapTo(ModalBottomSheetValue.Hidden)
         keyboardController?.hide()

--- a/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
@@ -2,7 +2,6 @@ package com.pocs.presentation.view.component.bottomsheet
 
 import androidx.activity.compose.BackHandler
 import androidx.annotation.VisibleForTesting
-import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.TweenSpec
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
@@ -87,7 +86,7 @@ fun CommentModalBottomSheet(
 
     val bottomSheetState = rememberModalBottomSheetState(
         initialValue = ModalBottomSheetValue.Hidden,
-        animationSpec = TweenSpec(durationMillis = 75, easing = FastOutSlowInEasing)
+        animationSpec = TweenSpec(durationMillis = 0)
     )
     val textFieldValueState = remember {
         mutableStateOf(TextFieldValue()).also {

--- a/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
@@ -173,9 +173,9 @@ fun CommentModalBottomSheet(
                         onCreated(controller.parentId, it)
                     }
 
+                    keyboardController?.hide()
                     coroutineScope.launch {
                         controller.hide()
-                        keyboardController?.hide()
                     }
                 },
                 hint = stringResource(

--- a/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
@@ -157,6 +157,7 @@ fun CommentModalBottomSheet(
 
     ModalBottomSheetLayout(
         sheetState = bottomSheetState,
+        sheetBackgroundColor = MaterialTheme.colorScheme.surface,
         sheetContent = {
             CommentTextField(
                 modifier = Modifier.heightIn(max = 260.dp),

--- a/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
@@ -1,0 +1,152 @@
+package com.pocs.presentation.view.component.bottomsheet
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Send
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.*
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.SoftwareKeyboardController
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.pocs.presentation.R
+import com.pocs.presentation.model.comment.item.CommentItemUiState
+import com.pocs.presentation.view.component.textfield.SimpleTextField
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.launch
+
+typealias CommentSendCallback = (parentComment: CommentItemUiState?, comment: String) -> Unit
+
+@Composable
+private fun CommentTextField(
+    modifier: Modifier = Modifier,
+    comment: String,
+    onCommentChange: (String) -> Unit,
+    hint: String,
+    onSend: (String) -> Unit,
+    focusRequester: FocusRequester
+) {
+    SimpleTextField(
+        modifier = modifier
+            .fillMaxWidth()
+            .focusRequester(focusRequester),
+        hint = hint,
+        value = comment,
+        onValueChange = onCommentChange,
+        maxLength = 250,// TODO: 벡엔드에서 댓글 최대 길이 결정되면 수정하기
+        trailingIcon = {
+            if (comment.isNotEmpty()) {
+                IconButton(onClick = { onSend(comment) }) {
+                    Icon(
+                        imageVector = Icons.Default.Send,
+                        contentDescription = stringResource(R.string.send_comment),
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+        }
+    )
+}
+
+@OptIn(ExperimentalMaterialApi::class, ExperimentalComposeUiApi::class)
+@Composable
+fun CommentModalBottomSheet(
+    onSend: CommentSendCallback,
+    content: @Composable (CommentModalController) -> Unit
+) {
+    val bottomSheetState = rememberModalBottomSheetState(
+        initialValue = ModalBottomSheetValue.Hidden
+    )
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val focusRequester = remember { FocusRequester() }
+    val commentModalController = remember {
+        CommentModalController(
+            bottomSheetState,
+            keyboardController,
+            focusRequester
+        )
+    }
+    val coroutineScope = rememberCoroutineScope()
+    var comment by remember { mutableStateOf("") }
+
+    BackHandler(bottomSheetState.isVisible) {
+        if (bottomSheetState.isVisible) {
+            coroutineScope.launch {
+                bottomSheetState.hide()
+            }
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        snapshotFlow { bottomSheetState.currentValue }
+            .filter { it == ModalBottomSheetValue.Hidden }
+            .collectLatest {
+                keyboardController?.hide()
+                comment = ""
+            }
+    }
+
+    ModalBottomSheetLayout(
+        sheetState = bottomSheetState,
+        sheetContent = {
+            CommentTextField(
+                modifier = Modifier.heightIn(max = 260.dp),
+                comment = comment,
+                onCommentChange = { comment = it },
+                focusRequester = focusRequester,
+                onSend = {
+                    onSend(commentModalController.parentComment, it)
+                    coroutineScope.launch {
+                        commentModalController.hide()
+                    }
+                },
+                hint = stringResource(
+                    id = if (commentModalController.isReply) {
+                        R.string.add_reply
+                    } else {
+                        R.string.add_comment
+                    }
+                )
+            )
+        },
+    ) {
+        content(commentModalController)
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class, ExperimentalComposeUiApi::class)
+class CommentModalController(
+    private val modalBottomSheetState: ModalBottomSheetState,
+    private val keyboardController: SoftwareKeyboardController?,
+    private val focusRequester: FocusRequester
+) {
+
+    private var _parentComment: CommentItemUiState? = null
+    val parentComment: CommentItemUiState? get() = _parentComment
+
+    val isReply: Boolean get() = parentComment != null
+
+    suspend fun show(parentComment: CommentItemUiState? = null) {
+        _parentComment = parentComment
+        focusRequester.requestFocus()
+        modalBottomSheetState.show()
+        keyboardController?.show()
+    }
+
+    suspend fun hide() {
+        _parentComment = null
+        focusRequester.freeFocus()
+        modalBottomSheetState.hide()
+        keyboardController?.hide()
+    }
+}

--- a/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
@@ -35,8 +35,6 @@ typealias CommentCreateCallback = (parentId: Int?, content: String) -> Unit
 
 typealias CommentUpdateCallback = (id: Int, content: String) -> Unit
 
-const val commentTextFieldDescription = "CommentTextField"
-
 @Composable
 private fun CommentTextField(
     modifier: Modifier = Modifier,
@@ -47,6 +45,8 @@ private fun CommentTextField(
     focusRequester: FocusRequester,
     showSendIcon: Boolean
 ) {
+    val commentTextFieldDescription = stringResource(R.string.comment_text_field)
+
     SimpleTextField(
         modifier = modifier
             .fillMaxWidth()

--- a/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
@@ -29,6 +29,7 @@ import com.pocs.presentation.model.comment.item.CommentItemUiState
 import com.pocs.presentation.view.component.RecheckDialog
 import com.pocs.presentation.view.component.textfield.SimpleTextField
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 
 typealias CommentCreateCallback = (parentId: Int?, content: String) -> Unit
@@ -133,31 +134,27 @@ fun CommentModalBottomSheet(
 
     LaunchedEffect(Unit) {
         snapshotFlow { bottomSheetState.currentValue }
+            .filter { it == ModalBottomSheetValue.Expanded }
             .collectLatest {
-                when (it) {
-                    ModalBottomSheetValue.Expanded -> {
-                        focusRequester.requestFocus()
-                        keyboardController?.show()
-                    }
-                    ModalBottomSheetValue.Hidden -> {
-                        if (!didSend && canSend) {
-                            showRecheckDialog = true
-                        } else {
-                            controller.clear()
-                        }
-
-                        keyboardController?.hide()
-
-                        didSend = false
-                    }
-                    else -> {}
-                }
+                focusRequester.requestFocus()
+                keyboardController?.show()
             }
     }
 
-    ModalBottomSheetLayout(
+    PocsModalBottomSheetLayout(
         sheetState = bottomSheetState,
         sheetBackgroundColor = MaterialTheme.colorScheme.surface,
+        onDismiss = {
+            if (!didSend && canSend) {
+                showRecheckDialog = true
+            } else {
+                controller.clear()
+            }
+
+            keyboardController?.hide()
+
+            didSend = false
+        },
         sheetContent = {
             CommentTextField(
                 modifier = Modifier.heightIn(max = 260.dp),

--- a/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/OptionModalBottomSheet.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/OptionModalBottomSheet.kt
@@ -10,10 +10,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Stable
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
@@ -23,14 +20,13 @@ import androidx.compose.ui.unit.dp
 import com.pocs.presentation.R
 import com.pocs.presentation.model.comment.item.CommentItemUiState
 import kotlinx.coroutines.launch
-import java.io.Serializable
 
-@Stable
+@Immutable
 data class Option(
     val imageVector: ImageVector,
     @StringRes val stringResId: Int,
     val onClick: (CommentItemUiState) -> Unit
-) : Serializable
+)
 
 @Composable
 private fun OptionBottomSheet(options: List<Option>, controller: OptionModalController) {

--- a/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/OptionModalBottomSheet.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/OptionModalBottomSheet.kt
@@ -97,6 +97,7 @@ fun OptionModalBottomSheet(
 
     ModalBottomSheetLayout(
         sheetState = bottomSheetState,
+        sheetBackgroundColor = MaterialTheme.colorScheme.surface,
         sheetContent = { OptionBottomSheet(options, controller) },
     ) {
         content(controller)

--- a/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/OptionModalBottomSheet.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/OptionModalBottomSheet.kt
@@ -95,7 +95,7 @@ fun OptionModalBottomSheet(
         }
     }
 
-    ModalBottomSheetLayout(
+    PocsModalBottomSheetLayout(
         sheetState = bottomSheetState,
         sheetBackgroundColor = MaterialTheme.colorScheme.surface,
         sheetContent = { OptionBottomSheet(options, controller) },

--- a/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/OptionModalBottomSheet.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/OptionModalBottomSheet.kt
@@ -23,13 +23,14 @@ import androidx.compose.ui.unit.dp
 import com.pocs.presentation.R
 import com.pocs.presentation.model.comment.item.CommentItemUiState
 import kotlinx.coroutines.launch
+import java.io.Serializable
 
 @Stable
 data class Option(
     val imageVector: ImageVector,
     @StringRes val stringResId: Int,
     val onClick: (CommentItemUiState) -> Unit
-)
+) : Serializable
 
 @Composable
 private fun OptionBottomSheet(options: List<Option>, controller: OptionModalController) {

--- a/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/OptionModalBottomSheet.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/OptionModalBottomSheet.kt
@@ -1,0 +1,134 @@
+package com.pocs.presentation.view.component.bottomsheet
+
+import androidx.activity.compose.BackHandler
+import androidx.annotation.StringRes
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.ripple.rememberRipple
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.pocs.presentation.R
+import com.pocs.presentation.model.comment.item.CommentItemUiState
+import kotlinx.coroutines.launch
+
+@Stable
+data class Option(
+    val imageVector: ImageVector,
+    @StringRes val stringResId: Int,
+    val onClick: (CommentItemUiState) -> Unit
+)
+
+@Composable
+private fun OptionBottomSheet(options: List<Option>, controller: OptionModalController) {
+    Column {
+        for (option in options) {
+            OptionBottomSheetItem(option, controller)
+        }
+    }
+}
+
+@Composable
+fun OptionBottomSheetItem(option: Option, controller: OptionModalController) {
+    val coroutineScope = rememberCoroutineScope()
+    val interactionSource = remember { MutableInteractionSource() }
+    val label = stringResource(id = option.stringResId)
+    val color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f)
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(
+                interactionSource = interactionSource,
+                indication = rememberRipple(bounded = true),
+                role = Role.Button,
+                onClick = {
+                    option.onClick(requireNotNull(controller.comment))
+                    coroutineScope.launch {
+                        controller.hide()
+                    }
+                }
+            )
+            .padding(16.dp),
+    ) {
+        Icon(
+            imageVector = option.imageVector,
+            contentDescription = label,
+            tint = color
+        )
+        Box(modifier = Modifier.width(24.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyLarge.copy(color = color)
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun OptionModalBottomSheet(
+    options: List<Option>,
+    content: @Composable (OptionModalController) -> Unit
+) {
+    val bottomSheetState = rememberModalBottomSheetState(
+        initialValue = ModalBottomSheetValue.Hidden
+    )
+    val controller = remember { OptionModalController(bottomSheetState) }
+    val coroutineScope = rememberCoroutineScope()
+
+    BackHandler(bottomSheetState.isVisible) {
+        coroutineScope.launch {
+            controller.hide()
+        }
+    }
+
+    ModalBottomSheetLayout(
+        sheetState = bottomSheetState,
+        sheetContent = { OptionBottomSheet(options, controller) },
+    ) {
+        content(controller)
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+class OptionModalController(
+    private val modalBottomSheetState: ModalBottomSheetState
+) {
+    private var _comment: CommentItemUiState? = null
+    val comment get() = _comment
+
+    suspend fun show(comment: CommentItemUiState) {
+        _comment = comment
+        modalBottomSheetState.show()
+    }
+
+    suspend fun hide() {
+        _comment = null
+        modalBottomSheetState.hide()
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Preview(showBackground = true)
+@Composable
+private fun OptionBottomSheetItemPreview() {
+    val bottomSheetState = rememberModalBottomSheetState(
+        initialValue = ModalBottomSheetValue.Hidden
+    )
+    OptionBottomSheetItem(
+        Option(imageVector = Icons.Default.Edit, stringResId = R.string.edit, onClick = {}),
+        controller = OptionModalController(bottomSheetState)
+    )
+}

--- a/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/PocsModalBottomSheet.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/PocsModalBottomSheet.kt
@@ -1,0 +1,174 @@
+package com.pocs.presentation.view.component.bottomsheet
+
+import androidx.compose.animation.core.TweenSpec
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.isSpecified
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.semantics.dismiss
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.math.max
+import kotlin.math.roundToInt
+
+/**
+ * [ModalBottomSheetLayout]로 원하는 구현을 할 수 없어서 복사한 컴포즈 함수이다.
+ *
+ * 추가된 기능
+ * - [ModalBottomSheetValue.Hidden]일 때는 아예 안보이도록 하여 링크의 문제를 해결함
+ *   https://github.com/hansung-pocs/blog-android/pull/170#issuecomment-1215451403
+ * -
+ *
+ * 사라진 기능
+ * - [ModalBottomSheetState.confirmStateChange] 함수 작동 안함
+ * - [ModalBottomSheetValue.HalfExpanded] 작동 안함
+ * - Swipe 동작 안함
+ */
+@Composable
+@ExperimentalMaterialApi
+fun PocsModalBottomSheetLayout(
+    sheetContent: @Composable ColumnScope.() -> Unit,
+    modifier: Modifier = Modifier,
+    sheetState: ModalBottomSheetState = rememberModalBottomSheetState(ModalBottomSheetValue.Hidden),
+    sheetShape: Shape = MaterialTheme.shapes.large,
+    sheetElevation: Dp = ModalBottomSheetDefaults.Elevation,
+    sheetBackgroundColor: Color = MaterialTheme.colors.surface,
+    sheetContentColor: Color = contentColorFor(sheetBackgroundColor),
+    scrimColor: Color = ModalBottomSheetDefaults.scrimColor,
+    onDismiss: (() -> Unit)? = null,
+    content: @Composable () -> Unit
+) {
+    val scope = rememberCoroutineScope()
+    BoxWithConstraints(modifier) {
+        val fullHeight = constraints.maxHeight.toFloat()
+        val sheetHeightState = remember { mutableStateOf<Float?>(null) }
+        val anchorInited = remember { mutableStateOf(false) }
+        val sheetAlpha by animateFloatAsState(
+            targetValue = if (sheetState.targetValue != ModalBottomSheetValue.Hidden) 1f else 0f,
+            animationSpec = TweenSpec(durationMillis = 10)
+        )
+        LaunchedEffect(Unit) {
+            // anchor가 internal이기 때문에 비어있는지 확인 할 수 없어 임시로 100ms 후에 초기화 된 것 처럼 보이게 한다.
+            delay(100)
+            anchorInited.value = true
+        }
+        Box(Modifier.fillMaxSize()) {
+            content()
+            Scrim(
+                color = scrimColor,
+                onDismiss = {
+                    onDismiss?.invoke()
+                    scope.launch { sheetState.hide() }
+                },
+                visible = sheetState.targetValue != ModalBottomSheetValue.Hidden
+            )
+        }
+        Surface(
+            Modifier
+                .fillMaxWidth()
+                .alpha(sheetAlpha)
+                .offset {
+                    val y = if (!anchorInited.value) {
+                        // if we don't know our anchors yet, render the sheet as hidden
+                        fullHeight.roundToInt()
+                    } else {
+                        // if we do know our anchors, respect them
+                        sheetState.offset.value.roundToInt()
+                    }
+                    IntOffset(0, y)
+                }
+                .bottomSheetSwipeable(sheetState, fullHeight, sheetHeightState)
+                .onGloballyPositioned {
+                    sheetHeightState.value = it.size.height.toFloat()
+                }
+                .semantics {
+                    if (sheetState.isVisible) {
+                        dismiss {
+                            scope.launch { sheetState.hide() }
+                            true
+                        }
+                    }
+                },
+            shape = sheetShape,
+            elevation = sheetElevation,
+            color = sheetBackgroundColor,
+            contentColor = sheetContentColor
+        ) {
+            Column(content = sheetContent)
+        }
+    }
+}
+
+@Composable
+private fun Scrim(
+    color: Color,
+    onDismiss: () -> Unit,
+    visible: Boolean
+) {
+    if (color.isSpecified) {
+        val alpha by animateFloatAsState(
+            targetValue = if (visible) 1f else 0f,
+            animationSpec = TweenSpec()
+        )
+        val dismissModifier = if (visible) {
+            Modifier.pointerInput(Unit) { detectTapGestures { onDismiss() } }
+        } else {
+            Modifier
+        }
+        Canvas(
+            Modifier
+                .fillMaxSize()
+                .then(dismissModifier)
+        ) {
+            drawRect(color = color, alpha = alpha)
+        }
+    }
+}
+
+@Suppress("ModifierInspectorInfo")
+@OptIn(ExperimentalMaterialApi::class)
+private fun Modifier.bottomSheetSwipeable(
+    sheetState: ModalBottomSheetState,
+    fullHeight: Float,
+    sheetHeightState: State<Float?>
+): Modifier {
+    val sheetHeight = sheetHeightState.value
+    val modifier = if (sheetHeight != null) {
+        val anchors = if (sheetHeight < fullHeight / 2) {
+            mapOf(
+                fullHeight to ModalBottomSheetValue.Hidden,
+                fullHeight - sheetHeight to ModalBottomSheetValue.Expanded
+            )
+        } else {
+            mapOf(
+                fullHeight to ModalBottomSheetValue.Hidden,
+                fullHeight / 2 to ModalBottomSheetValue.HalfExpanded,
+                max(0f, fullHeight - sheetHeight) to ModalBottomSheetValue.Expanded
+            )
+        }
+        Modifier.swipeable(
+            state = sheetState,
+            anchors = anchors,
+            orientation = Orientation.Vertical,
+            enabled = false,
+            resistance = null
+        )
+    } else {
+        Modifier
+    }
+
+    return this.then(modifier)
+}

--- a/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/PocsModalBottomSheet.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/PocsModalBottomSheet.kt
@@ -56,8 +56,9 @@ fun PocsModalBottomSheetLayout(
         val fullHeight = constraints.maxHeight.toFloat()
         val sheetHeightState = remember { mutableStateOf<Float?>(null) }
         val anchorInited = remember { mutableStateOf(false) }
+        val sheetVisible = sheetState.targetValue != ModalBottomSheetValue.Hidden
         val sheetAlpha by animateFloatAsState(
-            targetValue = if (sheetState.targetValue != ModalBottomSheetValue.Hidden) 1f else 0f,
+            targetValue = if (sheetVisible) 1f else 0f,
             animationSpec = TweenSpec(durationMillis = 10)
         )
         LaunchedEffect(Unit) {
@@ -73,7 +74,7 @@ fun PocsModalBottomSheetLayout(
                     onDismiss?.invoke()
                     scope.launch { sheetState.hide() }
                 },
-                visible = sheetState.targetValue != ModalBottomSheetValue.Hidden
+                visible = sheetVisible
             )
         }
         Surface(

--- a/presentation/src/main/java/com/pocs/presentation/view/component/button/DropdownButton.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/button/DropdownButton.kt
@@ -4,7 +4,9 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import com.pocs.presentation.R
 
@@ -33,6 +35,7 @@ fun DropdownButton(
     ) {
         options.forEach { option ->
             DropdownMenuItem(
+                modifier = Modifier.testTag(option.label),
                 onClick = {
                     option.onClick()
                     showDropdownMenu = false

--- a/presentation/src/main/java/com/pocs/presentation/view/component/button/DropdownButton.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/button/DropdownButton.kt
@@ -1,0 +1,51 @@
+package com.pocs.presentation.view.component.button
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import com.pocs.presentation.R
+
+@Stable
+data class DropdownOption(
+    val label: String,
+    val onClick: () -> Unit,
+    val labelColor: Color? = null
+)
+
+@Composable
+fun DropdownButton(
+    options: List<DropdownOption>,
+) {
+    var showDropdownMenu by remember { mutableStateOf(false) }
+
+    IconButton(onClick = { showDropdownMenu = !showDropdownMenu }) {
+        Icon(
+            imageVector = Icons.Filled.MoreVert,
+            contentDescription = stringResource(id = R.string.more_info_button)
+        )
+    }
+    DropdownMenu(
+        expanded = showDropdownMenu,
+        onDismissRequest = { showDropdownMenu = false },
+    ) {
+        options.forEach { option ->
+            DropdownMenuItem(
+                onClick = {
+                    option.onClick()
+                    showDropdownMenu = false
+                },
+                text = {
+                    Text(
+                        text = option.label,
+                        style = MaterialTheme.typography.bodyLarge.copy(
+                            color = option.labelColor ?: MaterialTheme.colorScheme.onSurface
+                        )
+                    )
+                }
+            )
+        }
+    }
+}

--- a/presentation/src/main/java/com/pocs/presentation/view/component/textfield/SimpleTextField.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/textfield/SimpleTextField.kt
@@ -1,5 +1,6 @@
 package com.pocs.presentation.view.component.textfield
 
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
@@ -12,12 +13,14 @@ import androidx.compose.ui.graphics.Color
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SimpleTextField(
+    modifier: Modifier,
     hint: String,
     value: String,
     maxLength: Int,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
     onValueChange: (String) -> Unit,
-    modifier: Modifier
+    trailingIcon: @Composable (() -> Unit)? = null
 ) {
     TextField(
         colors = TextFieldDefaults.textFieldColors(
@@ -27,6 +30,7 @@ fun SimpleTextField(
             containerColor = Color.Transparent
         ),
         keyboardOptions = keyboardOptions,
+        keyboardActions = keyboardActions,
         placeholder = { Text(hint) },
         value = value,
         onValueChange = {
@@ -34,6 +38,7 @@ fun SimpleTextField(
                 onValueChange(it)
             }
         },
-        modifier = modifier
+        modifier = modifier,
+        trailingIcon = trailingIcon
     )
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/component/textfield/SimpleTextField.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/textfield/SimpleTextField.kt
@@ -2,10 +2,7 @@ package com.pocs.presentation.view.component.textfield
 
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
-import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -27,7 +24,8 @@ fun SimpleTextField(
             focusedIndicatorColor = Color.Transparent,
             disabledIndicatorColor = Color.Transparent,
             unfocusedIndicatorColor = Color.Transparent,
-            containerColor = Color.Transparent
+            containerColor = Color.Transparent,
+            placeholderColor = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.4f)
         ),
         keyboardOptions = keyboardOptions,
         keyboardActions = keyboardActions,

--- a/presentation/src/main/java/com/pocs/presentation/view/component/textfield/SimpleTextField.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/textfield/SimpleTextField.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.TextFieldValue
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -33,6 +34,40 @@ fun SimpleTextField(
         value = value,
         onValueChange = {
             if (it.length <= maxLength) {
+                onValueChange(it)
+            }
+        },
+        modifier = modifier,
+        trailingIcon = trailingIcon
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SimpleTextField(
+    modifier: Modifier,
+    hint: String,
+    value: TextFieldValue,
+    maxLength: Int,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    onValueChange: (TextFieldValue) -> Unit,
+    trailingIcon: @Composable (() -> Unit)? = null
+) {
+    TextField(
+        colors = TextFieldDefaults.textFieldColors(
+            focusedIndicatorColor = Color.Transparent,
+            disabledIndicatorColor = Color.Transparent,
+            unfocusedIndicatorColor = Color.Transparent,
+            containerColor = Color.Transparent,
+            placeholderColor = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.4f)
+        ),
+        keyboardOptions = keyboardOptions,
+        keyboardActions = keyboardActions,
+        placeholder = { Text(hint) },
+        value = value,
+        onValueChange = {
+            if (it.text.length <= maxLength) {
                 onValueChange(it)
             }
         },

--- a/presentation/src/main/java/com/pocs/presentation/view/component/textfield/SimpleTextField.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/textfield/SimpleTextField.kt
@@ -1,0 +1,39 @@
+package com.pocs.presentation.view.component.textfield
+
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SimpleTextField(
+    hint: String,
+    value: String,
+    maxLength: Int,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier
+) {
+    TextField(
+        colors = TextFieldDefaults.textFieldColors(
+            focusedIndicatorColor = Color.Transparent,
+            disabledIndicatorColor = Color.Transparent,
+            unfocusedIndicatorColor = Color.Transparent,
+            containerColor = Color.Transparent
+        ),
+        keyboardOptions = keyboardOptions,
+        placeholder = { Text(hint) },
+        value = value,
+        onValueChange = {
+            if (it.length <= maxLength) {
+                onValueChange(it)
+            }
+        },
+        modifier = modifier
+    )
+}

--- a/presentation/src/main/java/com/pocs/presentation/view/home/post/PostFragment.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/home/post/PostFragment.kt
@@ -102,8 +102,7 @@ class PostFragment : ViewBindingFragment<FragmentPostBinding>() {
     private fun onClickPost(postItemUiState: PostItemUiState) {
         val intent = PostDetailActivity.getIntent(
             requireContext(),
-            id = postItemUiState.id,
-            isDeleted = postItemUiState.isDeleted
+            id = postItemUiState.id
         )
         launcher?.launch(intent)
     }

--- a/presentation/src/main/java/com/pocs/presentation/view/home/question/QuestionFragment.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/home/question/QuestionFragment.kt
@@ -77,8 +77,7 @@ class QuestionFragment : ViewBindingFragment<FragmentQuestionBinding>() {
     private fun onClickPost(postItemUiState: PostItemUiState) {
         val intent = PostDetailActivity.getIntent(
             requireContext(),
-            id = postItemUiState.id,
-            isDeleted = postItemUiState.isDeleted
+            id = postItemUiState.id
         )
         launcher?.launch(intent)
     }

--- a/presentation/src/main/java/com/pocs/presentation/view/home/study/StudyFragment.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/home/study/StudyFragment.kt
@@ -81,8 +81,7 @@ class StudyFragment : ViewBindingFragment<FragmentPostBinding>() {
     private fun onClickPost(postItemUiState: PostItemUiState) {
         val intent = PostDetailActivity.getIntent(
             requireContext(),
-            id = postItemUiState.id,
-            isDeleted = postItemUiState.isDeleted
+            id = postItemUiState.id
         )
         launcher?.launch(intent)
     }

--- a/presentation/src/main/java/com/pocs/presentation/view/post/by/user/PostByUserActivity.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/by/user/PostByUserActivity.kt
@@ -105,8 +105,7 @@ class PostByUserActivity : ViewBindingActivity<ActivityPostByUserBinding>() {
     private fun startPostDetailActivity(postItemUiState: PostItemUiState) {
         val intent = PostDetailActivity.getIntent(
             this,
-            id = postItemUiState.id,
-            isDeleted = postItemUiState.isDeleted
+            id = postItemUiState.id
         )
         launcher?.launch(intent)
     }

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailActivity.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailActivity.kt
@@ -3,33 +3,20 @@ package com.pocs.presentation.view.post.detail
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.Menu
-import android.view.MenuItem
+import androidx.activity.compose.setContent
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.viewModels
-import androidx.core.view.children
-import androidx.core.view.isVisible
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import com.google.android.material.snackbar.Snackbar
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.composethemeadapter3.Mdc3Theme
 import com.pocs.presentation.R
-import com.pocs.presentation.base.ViewBindingActivity
-import com.pocs.presentation.databinding.ActivityPostDetailBinding
 import com.pocs.presentation.extension.RefreshStateContract
 import com.pocs.presentation.extension.setResultRefresh
 import com.pocs.presentation.model.post.PostDetailUiState
 import com.pocs.presentation.view.post.edit.PostEditActivity
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
-class PostDetailActivity : ViewBindingActivity<ActivityPostDetailBinding>() {
-
-    override val bindingInflater: (LayoutInflater) -> ActivityPostDetailBinding
-        get() = ActivityPostDetailBinding::inflate
+class PostDetailActivity : AppCompatActivity() {
 
     private val viewModel: PostDetailViewModel by viewModels()
 
@@ -46,61 +33,24 @@ class PostDetailActivity : ViewBindingActivity<ActivityPostDetailBinding>() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        fetchPost()
-        initToolBar()
-
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.uiState.collect(::updateUi)
+        setContent {
+            Mdc3Theme(this) {
+                PostDetailScreen(
+                    viewModel,
+                    onEditClick = ::startPostEditActivity,
+                    onDeleteSuccess = ::onDeleteSuccess
+                )
             }
         }
+
+        fetchPost()
 
         launcher = registerForActivityResult(RefreshStateContract()) {
             if (it != null) {
                 setResultRefresh()
                 fetchPost()
-                it.message?.let { message -> showSnackBar(message) }
+                it.message?.let { message -> viewModel.showUserMessage(message) }
             }
-        }
-    }
-
-    override fun onSupportNavigateUp(): Boolean {
-        onBackPressed()
-        return true
-    }
-
-    override fun onCreateOptionsMenu(menu: Menu): Boolean {
-        menuInflater.inflate(R.menu.menu_post_detail, menu)
-        return true
-    }
-
-    override fun onPrepareOptionsMenu(menu: Menu): Boolean {
-        val uiState = viewModel.uiState.value
-
-        menu.children.forEach {
-            when (it.itemId) {
-                R.id.action_edit_post -> {
-                    it.isVisible = (uiState as? PostDetailUiState.Success)?.canEditPost ?: false
-                }
-                R.id.action_delete_post -> {
-                    it.isVisible = (uiState as? PostDetailUiState.Success)?.canDeletePost ?: false
-                }
-            }
-        }
-        return true
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            R.id.action_edit_post -> {
-                startPostEditActivity()
-                true
-            }
-            R.id.action_delete_post -> {
-                showRecheckDialog()
-                true
-            }
-            else -> super.onOptionsItemSelected(item)
         }
     }
 
@@ -115,65 +65,9 @@ class PostDetailActivity : ViewBindingActivity<ActivityPostDetailBinding>() {
         viewModel.fetchPost(id)
     }
 
-    private fun initToolBar() {
-        setSupportActionBar(binding.toolBar)
-        supportActionBar?.setDisplayHomeAsUpEnabled(true)
-        supportActionBar?.setDisplayShowTitleEnabled(false)
-    }
-
-    private fun updateUi(uiState: PostDetailUiState) = with(binding) {
-        invalidateOptionsMenu()
-        progressBar.isVisible = uiState is PostDetailUiState.Loading
-        when (uiState) {
-            is PostDetailUiState.Success -> {
-                val postDetail = uiState.postDetail
-
-                title.text = postDetail.title
-                subtitle.text = getString(
-                    R.string.post_subtitle,
-                    postDetail.date,
-                    postDetail.writer.name
-                )
-                content.text = postDetail.content
-
-                if (uiState.isSuccessToDelete) {
-                    onDeleteSuccess()
-                }
-                if (uiState.errorMessage != null) {
-                    showSnackBar(uiState.errorMessage)
-                    viewModel.shownErrorMessage()
-                }
-            }
-            is PostDetailUiState.Failure -> {
-                title.text = getString(R.string.failed_to_load)
-                content.text = uiState.message
-            }
-            else -> {}
-        }
-    }
-
-    private fun showRecheckDialog() {
-        MaterialAlertDialogBuilder(this).apply {
-            setTitle(getString(R.string.are_you_sure_you_want_to_delete))
-            setPositiveButton(getString(R.string.delete)) { _, _ ->
-                requestPostDeleting()
-            }
-            setNegativeButton(getString(R.string.cancel)) { _, _ -> }
-        }.show()
-    }
-
-    private fun showSnackBar(message: String) {
-        Snackbar.make(binding.root, message, Snackbar.LENGTH_SHORT).show()
-    }
-
-    private fun requestPostDeleting() {
-        val postId = intent.getIntExtra("id", -1)
-        viewModel.requestPostDeleting(postId)
-    }
-
     private fun startPostEditActivity() {
         val uiState = viewModel.uiState.value
-        if (uiState !is PostDetailUiState.Success) return
+        require(uiState is PostDetailUiState.Success)
 
         val postDetail = uiState.postDetail
         val intent = PostEditActivity.getIntent(

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailActivity.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailActivity.kt
@@ -7,6 +7,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.WindowCompat
 import com.google.android.material.composethemeadapter3.Mdc3Theme
 import com.pocs.presentation.R
 import com.pocs.presentation.extension.RefreshStateContract
@@ -31,6 +32,7 @@ class PostDetailActivity : AppCompatActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        WindowCompat.setDecorFitsSystemWindows(window, true)
         super.onCreate(savedInstanceState)
 
         setContent {

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailActivity.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailActivity.kt
@@ -36,10 +36,9 @@ class PostDetailActivity : ViewBindingActivity<ActivityPostDetailBinding>() {
     private var launcher: ActivityResultLauncher<Intent>? = null
 
     companion object {
-        fun getIntent(context: Context, id: Int, isDeleted: Boolean): Intent {
+        fun getIntent(context: Context, id: Int): Intent {
             return Intent(context, PostDetailActivity::class.java).apply {
                 putExtra("id", id)
-                putExtra("isDeleted", isDeleted)
             }
         }
     }
@@ -112,9 +111,8 @@ class PostDetailActivity : ViewBindingActivity<ActivityPostDetailBinding>() {
 
     private fun fetchPost() {
         val id = intent.getIntExtra("id", -1)
-        val isDeleted = intent.getBooleanExtra("isDeleted", false)
 
-        viewModel.fetchPost(id, isDeleted)
+        viewModel.fetchPost(id)
     }
 
     private fun initToolBar() {
@@ -137,7 +135,6 @@ class PostDetailActivity : ViewBindingActivity<ActivityPostDetailBinding>() {
                     postDetail.writer.name
                 )
                 content.text = postDetail.content
-                deleted.isVisible = uiState.isDeleted
 
                 if (uiState.isSuccessToDelete) {
                     onDeleteSuccess()

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
@@ -185,12 +185,12 @@ fun PostDetailContent(
                         },
                         onReplyIconClick = {
                             coroutineScope.launch {
-                                commentModalController.show(parentComment = it)
+                                commentModalController.show(parentId = it.id)
                             }
                         },
                         onCommentClick = {
                             coroutineScope.launch {
-                                commentModalController.show(parentComment = it)
+                                commentModalController.show(parentId = it.id)
                             }
                         },
                     )

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
@@ -1,0 +1,255 @@
+package com.pocs.presentation.view.post.detail
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Error
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.pocs.domain.model.post.PostCategory
+import com.pocs.presentation.R
+import com.pocs.presentation.model.post.PostDetailUiState
+import com.pocs.presentation.model.post.item.PostDetailItemUiState
+import com.pocs.presentation.model.post.item.PostWriterUiState
+import com.pocs.presentation.view.component.LoadingContent
+import com.pocs.presentation.view.component.PocsDivider
+import com.pocs.presentation.view.component.RecheckDialog
+import com.pocs.presentation.view.component.ThickDivider
+import com.pocs.presentation.view.component.button.AppBarBackButton
+import com.pocs.presentation.view.component.button.DropdownButton
+import com.pocs.presentation.view.component.button.DropdownOption
+
+@Composable
+fun PostDetailScreen(
+    viewModel: PostDetailViewModel,
+    onEditClick: () -> Unit,
+    onDeleteSuccess: () -> Unit,
+) {
+    when (val uiState = viewModel.uiState.collectAsState().value) {
+        is PostDetailUiState.Failure -> {
+            PostDetailFailureContent(uiState = uiState)
+        }
+        PostDetailUiState.Loading -> {
+            LoadingContent()
+        }
+        is PostDetailUiState.Success -> {
+            val snackbarHostState = remember { SnackbarHostState() }
+
+            if (uiState.isDeleteSuccess) {
+                onDeleteSuccess()
+            }
+            if (uiState.userMessage != null) {
+                LaunchedEffect(uiState.userMessage) {
+                    snackbarHostState.showSnackbar(uiState.userMessage)
+                    viewModel.userMessageShown()
+                }
+            }
+
+            PostDetailContent(
+                uiState = uiState,
+                snackbarHostState = snackbarHostState,
+                onEditClick = onEditClick,
+                onDeleteClick = { viewModel.requestPostDeleting(uiState.postDetail.id) }
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PostDetailContent(
+    uiState: PostDetailUiState.Success,
+    snackbarHostState: SnackbarHostState,
+    onEditClick: () -> Unit,
+    onDeleteClick: () -> Unit
+) {
+    val postDetail = uiState.postDetail
+    var showDeleteDialog by remember { mutableStateOf(false) }
+
+
+    if (showDeleteDialog) {
+        RecheckDialog(
+            title = stringResource(id = R.string.are_you_sure_you_want_to_delete),
+            onOkClick = onDeleteClick,
+            onDismissRequest = { showDeleteDialog = false },
+            confirmText = stringResource(id = R.string.delete)
+        )
+    }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
+        topBar = {
+            PostDetailTopAppBar(
+                uiState,
+                onEditClick = onEditClick,
+                onDeleteClick = { showDeleteDialog = true }
+            )
+        }
+    ) {
+        LazyColumn(Modifier.padding(it)) {
+            headerItems(
+                title = postDetail.title,
+                writerName = postDetail.writer.name,
+                date = postDetail.date
+            )
+            item {
+                Text(
+                    modifier = Modifier.padding(20.dp),
+                    text = postDetail.content,
+                    style = MaterialTheme.typography.bodyLarge.copy(
+                        color = MaterialTheme.colorScheme.onBackground
+                    )
+                )
+            }
+            item {
+                ThickDivider()
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PostDetailTopAppBar(
+    uiState: PostDetailUiState.Success,
+    onEditClick: () -> Unit,
+    onDeleteClick: () -> Unit
+) {
+    SmallTopAppBar(
+        navigationIcon = {
+            AppBarBackButton()
+        },
+        title = {},
+        actions = {
+            val options = mutableListOf<Int>()
+            if (uiState.canEditPost) {
+                options += R.string.edit
+            }
+            if (uiState.canDeletePost) {
+                options += R.string.delete
+            }
+            if (options.isNotEmpty()) {
+                DropdownButton(
+                    options = options.map { resourceId ->
+                        DropdownOption(
+                            label = stringResource(id = resourceId),
+                            onClick = {
+                                when (resourceId) {
+                                    R.string.edit -> onEditClick()
+                                    R.string.delete -> onDeleteClick()
+                                    else -> throw IllegalArgumentException()
+                                }
+                            },
+                            labelColor = if (resourceId == R.string.delete) {
+                                MaterialTheme.colorScheme.error
+                            } else {
+                                MaterialTheme.colorScheme.onSurface
+                            }
+                        )
+                    }
+                )
+            }
+        }
+    )
+}
+
+private fun LazyListScope.headerItems(title: String, writerName: String, date: String) {
+    item {
+        Column(modifier = Modifier.padding(20.dp)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.headlineMedium.copy(
+                    color = MaterialTheme.colorScheme.onBackground
+                )
+            )
+            Box(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(
+                    id = R.string.post_subtitle,
+                    writerName,
+                    date
+                ),
+                style = MaterialTheme.typography.bodyMedium.copy(
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
+                )
+            )
+        }
+    }
+    item {
+        PocsDivider(startIndent = 20.dp)
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun PostDetailFailureContent(uiState: PostDetailUiState.Failure) {
+    Scaffold(
+        topBar = {
+            SmallTopAppBar(
+                title = {},
+                navigationIcon = { AppBarBackButton() }
+            )
+        }
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(it)
+                .fillMaxSize()
+                .padding(20.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(
+                imageVector = Icons.Default.Error,
+                contentDescription = stringResource(R.string.error_icon),
+                modifier = Modifier.size(96.dp),
+                tint = MaterialTheme.colorScheme.primary
+            )
+            Box(modifier = Modifier.height(16.dp))
+            Text(
+                text = uiState.message ?: stringResource(id = R.string.failed_to_load),
+                style = MaterialTheme.typography.headlineSmall.copy(
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f)
+                ),
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PostDetailContentPreview() {
+    PostDetailContent(
+        uiState = PostDetailUiState.Success(
+            postDetail = PostDetailItemUiState(
+                id = 1,
+                title = "제목입니다",
+                writer = PostWriterUiState(id = 1, name = "김정은"),
+                content = "내용이 들어가는 자리입니다.",
+                date = "어제",
+                category = PostCategory.NOTICE
+            ),
+            canDeletePost = true,
+            canEditPost = true,
+            isDeleteSuccess = false,
+            userMessage = null
+        ),
+        snackbarHostState = SnackbarHostState(),
+        onEditClick = {},
+        onDeleteClick = {}
+    )
+}
+
+@Preview
+@Composable
+fun PostDetailFailureContentPreview() {
+    PostDetailFailureContent(PostDetailUiState.Failure("연결 실패"))
+}

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
@@ -190,15 +190,18 @@ fun PostDetailContent(
                         },
                         onReplyIconClick = {
                             coroutineScope.launch {
-                                commentModalController.showForCreate(parentId = it.id)
+                                commentModalController.showForCreate(parentComment = it)
                             }
                         },
                         onCommentClick = {
                             coroutineScope.launch {
-                                commentModalController.showForCreate(parentId = it.id)
+                                commentModalController.showForCreate(parentComment = it)
                             }
                         },
                     )
+                    item {
+                        Box(Modifier.height(104.dp))
+                    }
                 }
             }
         }

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
@@ -111,6 +111,12 @@ fun PostDetailContent(
             item {
                 ThickDivider()
             }
+            item {
+                CommentAddButton(onClick = {})
+            }
+            item {
+                PocsDivider()
+            }
             commentItems(
                 uiState = uiState.comments,
                 onMoreButtonClick = {},

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
@@ -15,13 +15,13 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.pocs.domain.model.post.PostCategory
 import com.pocs.presentation.R
+import com.pocs.presentation.model.comment.CommentsUiState
+import com.pocs.presentation.model.comment.item.CommentItemUiState
+import com.pocs.presentation.model.comment.item.CommentWriterUiState
 import com.pocs.presentation.model.post.PostDetailUiState
 import com.pocs.presentation.model.post.item.PostDetailItemUiState
 import com.pocs.presentation.model.post.item.PostWriterUiState
-import com.pocs.presentation.view.component.LoadingContent
-import com.pocs.presentation.view.component.PocsDivider
-import com.pocs.presentation.view.component.RecheckDialog
-import com.pocs.presentation.view.component.ThickDivider
+import com.pocs.presentation.view.component.*
 import com.pocs.presentation.view.component.button.AppBarBackButton
 import com.pocs.presentation.view.component.button.DropdownButton
 import com.pocs.presentation.view.component.button.DropdownOption
@@ -111,6 +111,12 @@ fun PostDetailContent(
             item {
                 ThickDivider()
             }
+            commentItems(
+                uiState = uiState.comments,
+                onMoreButtonClick = {},
+                onReplyIconClick = {},
+                onCommentClick = {}
+            )
         }
     }
 }
@@ -227,6 +233,28 @@ private fun PostDetailFailureContent(uiState: PostDetailUiState.Failure) {
 @Preview
 @Composable
 private fun PostDetailContentPreview() {
+    val mockComment = CommentItemUiState(
+        id = 10,
+        parentId = null,
+        childrenCount = 0,
+        postId = 1,
+        isMyComment = true,
+        writer = CommentWriterUiState(
+            userId = 1,
+            name = "홍길동"
+        ),
+        content = "댓글 내용입니다.",
+        date = "오늘"
+    )
+    val commentsUiState = CommentsUiState.Success(
+        comments = listOf(
+            mockComment,
+            mockComment.copy(childrenCount = 1),
+            mockComment.copy(parentId = 10, id = 11),
+            mockComment
+        )
+    )
+
     PostDetailContent(
         uiState = PostDetailUiState.Success(
             postDetail = PostDetailItemUiState(
@@ -235,12 +263,13 @@ private fun PostDetailContentPreview() {
                 writer = PostWriterUiState(id = 1, name = "김정은"),
                 content = "내용이 들어가는 자리입니다.",
                 date = "어제",
-                category = PostCategory.NOTICE
+                category = PostCategory.NOTICE,
             ),
             canDeletePost = true,
             canEditPost = true,
             isDeleteSuccess = false,
-            userMessage = null
+            userMessage = null,
+            comments = commentsUiState
         ),
         snackbarHostState = SnackbarHostState(),
         onEditClick = {},

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
@@ -80,6 +80,7 @@ fun PostDetailScreen(
 @Composable
 fun PostDetailContent(
     uiState: PostDetailUiState.Success,
+    commentModalController: CommentModalController = remember { CommentModalController() },
     snackbarHostState: SnackbarHostState,
     onEditClick: () -> Unit,
     onDeleteClick: () -> Unit,
@@ -115,10 +116,10 @@ fun PostDetailContent(
 
 
     CommentModalBottomSheet(
+        controller = commentModalController,
         onCreated = onCommentCreated,
         onUpdated = onCommentUpdated
-    ) { commentModalController ->
-
+    ) {
         OptionModalBottomSheet(
             options = rememberSaveable {
                 listOf(

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -121,7 +120,7 @@ fun PostDetailContent(
         onUpdated = onCommentUpdated
     ) {
         OptionModalBottomSheet(
-            options = rememberSaveable {
+            options = remember {
                 listOf(
                     Option(
                         imageVector = Icons.Default.Edit,

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailViewModel.kt
@@ -90,6 +90,10 @@ class PostDetailViewModel @Inject constructor(
         // TODO: 구현하기
     }
 
+    fun updateComment(id: Int, comment: String) {
+
+    }
+
     fun deleteComment(comment: CommentItemUiState) {
         // TODO: 구현하기
     }

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailViewModel.kt
@@ -29,7 +29,7 @@ class PostDetailViewModel @Inject constructor(
 
     private var fetchJob: Job? = null
 
-    fun fetchPost(id: Int, isDeleted: Boolean) {
+    fun fetchPost(id: Int) {
         fetchJob?.cancel()
         fetchJob = viewModelScope.launch {
             val result = getPostDetailUseCase(id)
@@ -38,9 +38,8 @@ class PostDetailViewModel @Inject constructor(
                 _uiState.update {
                     PostDetailUiState.Success(
                         postDetail = postDetail.toUiState(),
-                        canEditPost = if (isDeleted) false else canEditPostUseCase(postDetail),
-                        canDeletePost = if (isDeleted) false else canDeletePostUseCase(postDetail),
-                        isDeleted = isDeleted
+                        canEditPost = canEditPostUseCase(postDetail),
+                        canDeletePost = canDeletePostUseCase(postDetail)
                     )
                 }
             } else {
@@ -51,7 +50,6 @@ class PostDetailViewModel @Inject constructor(
     }
 
     fun requestPostDeleting(id: Int) {
-        assert(!(uiState.value as PostDetailUiState.Success).isDeleted)
         viewModelScope.launch {
             val result = deletePostUseCase(postId = id)
 

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailViewModel.kt
@@ -10,6 +10,7 @@ import com.pocs.domain.usecase.post.DeletePostUseCase
 import com.pocs.domain.usecase.post.GetPostDetailUseCase
 import com.pocs.presentation.mapper.toUiState
 import com.pocs.presentation.model.comment.CommentsUiState
+import com.pocs.presentation.model.comment.item.CommentItemUiState
 import com.pocs.presentation.model.post.PostDetailUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
@@ -77,6 +78,10 @@ class PostDetailViewModel @Inject constructor(
         }
 
         _uiState.update { postDetailUiState.copy(comments = comments) }
+    }
+
+    fun addComment(parentComment: CommentItemUiState?, comment: String) {
+        // TODO: 구현하기
     }
 
     fun requestPostDeleting(id: Int) {

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailViewModel.kt
@@ -91,7 +91,7 @@ class PostDetailViewModel @Inject constructor(
     }
 
     fun updateComment(id: Int, comment: String) {
-
+        // TODO: 구현하기
     }
 
     fun deleteComment(comment: CommentItemUiState) {

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailViewModel.kt
@@ -86,7 +86,7 @@ class PostDetailViewModel @Inject constructor(
         _uiState.update { postDetailUiState.copy(comments = comments) }
     }
 
-    fun addComment(parentComment: CommentItemUiState?, comment: String) {
+    fun addComment(parentId: Int?, comment: String) {
         // TODO: 구현하기
     }
 

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailViewModel.kt
@@ -2,6 +2,7 @@ package com.pocs.presentation.view.post.detail
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.pocs.domain.model.user.UserType
 import com.pocs.domain.usecase.auth.GetCurrentUserUseCase
 import com.pocs.domain.usecase.comment.GetCommentsUseCase
 import com.pocs.domain.usecase.post.CanDeletePostUseCase
@@ -69,8 +70,13 @@ class PostDetailViewModel @Inject constructor(
         val result = getCommentsUseCase(postId = postId)
 
         val comments = if (result.isSuccess) {
-            val currentUserId = getCurrentUserUseCase()?.id
-            val comments = result.getOrNull()!!.map { it.toUiState(currentUserId) }
+            val currentUser = getCurrentUserUseCase()
+            val comments = result.getOrNull()!!.map {
+                it.toUiState(
+                    currentUserId = currentUser?.id,
+                    isAdmin = currentUser?.type == UserType.ADMIN
+                )
+            }
             CommentsUiState.Success(comments = comments)
         } else {
             val errorMessage = result.exceptionOrNull()!!.message
@@ -81,6 +87,10 @@ class PostDetailViewModel @Inject constructor(
     }
 
     fun addComment(parentComment: CommentItemUiState?, comment: String) {
+        // TODO: 구현하기
+    }
+
+    fun deleteComment(comment: CommentItemUiState) {
         // TODO: 구현하기
     }
 

--- a/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -24,6 +23,7 @@ import com.pocs.presentation.view.component.HorizontalChips
 import com.pocs.presentation.view.component.PocsDivider
 import com.pocs.presentation.view.component.RecheckHandler
 import com.pocs.presentation.view.component.appbar.EditContentAppBar
+import com.pocs.presentation.view.component.textfield.SimpleTextField
 import kotlinx.coroutines.launch
 
 @Composable
@@ -141,35 +141,6 @@ fun PostCategoryChips(
         itemLabelBuilder = { stringResource(id = it.koreanStringResource) },
         selectedItem = selectedCategory,
         onItemClick = onClick
-    )
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun SimpleTextField(
-    hint: String,
-    value: String,
-    maxLength: Int,
-    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
-    onValueChange: (String) -> Unit,
-    modifier: Modifier
-) {
-    TextField(
-        colors = TextFieldDefaults.textFieldColors(
-            focusedIndicatorColor = Color.Transparent,
-            disabledIndicatorColor = Color.Transparent,
-            unfocusedIndicatorColor = Color.Transparent,
-            containerColor = Color.Transparent
-        ),
-        keyboardOptions = keyboardOptions,
-        placeholder = { Text(hint) },
-        value = value,
-        onValueChange = {
-            if (it.length <= maxLength) {
-                onValueChange(it)
-            }
-        },
-        modifier = modifier
     )
 }
 

--- a/presentation/src/main/java/com/pocs/presentation/view/user/detail/UserDetailScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/user/detail/UserDetailScreen.kt
@@ -29,6 +29,8 @@ import com.pocs.presentation.view.component.button.AppBarBackButton
 import com.pocs.presentation.view.component.FailureContent
 import com.pocs.presentation.view.component.LoadingContent
 import com.pocs.presentation.view.component.RecheckDialog
+import com.pocs.presentation.view.component.button.DropdownButton
+import com.pocs.presentation.view.component.button.DropdownOption
 import com.pocs.presentation.view.post.by.user.PostByUserActivity
 import com.pocs.presentation.view.user.edit.UserEditActivity
 import kotlinx.coroutines.launch
@@ -211,50 +213,31 @@ fun UserDetailTopBar(
         navigationIcon = { AppBarBackButton() },
         actions = {
             if (displayActions) {
-                var showDropdownMenu by remember { mutableStateOf(false) }
-                val options = remember(isUserKicked) {
-                    if (isUserKicked) {
-                        listOf(R.string.see_user_post)
-                    } else {
-                        listOf(R.string.see_user_post, R.string.kick)
-                    }
+                val options = mutableListOf(R.string.see_user_post)
+
+                if (!isUserKicked) {
+                    options += R.string.kick
                 }
 
-                IconButton(onClick = { showDropdownMenu = !showDropdownMenu }) {
-                    Icon(
-                        imageVector = Icons.Filled.MoreVert,
-                        contentDescription = stringResource(id = R.string.more_info_button)
-                    )
-                }
-                DropdownMenu(
-                    expanded = showDropdownMenu,
-                    onDismissRequest = { showDropdownMenu = false },
-                ) {
-                    options.forEach { stringResourceId ->
-                        DropdownMenuItem(
+                DropdownButton(
+                    options = options.map { resourceId ->
+                        DropdownOption(
+                            label = stringResource(resourceId),
                             onClick = {
-                                when (stringResourceId) {
+                                when (resourceId) {
                                     R.string.kick -> onKickClick()
                                     R.string.see_user_post -> onSeeUsersPostClick()
                                     else -> throw IllegalArgumentException()
                                 }
-                                showDropdownMenu = false
                             },
-                            text = {
-                                Text(
-                                    text = stringResource(stringResourceId),
-                                    style = MaterialTheme.typography.bodyLarge.copy(
-                                        color = if (stringResourceId == R.string.kick) {
-                                            MaterialTheme.colorScheme.error
-                                        } else {
-                                            MaterialTheme.colorScheme.onSurface
-                                        }
-                                    )
-                                )
+                            labelColor = if (resourceId == R.string.kick) {
+                                MaterialTheme.colorScheme.error
+                            } else {
+                                MaterialTheme.colorScheme.onSurface
                             }
                         )
-                    }
-                }
+                    },
+                )
             }
         }
     )

--- a/presentation/src/main/res/layout/activity_post_detail.xml
+++ b/presentation/src/main/res/layout/activity_post_detail.xml
@@ -35,18 +35,6 @@
             android:orientation="vertical">
 
             <TextView
-                android:id="@+id/deleted"
-                style="?attr/textAppearanceBodyMedium"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="20dp"
-                android:layout_marginTop="8dp"
-                android:text="@string/deleted"
-                android:textColor="?attr/colorError"
-                android:visibility="gone"
-                tools:textColor="#ff0000" />
-
-            <TextView
                 android:id="@+id/title"
                 style="?attr/textAppearanceHeadlineMedium"
                 android:layout_width="match_parent"

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -98,6 +98,9 @@
     <string name="add_comment">댓글 추가…</string>
     <string name="add_reply">답글 추가…</string>
     <string name="send_comment">댓글 제출</string>
+    <string name="stop">그만두기</string>
+    <string name="keep_writing">계속작성</string>
+    <string name="stop_writing">작성을 그만둘까요?</string>
     <string-array name="admin_tab">
         <item>전체 게시글</item>
         <item>회원목록</item>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -62,6 +62,7 @@
     <string name="hide_password">비밀번호 숨기기</string>
     <string name="failed_to_update">수정에 실패했습니다.</string>
     <string name="more_info_button">더보기 버튼</string>
+    <string name="comment_info_button">댓글 정보 버튼</string>
     <string name="is_kicked">탈퇴됨</string>
     <string name="create_user">회원 생성</string>
     <string name="type">타입</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -92,7 +92,7 @@
     <string name="all">전체</string>
     <string name="best">인기</string>
     <string name="writing_time">작성시간</string>
-    <string name="child_comment_count">대댓글 갯수</string>
+    <string name="reply_count">답글 갯수</string>
     <string name="error_icon">에러 아이콘</string>
     <string name="question_answer">질문답변</string>
     <string name="failed_to_load_comment">댓글을 불러올 수 없습니다</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -103,6 +103,7 @@
     <string name="keep_writing">계속작성</string>
     <string name="stop_writing">작성을 그만둘까요?</string>
     <string name="comment_add_button">댓글 추가 버튼</string>
+    <string name="comment_text_field">댓글 입력 창</string>
     <string-array name="admin_tab">
         <item>전체 게시글</item>
         <item>회원목록</item>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -95,6 +95,7 @@
     <string name="error_icon">에러 아이콘</string>
     <string name="question_answer">질문답변</string>
     <string name="failed_to_load_comment">댓글을 불러올 수 없습니다</string>
+    <string name="add_comment">댓글 추가...</string>
     <string-array name="admin_tab">
         <item>전체 게시글</item>
         <item>회원목록</item>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -94,6 +94,7 @@
     <string name="child_comment_count">대댓글 갯수</string>
     <string name="error_icon">에러 아이콘</string>
     <string name="question_answer">질문답변</string>
+    <string name="failed_to_load_comment">댓글을 불러올 수 없습니다</string>
     <string-array name="admin_tab">
         <item>전체 게시글</item>
         <item>회원목록</item>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -101,6 +101,7 @@
     <string name="stop">그만두기</string>
     <string name="keep_writing">계속작성</string>
     <string name="stop_writing">작성을 그만둘까요?</string>
+    <string name="comment_add_button">댓글 추가 버튼</string>
     <string-array name="admin_tab">
         <item>전체 게시글</item>
         <item>회원목록</item>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -95,7 +95,9 @@
     <string name="error_icon">에러 아이콘</string>
     <string name="question_answer">질문답변</string>
     <string name="failed_to_load_comment">댓글을 불러올 수 없습니다</string>
-    <string name="add_comment">댓글 추가...</string>
+    <string name="add_comment">댓글 추가…</string>
+    <string name="add_reply">답글 추가…</string>
+    <string name="send_comment">댓글 제출</string>
     <string-array name="admin_tab">
         <item>전체 게시글</item>
         <item>회원목록</item>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -7,11 +7,11 @@
     <string name="knowhow">노하우</string>
     <string name="reference">레퍼런스</string>
     <string name="user_list">회원 목록</string>
-    <string name="post_subtitle">%s · %s</string>
-    <string name="middle_dot">\u0020·\u0020</string>
-    <string name="deleted_post_subtitle_prefix">삭제됨 ·\u0020</string>
-    <string name="user_item_subtitle">%s · %s기</string>
-    <string name="kicked_user_item_subtitle">탈퇴됨 · %s · %s기</string>
+    <string name="post_subtitle">%s • %s</string>
+    <string name="middle_dot">\u0020•\u0020</string>
+    <string name="deleted_post_subtitle_prefix">삭제됨 •\u0020</string>
+    <string name="user_item_subtitle">%s • %s기</string>
+    <string name="kicked_user_item_subtitle">탈퇴됨 • %s • %s기</string>
     <string name="fail_to_connect">연결에 실패하였습니다.</string>
     <string name="retry">재시도</string>
     <string name="user_image">회원 사진</string>
@@ -90,6 +90,8 @@
     <string name="logout_dialog_title">정말로 로그아웃 하시겠습니까?</string>
     <string name="all">전체</string>
     <string name="best">인기</string>
+    <string name="writing_time">작성시간</string>
+    <string name="child_comment_count">대댓글 갯수</string>
     <string name="question_answer">질문답변</string>
     <string-array name="admin_tab">
         <item>전체 게시글</item>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -92,6 +92,7 @@
     <string name="best">인기</string>
     <string name="writing_time">작성시간</string>
     <string name="child_comment_count">대댓글 갯수</string>
+    <string name="error_icon">에러 아이콘</string>
     <string name="question_answer">질문답변</string>
     <string-array name="admin_tab">
         <item>전체 게시글</item>

--- a/presentation/src/test/java/com/pocs/presentation/PostDetailViewModelTest.kt
+++ b/presentation/src/test/java/com/pocs/presentation/PostDetailViewModelTest.kt
@@ -101,7 +101,7 @@ class PostDetailViewModelTest {
 
         assertEquals(
             exception.message,
-            (viewModel.uiState.value as PostDetailUiState.Success).errorMessage
+            (viewModel.uiState.value as PostDetailUiState.Success).userMessage
         )
     }
 
@@ -114,6 +114,6 @@ class PostDetailViewModelTest {
 
         viewModel.requestPostDeleting(1)
 
-        assertEquals(true, (viewModel.uiState.value as PostDetailUiState.Success).isSuccessToDelete)
+        assertEquals(true, (viewModel.uiState.value as PostDetailUiState.Success).isDeleteSuccess)
     }
 }

--- a/presentation/src/test/java/com/pocs/presentation/PostDetailViewModelTest.kt
+++ b/presentation/src/test/java/com/pocs/presentation/PostDetailViewModelTest.kt
@@ -62,7 +62,7 @@ class PostDetailViewModelTest {
             viewModel.uiState.collect()
         }
 
-        viewModel.fetchPost(mockPostDetail1.id, isDeleted = false)
+        viewModel.fetchPost(mockPostDetail1.id)
 
         assertTrue(viewModel.uiState.value is PostDetailUiState.Success)
 
@@ -78,7 +78,7 @@ class PostDetailViewModelTest {
             viewModel.uiState.collect()
         }
 
-        viewModel.fetchPost(mockPostDetail1.id, isDeleted = false)
+        viewModel.fetchPost(mockPostDetail1.id)
 
         assertTrue(viewModel.uiState.value is PostDetailUiState.Failure)
         assertEquals(
@@ -95,7 +95,7 @@ class PostDetailViewModelTest {
         postRepository.postDetailResult = Result.success(mockPostDetail1)
         postRepository.deletePostResult = Result.failure(exception)
         authRepository.currentUser.value = mockNormalUserDetail.copy(id = mockPostDetail1.writer.id)
-        viewModel.fetchPost(mockPostDetail1.id, isDeleted = false)
+        viewModel.fetchPost(mockPostDetail1.id)
 
         viewModel.requestPostDeleting(1)
 
@@ -110,7 +110,7 @@ class PostDetailViewModelTest {
         postRepository.postDetailResult = Result.success(mockPostDetail1)
         postRepository.deletePostResult = Result.success(Unit)
         authRepository.currentUser.value = mockNormalUserDetail.copy(id = mockPostDetail1.writer.id)
-        viewModel.fetchPost(mockPostDetail1.id, isDeleted = false)
+        viewModel.fetchPost(mockPostDetail1.id)
 
         viewModel.requestPostDeleting(1)
 

--- a/presentation/src/test/java/com/pocs/presentation/PostDetailViewModelTest.kt
+++ b/presentation/src/test/java/com/pocs/presentation/PostDetailViewModelTest.kt
@@ -1,5 +1,7 @@
 package com.pocs.presentation
 
+import com.pocs.domain.usecase.auth.GetCurrentUserUseCase
+import com.pocs.domain.usecase.comment.GetCommentsUseCase
 import com.pocs.domain.usecase.post.CanDeletePostUseCase
 import com.pocs.domain.usecase.post.CanEditPostUseCase
 import com.pocs.domain.usecase.post.DeletePostUseCase
@@ -41,7 +43,9 @@ class PostDetailViewModelTest {
         GetPostDetailUseCase(postRepository),
         DeletePostUseCase(postRepository, authRepository),
         CanEditPostUseCase(authRepository),
-        CanDeletePostUseCase(authRepository)
+        CanDeletePostUseCase(authRepository),
+        GetCommentsUseCase(),
+        GetCurrentUserUseCase(authRepository)
     )
 
     @Before

--- a/test-library/src/main/java/com/pocs/test_library/mock/Comment.kt
+++ b/test-library/src/main/java/com/pocs/test_library/mock/Comment.kt
@@ -3,7 +3,7 @@ package com.pocs.test_library.mock
 import com.pocs.presentation.model.comment.item.CommentItemUiState
 import com.pocs.presentation.model.comment.item.CommentWriterUiState
 
-val mockComment = CommentItemUiState(
+val mockCommentItemUiState = CommentItemUiState(
     id = 10,
     parentId = null,
     childrenCount = 0,

--- a/test-library/src/main/java/com/pocs/test_library/mock/Comment.kt
+++ b/test-library/src/main/java/com/pocs/test_library/mock/Comment.kt
@@ -1,0 +1,19 @@
+package com.pocs.test_library.mock
+
+import com.pocs.presentation.model.comment.item.CommentItemUiState
+import com.pocs.presentation.model.comment.item.CommentWriterUiState
+
+val mockComment = CommentItemUiState(
+    id = 10,
+    parentId = null,
+    childrenCount = 0,
+    postId = 1,
+    canEdit = true,
+    canDelete = true,
+    writer = CommentWriterUiState(
+        userId = 1,
+        name = "홍길동"
+    ),
+    content = "댓글 내용입니다.",
+    date = "오늘"
+)


### PR DESCRIPTION
Resolves #163, resolves #164

코드 분량이 많아 저에게 설명을 듣고나서 리뷰해주시면 감사하겠습니다.

## 변경사항
- PostDetail 화면을 view에서 compose로 전환했습니다.
- PocsModalBottomSheetLayout을 이용하여 댓글 입력 창 기능을 구현했습니다.
  - PocsModalBottomSheetLayout는 ModalBottomSheetLayout를 복붙하여 만들었습니다. 기존의 ModalBottomSheetLayout는 저희가 원하는 기능이 없거나 부족하여 따로 복붙및 수정하여 만들었습니다.
  - **!!주의!!: 앞으로 compose 코드를 작성할 때 항상 material 3 컴포넌트를 사용하는지 확인해야합니다!! 이번에 추가된 compose-material 라이브러리가 대부분 중복되기 때문입니다. 이 라이브러리는 구형의 material 2 디자인입니다. 그러니 꼭 material 3 컴포넌트를 사용해야합니다.**(ex: MaterialTheme, Text 등등)
- `CommentModalBottomSheet`를 구현했습니다. 이것은 `CommetModalController`를 이용하여 컨트롤 가능하도록 구현했습니다.
- `OptionModalBottonSheet`를 구현했습니다. 이것도 `OptionModalController`를 이용하여 컨트롤 가능합니다.
- 뷰모델은 구현하지 않았습니다. 이는 벡엔드 구축시 구현할 예정입니다.

## 주요로직
- 게시글을 불러오고 성공한 경우 댓글을 불러오도록 했습니다.
- 답글(대댓글)이면 색상이 다르고 답글 아이콘이 없습니다. 
- 내 댓글인 경우 댓글 삭제, 편집이 가능합니다.
- 어드민의 경우 댓글 삭제 가능합니다.
- 댓글입력
  - `댓글 추가...`버튼을 누르면 댓글 입력 창이 나옵니다.
  - 댓글, 답글 아이콘을 누르면 **답글**입력 창이 나옵니다.
  - 더보기버튼(떙떙이 버튼)을 누르면 `편집, 삭제` 버튼이 있는 bottom sheet가 나옵니다.
  - 댓글내용을 입력하면 전송 버튼이 보입니다.(댓글을 편집하는 경우는 내용이 수정되어야 보입니다.)
  - 댓글 작성 중 뒤로가기를 누르면 다시 묻는 다이어로그가 보입니다.
  - 댓글 삭제 버튼을 누르면 다시 묻는 다이어로그가 보입니다.


https://user-images.githubusercontent.com/57604817/184662765-5e82ac68-8606-4994-a049-b5c540a0f050.mov


## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [ ] Action에서 진행하는 테스트를 모두 통과했는가?
- [x] 수정 사항을 검증할 테스트를 추가하였는가?
- [ ] 리뷰를 받았는가?