### PR TITLE
헤더에 토큰 추가하는 로직 문제수정 및 토큰 헤더 중복추가 않도록 수정

### DIFF
--- a/data/src/main/java/com/pocs/data/api/AuthApi.kt
+++ b/data/src/main/java/com/pocs/data/api/AuthApi.kt
@@ -1,13 +1,11 @@
 package com.pocs.data.api
 
-import com.pocs.data.di.NetworkModule.Companion.TOKEN_HEADER_KEY
 import com.pocs.data.model.ResponseBody
 import com.pocs.data.model.auth.LoginRequestBody
 import com.pocs.data.model.auth.LoginResponseData
 import com.pocs.data.model.auth.SessionValidResponseData
 import retrofit2.Response
 import retrofit2.http.Body
-import retrofit2.http.Header
 import retrofit2.http.Headers
 import retrofit2.http.POST
 
@@ -19,12 +17,8 @@ interface AuthApi {
     ): Response<ResponseBody<LoginResponseData>>
 
     @POST("auth/logout")
-    suspend fun logout(
-        @Header(TOKEN_HEADER_KEY) token: String
-    ): Response<ResponseBody<Unit>>
+    suspend fun logout(): Response<ResponseBody<Unit>>
 
     @POST("auth/validation")
-    suspend fun isSessionValid(
-        @Header(TOKEN_HEADER_KEY) token: String
-    ): Response<ResponseBody<SessionValidResponseData>>
+    suspend fun isSessionValid(): Response<ResponseBody<SessionValidResponseData>>
 }

