### PR TITLE
불안정한 테스트 수정

### DIFF
--- a/presentation/src/androidTest/java/com/pocs/presentation/KeyboardHelper.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/KeyboardHelper.kt
@@ -1,6 +1,7 @@
 package com.pocs.presentation
 
 import android.content.Context
+import android.graphics.Rect
 import android.os.Build
 import android.view.View
 import android.view.WindowInsets
@@ -18,7 +19,7 @@ import java.util.concurrent.TimeUnit
  */
 class KeyboardHelper(
     private val composeRule: ComposeTestRule,
-    private val timeout: Long = 15_000L
+    private val timeout: Long = 1_000L
 ) {
     /**
      * The [View] hosting the compose rule's content. Must be set before calling any methods on this
@@ -64,7 +65,7 @@ class KeyboardHelper(
         return if (Build.VERSION.SDK_INT >= 30) {
             isSoftwareKeyboardShownWithInsets()
         } else {
-            isSoftwareKeyboardShownWithImm()
+            isSoftwareKeyboardShownWithScreenHeight()
         }
     }
 
@@ -74,10 +75,17 @@ class KeyboardHelper(
                 view.rootWindowInsets.isVisible(WindowInsets.Type.ime())
     }
 
-    private fun isSoftwareKeyboardShownWithImm(): Boolean {
-        // TODO(b/163742556): This is just a proxy for software keyboard visibility. Find a better
-        //  way to check if the software keyboard is shown.
-        return imm.isAcceptingText
+    private fun isSoftwareKeyboardShownWithScreenHeight(): Boolean {
+        val r = Rect()
+        view.getWindowVisibleDisplayFrame(r)
+        val screenHeight = view.rootView.height
+
+        // r.bottom is the position above soft keypad or device button.
+        // if keypad is shown, the r.bottom is smaller than that before.
+        val keypadHeight = screenHeight - r.bottom
+
+        // 0.15 ratio is perhaps enough to determine keypad height.
+        return keypadHeight > screenHeight * 0.15
     }
 
     private fun hideKeyboardWithImm() {

--- a/presentation/src/androidTest/java/com/pocs/presentation/KeyboardHelper.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/KeyboardHelper.kt
@@ -1,0 +1,128 @@
+package com.pocs.presentation
+
+import android.content.Context
+import android.os.Build
+import android.view.View
+import android.view.WindowInsets
+import android.view.WindowInsetsAnimation
+import android.view.inputmethod.InputMethodManager
+import androidx.annotation.RequiresApi
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import org.junit.Assert.assertTrue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * Helper methods for hiding and showing the keyboard in tests.
+ * Must set [view] before calling any methods on this class.
+ */
+class KeyboardHelper(
+    private val composeRule: ComposeTestRule,
+    private val timeout: Long = 15_000L
+) {
+    /**
+     * The [View] hosting the compose rule's content. Must be set before calling any methods on this
+     * class.
+     */
+    lateinit var view: View
+    private val imm by lazy {
+        view.context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+    }
+
+    /**
+     * Requests the keyboard to be hidden without waiting for it.
+     * Should be called from the main thread.
+     */
+    fun hideKeyboard() {
+        if (Build.VERSION.SDK_INT >= 30) {
+            hideKeyboardWithInsets()
+        } else {
+            hideKeyboardWithImm()
+        }
+    }
+
+    /**
+     * Blocks until the [timeout] or the keyboard's visibility matches [visible].
+     * May be called from the test thread or the main thread.
+     */
+    fun waitForKeyboardVisibility(visible: Boolean) {
+        waitUntil(timeout) {
+            isSoftwareKeyboardShown() == visible
+        }
+    }
+
+    fun hideKeyboardIfShown() {
+        composeRule.runOnIdle {
+            if (isSoftwareKeyboardShown()) {
+                hideKeyboard()
+                waitForKeyboardVisibility(visible = false)
+            }
+        }
+    }
+
+    fun isSoftwareKeyboardShown(): Boolean {
+        return if (Build.VERSION.SDK_INT >= 30) {
+            isSoftwareKeyboardShownWithInsets()
+        } else {
+            isSoftwareKeyboardShownWithImm()
+        }
+    }
+
+    @RequiresApi(30)
+    private fun isSoftwareKeyboardShownWithInsets(): Boolean {
+        return view.rootWindowInsets != null &&
+                view.rootWindowInsets.isVisible(WindowInsets.Type.ime())
+    }
+
+    private fun isSoftwareKeyboardShownWithImm(): Boolean {
+        // TODO(b/163742556): This is just a proxy for software keyboard visibility. Find a better
+        //  way to check if the software keyboard is shown.
+        return imm.isAcceptingText
+    }
+
+    private fun hideKeyboardWithImm() {
+        imm.hideSoftInputFromWindow(view.windowToken, 0)
+    }
+
+    @RequiresApi(30)
+    private fun hideKeyboardWithInsets() {
+        view.windowInsetsController?.hide(WindowInsets.Type.ime())
+    }
+
+    private fun waitUntil(timeout: Long, condition: () -> Boolean) {
+        if (Build.VERSION.SDK_INT >= 30) {
+            view.waitUntil(timeout, condition)
+        } else {
+            composeRule.waitUntil(timeout, condition)
+        }
+    }
+}
+
+@RequiresApi(30)
+fun View.waitUntil(timeoutMillis: Long, condition: () -> Boolean) {
+    val latch = CountDownLatch(1)
+    rootView.setWindowInsetsAnimationCallback(
+        InsetAnimationCallback {
+            if (condition()) {
+                latch.countDown()
+            }
+        }
+    )
+    val conditionMet = latch.await(timeoutMillis, TimeUnit.MILLISECONDS)
+    assertTrue(conditionMet)
+}
+
+@RequiresApi(30)
+private class InsetAnimationCallback(val block: () -> Unit) :
+    WindowInsetsAnimation.Callback(DISPATCH_MODE_CONTINUE_ON_SUBTREE) {
+
+    override fun onProgress(
+        insets: WindowInsets,
+        runningAnimations: MutableList<WindowInsetsAnimation>
+    ) = insets
+
+    override fun onEnd(animation: WindowInsetsAnimation) {
+        block()
+        super.onEnd(animation)
+    }
+}

--- a/presentation/src/androidTest/java/com/pocs/presentation/PostDetailScreenTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/PostDetailScreenTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.annotation.StringRes
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.platform.app.InstrumentationRegistry
@@ -410,11 +411,13 @@ class PostDetailScreenTest {
     }
 
     @Test
-    fun shouldHideCommentBottomSheet_WhenClickSendButton() {
+    fun shouldHideKeyboard_WhenClickSendButton() {
         composeRule.run {
             val controller = CommentModalController()
+            val keyboardHelper = KeyboardHelper(composeRule)
 
             setContent {
+                keyboardHelper.view = LocalView.current
                 val snackbarHostState = remember { SnackbarHostState() }
 
                 PostDetailContent(
@@ -434,8 +437,8 @@ class PostDetailScreenTest {
             onNodeWithContentDescription(getString(R.string.comment_text_field)).performTextInput(text)
             onNodeWithContentDescription(getString(R.string.send_comment)).performClick()
 
-            onNodeWithText(text).assertDoesNotExist()
-            assertTrue(controller.isCleared)
+            keyboardHelper.waitForKeyboardVisibility(false)
+            assertFalse(keyboardHelper.isSoftwareKeyboardShown())
         }
     }
 }


### PR DESCRIPTION
아래의 코드에서 키보드를 숨기는 `keyboardController?.hide()` 코드가 호출되고 `controller.hide()`가 호출될 때 테스트에 가끔 실패합니다. 원인을 파악하지 못하였기 때문에 테스트를 불가피하게 수정했습니다.
https://github.com/hansung-pocs/blog-android/blob/e89ed3bd43770e8a4a5dfaa25673d0a05c5b4e90/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt#L176-L179

KeyboardHelper는 https://github.com/androidx/androidx/blob/androidx-main/compose/foundation/foundation/src/androidAndroidTest/kotlin/androidx/compose/foundation/text/KeyboardActionsTest.kt 에서 구했습니다.

## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [x] Action에서 진행하는 테스트를 모두 통과했는가?
- [ ] 수정 사항을 검증할 테스트를 추가하였는가?
- [x] 리뷰를 받았는가?