### PR TITLE
모든 API 요청에 세션 토큰 헤더 포함하도록 수정

### DIFF
--- a/data/src/main/java/com/pocs/data/api/AuthApi.kt
+++ b/data/src/main/java/com/pocs/data/api/AuthApi.kt
@@ -1,5 +1,6 @@
 package com.pocs.data.api
 
+import com.pocs.data.di.NetworkModule.Companion.TOKEN_HEADER_KEY
 import com.pocs.data.model.ResponseBody
 import com.pocs.data.model.auth.LoginRequestBody
 import com.pocs.data.model.auth.LoginResponseData
@@ -19,11 +20,11 @@ interface AuthApi {
 
     @POST("auth/logout")
     suspend fun logout(
-        @Header("x-pocs-session-token") token: String
+        @Header(TOKEN_HEADER_KEY) token: String
     ): Response<ResponseBody<Unit>>
 
     @POST("auth/validation")
     suspend fun isSessionValid(
-        @Header("x-pocs-session-token") token: String
+        @Header(TOKEN_HEADER_KEY) token: String
     ): Response<ResponseBody<SessionValidResponseData>>
 }

--- a/data/src/main/java/com/pocs/data/di/NetworkModule.kt
+++ b/data/src/main/java/com/pocs/data/di/NetworkModule.kt
@@ -6,6 +6,7 @@ import com.pocs.data.api.AuthApi
 import com.pocs.data.api.PostApi
 import com.pocs.data.api.UserApi
 import com.pocs.data.mapper.EnumConverterFactory
+import com.pocs.data.source.AuthLocalDataSource
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -23,11 +24,12 @@ class NetworkModule {
 
     companion object {
         const val BASE_URL = BuildConfig.SERVER_URL
+        const val TOKEN_HEADER_KEY = "x-pocs-session-token"
     }
 
     @Provides
     @Singleton
-    fun provideHttpClient(): OkHttpClient {
+    fun provideHttpClient(authLocalDataSource: AuthLocalDataSource): OkHttpClient {
         val client = OkHttpClient.Builder()
             .readTimeout(5, TimeUnit.SECONDS)
             .connectTimeout(5, TimeUnit.SECONDS)
@@ -35,6 +37,17 @@ class NetworkModule {
             .addInterceptor(HttpLoggingInterceptor().apply {
                 this.level = HttpLoggingInterceptor.Level.BODY
             })
+            .addInterceptor {
+                val authLocalData = authLocalDataSource.getData()
+                val newRequest = it.request()
+                if (authLocalData != null) {
+                    newRequest.newBuilder().addHeader(
+                        name = TOKEN_HEADER_KEY,
+                        value = authLocalData.sessionToken
+                    ).build()
+                }
+                it.proceed(newRequest)
+            }
 
         return client.build()
     }

--- a/data/src/main/java/com/pocs/data/source/AuthLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/pocs/data/source/AuthLocalDataSourceImpl.kt
@@ -10,17 +10,26 @@ class AuthLocalDataSourceImpl @Inject constructor(
     @Named("auth") private val sharedPreferences: SharedPreferences
 ) : AuthLocalDataSource {
 
+    private var data: AuthLocalData? = null
+
     override fun getData(): AuthLocalData? {
+        // 이미 전에 데이터를 읽어 값이 있는 경우에는 곧바로 데이터를 반환한다.
+        if (data != null) {
+            return data
+        }
         val json = sharedPreferences.getString(AUTH_LOCAL_DATA_PREFS_KEY, null) ?: return null
-        return Gson().fromJson(json, AuthLocalData::class.java)
+        data = Gson().fromJson(json, AuthLocalData::class.java)
+        return data
     }
 
     override fun setData(authLocalData: AuthLocalData) {
+        data = authLocalData
         val json = Gson().toJson(authLocalData)
         sharedPreferences.edit().putString(AUTH_LOCAL_DATA_PREFS_KEY, json).apply()
     }
 
     override fun clear() {
+        data = null
         sharedPreferences.edit().remove(AUTH_LOCAL_DATA_PREFS_KEY).apply()
     }
 


### PR DESCRIPTION
Resolves #179 

OkHttp client에 인터셉터를 추가하여 API 요청할 때마다 세션 토큰이 존재하면 세션 토큰을 포함하도록 수정했습니다.
추가로 `AuthLocalDataSource.getData` 함수가 자주 호출되기 때문에 클래스 변수로 캐싱하여 빠르게 접근할 수 있도록 했습니다.

## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [ ] Action에서 진행하는 테스트를 모두 통과했는가?
- [ ] 수정 사항을 검증할 테스트를 추가하였는가?
- [ ] 리뷰를 받았는가?