--- a/data/src/main/java/com/pocs/data/di/NetworkModule.kt
+++ b/data/src/main/java/com/pocs/data/di/NetworkModule.kt
@@ -23,8 +23,8 @@ import javax.inject.Singleton
 class NetworkModule {
 
     companion object {
-        const val BASE_URL = BuildConfig.SERVER_URL
-        const val TOKEN_HEADER_KEY = "x-pocs-session-token"
+        private const val BASE_URL = BuildConfig.SERVER_URL
+        private const val TOKEN_HEADER_KEY = "x-pocs-session-token"
     }
 
     @Provides
@@ -39,9 +39,9 @@ class NetworkModule {
             })
             .addInterceptor {
                 val authLocalData = authLocalDataSource.getData()
-                val newRequest = it.request()
+                var newRequest = it.request()
                 if (authLocalData != null) {
-                    newRequest.newBuilder().addHeader(
+                    newRequest = newRequest.newBuilder().addHeader(
                         name = TOKEN_HEADER_KEY,
                         value = authLocalData.sessionToken
                     ).build()

--- a/data/src/main/java/com/pocs/data/source/AuthLocalDataSource.kt
+++ b/data/src/main/java/com/pocs/data/source/AuthLocalDataSource.kt
@@ -3,6 +3,7 @@ package com.pocs.data.source
 import com.pocs.data.model.auth.AuthLocalData
 
 interface AuthLocalDataSource {
+    fun hasData(): Boolean
     fun getData(): AuthLocalData?
     fun setData(authLocalData: AuthLocalData)
     fun clear()

--- a/data/src/main/java/com/pocs/data/source/AuthLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/pocs/data/source/AuthLocalDataSourceImpl.kt
@@ -12,6 +12,10 @@ class AuthLocalDataSourceImpl @Inject constructor(
 
     private var data: AuthLocalData? = null
 
+    override fun hasData(): Boolean {
+        return getData() != null
+    }
+
     override fun getData(): AuthLocalData? {
         // 이미 전에 데이터를 읽어 값이 있는 경우에는 곧바로 데이터를 반환한다.
         if (data != null) {

--- a/data/src/main/java/com/pocs/data/source/AuthRemoteDataSource.kt
+++ b/data/src/main/java/com/pocs/data/source/AuthRemoteDataSource.kt
@@ -4,11 +4,10 @@ import com.pocs.data.model.ResponseBody
 import com.pocs.data.model.auth.LoginRequestBody
 import com.pocs.data.model.auth.LoginResponseData
 import com.pocs.data.model.auth.SessionValidResponseData
-import com.pocs.data.model.user.UserDto
 import retrofit2.Response
 
 interface AuthRemoteDataSource {
     suspend fun login(loginRequestBody: LoginRequestBody): Response<ResponseBody<LoginResponseData>>
-    suspend fun logout(token: String): Response<ResponseBody<Unit>>
-    suspend fun isSessionValid(token: String): Response<ResponseBody<SessionValidResponseData>>
+    suspend fun logout(): Response<ResponseBody<Unit>>
+    suspend fun isSessionValid(): Response<ResponseBody<SessionValidResponseData>>
 }

--- a/data/src/main/java/com/pocs/data/source/AuthRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/pocs/data/source/AuthRemoteDataSourceImpl.kt
@@ -1,10 +1,7 @@
 package com.pocs.data.source
 
 import com.pocs.data.api.AuthApi
-import com.pocs.data.model.ResponseBody
 import com.pocs.data.model.auth.LoginRequestBody
-import com.pocs.data.model.auth.SessionValidResponseData
-import retrofit2.Response
 import javax.inject.Inject
 
 class AuthRemoteDataSourceImpl @Inject constructor(
@@ -13,9 +10,7 @@ class AuthRemoteDataSourceImpl @Inject constructor(
 
     override suspend fun login(loginRequestBody: LoginRequestBody) = api.login(loginRequestBody)
 
-    override suspend fun logout(token: String) = api.logout(token)
+    override suspend fun logout() = api.logout()
 
-    override suspend fun isSessionValid(
-        token: String
-    ): Response<ResponseBody<SessionValidResponseData>> = api.isSessionValid(token)
+    override suspend fun isSessionValid() = api.isSessionValid()
 }

--- a/test-library/src/main/java/com/pocs/test_library/fake/source/local/FakeAuthLocalDataSource.kt
+++ b/test-library/src/main/java/com/pocs/test_library/fake/source/local/FakeAuthLocalDataSource.kt
@@ -8,6 +8,10 @@ class FakeAuthLocalDataSource @Inject constructor() : AuthLocalDataSource {
 
     var authLocalData: AuthLocalData? = null
 
+    override fun hasData(): Boolean {
+        return getData() != null
+    }
+
     override fun getData(): AuthLocalData? {
         return authLocalData
     }

--- a/test-library/src/main/java/com/pocs/test_library/fake/source/remote/FakeAuthRemoteDataSource.kt
+++ b/test-library/src/main/java/com/pocs/test_library/fake/source/remote/FakeAuthRemoteDataSource.kt
@@ -4,7 +4,6 @@ import com.pocs.data.model.ResponseBody
 import com.pocs.data.model.auth.LoginRequestBody
 import com.pocs.data.model.auth.LoginResponseData
 import com.pocs.data.model.auth.SessionValidResponseData
-import com.pocs.data.model.user.UserDto
 import com.pocs.data.source.AuthRemoteDataSource
 import com.pocs.test_library.mock.errorResponse
 import retrofit2.Response
@@ -24,11 +23,11 @@ class FakeAuthRemoteDataSource @Inject constructor() : AuthRemoteDataSource {
         return loginResponse
     }
 
-    override suspend fun logout(token: String): Response<ResponseBody<Unit>> {
+    override suspend fun logout(): Response<ResponseBody<Unit>> {
         return logoutResponse
     }
 
-    override suspend fun isSessionValid(token: String): Response<ResponseBody<SessionValidResponseData>> {
+    override suspend fun isSessionValid(): Response<ResponseBody<SessionValidResponseData>> {
         isSessionValidInnerLambda()
         return isSessionValidResponse
     }


### PR DESCRIPTION
Fixes #179 

아래의 코드에서 `newRequest = `을 하지 않아 헤더에 토큰이 추가되지 않았습니다.
```kotlin
newRequest = newRequest.newBuilder().addHeader(
     name = TOKEN_HEADER_KEY,
     value = authLocalData.sessionToken
).build()
```

인터셉터를 통해 토큰이 추가되면 `AuthApi`의 `logout`, `isSessionValid`에서 헤더가 중복됩니다. 때문에 중복되지 않도록 헤더값들을 제거했습니다.
`AuthApi`에 토큰을 전달할 필요가 없어졌습니다. 따라서 `AuthRepositoryImpl`에 token 필드가 필요없어져 제거했습니다.

## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [ ] Action에서 진행하는 테스트를 모두 통과했는가?
- [ ] 수정 사항을 검증할 테스트를 추가하였는가?
- [ ] 리뷰를 받았는가?