### PR TITLE
게시글 상세 페이지에 마크다운 지원

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ buildscript {
         compose_version = "1.2.0"
         coroutines_version = "1.6.4"
         joda = "2.10.13"
+        markwon_version = "4.6.2"
     }
     dependencies {
         // hilt

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -41,6 +41,11 @@ android {
     }
 }
 
+// io.noties.markwon:syntax-highlight 사용시 충돌이 발생하여 아래의 코드가 필요함
+configurations.all {
+    exclude group: 'org.jetbrains', module: 'annotations-java5'
+}
+
 dependencies {
     implementation project(":domain")
     testImplementation project(":test-library")
@@ -89,6 +94,16 @@ dependencies {
 
     // joda datetime
     implementation "net.danlew:android.joda:$joda"
+
+    // markdown
+    implementation "io.noties.markwon:core:$markwon_version"
+    implementation "io.noties.markwon:ext-strikethrough:$markwon_version"
+    implementation "io.noties.markwon:ext-tables:$markwon_version"
+    implementation "io.noties.markwon:html:$markwon_version"
+    implementation "io.noties.markwon:image-coil:$markwon_version"
+    implementation "io.noties.markwon:linkify:$markwon_version"
+    implementation "io.noties.markwon:syntax-highlight:$markwon_version"
+    kapt "io.noties:prism4j-bundler:2.0.0"
 
     implementation "androidx.core:core-ktx:$androidx_core"
     implementation 'androidx.appcompat:appcompat:1.4.2'

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -103,6 +103,7 @@ dependencies {
     implementation "io.noties.markwon:image-coil:$markwon_version"
     implementation "io.noties.markwon:linkify:$markwon_version"
     implementation "io.noties.markwon:syntax-highlight:$markwon_version"
+    implementation "io.noties.markwon:ext-tasklist:$markwon_version"
     kapt "io.noties:prism4j-bundler:2.0.0"
 
     implementation "androidx.core:core-ktx:$androidx_core"

--- a/presentation/src/androidTest/java/com/pocs/presentation/PostDetailScreenTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/PostDetailScreenTest.kt
@@ -484,7 +484,7 @@ class PostDetailScreenTest {
                     uiState = uiState.copy(
                         postDetail = mockPostDetail1.copy(
                             title = title,
-                            content = "t\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nt"
+                            content = "t\n\nt\n\nt\n\nt\n\nt\n\nt\n\nt\n\nt\n\nt\n\nt\n\nt\n\nt\n\nt\n\nt\n\nt\n\nt\n\nt\n\nt\n\nt\n\nt\n\nt\n\nt\n\nt\n\nt\n\nt\n\nt"
                         ).toUiState()
                     ),
                     snackbarHostState = snackbarHostState,

--- a/presentation/src/androidTest/java/com/pocs/presentation/PostEditScreenTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/PostEditScreenTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -26,7 +27,7 @@ class PostEditScreenTest {
     private val emptyUiState = PostEditUiState(
         postId = 1,
         title = "",
-        content = "",
+        content = TextFieldValue(),
         category = PostCategory.NOTICE,
         isUserAdmin = true,
         onTitleChange = {},
@@ -62,7 +63,7 @@ class PostEditScreenTest {
     fun disableSendButton_IfTitleIsEmpty() {
         val fakeUiState = emptyUiState.copy(
             title = "",
-            content = "hello",
+            content = TextFieldValue("hello"),
         )
         composeTestRule.setContent {
             PostEditScreen(uiState = fakeUiState, {}) {}
@@ -75,7 +76,7 @@ class PostEditScreenTest {
     fun disableSendButton_IfContentIsEmpty() {
         val fakeUiState = emptyUiState.copy(
             title = "title",
-            content = "",
+            content = TextFieldValue(""),
         )
         composeTestRule.setContent {
             PostEditScreen(uiState = fakeUiState, {}) {}
@@ -88,7 +89,7 @@ class PostEditScreenTest {
     fun enableSendButton_IfTitleAndContentAreNotEmpty() {
         val fakeUiState = emptyUiState.copy(
             title = "title",
-            content = "content",
+            content = TextFieldValue("content"),
         )
         composeTestRule.setContent {
             PostEditScreen(uiState = fakeUiState, {}) {}
@@ -101,7 +102,7 @@ class PostEditScreenTest {
     fun showCircularProgressIndicator_IfUiStateIsInSaving() {
         val fakeUiState = emptyUiState.copy(
             title = "title",
-            content = "content",
+            content = TextFieldValue("content"),
             isInSaving = true,
         )
         composeTestRule.setContent {
@@ -117,7 +118,7 @@ class PostEditScreenTest {
         val exception = Exception("fail!!")
         val fakeUiState = emptyUiState.copy(
             title = "title",
-            content = "content",
+            content = TextFieldValue("content"),
             isInSaving = false,
             onSave = { Result.failure(exception) }
         )
@@ -139,7 +140,12 @@ class PostEditScreenTest {
     fun navigateToUp_WhenSuccessSaving() {
         composeTestRule.run {
             setContent {
-                PostEditScreenWithHomeBackStack(emptyUiState.copy(title = "a", content = "a"))
+                PostEditScreenWithHomeBackStack(
+                    emptyUiState.copy(
+                        title = "a",
+                        content = TextFieldValue("a")
+                    )
+                )
             }
 
             onNodeWithContentDescription("저장하기").performClick()
@@ -222,7 +228,8 @@ class PostEditScreenTest {
 
         for (i in 1..4) {
             stringBuilder.append("가")
-            composeTestRule.onNodeWithContentDescription("제목 입력창").performTextInput(stringBuilder.toString())
+            composeTestRule.onNodeWithContentDescription("제목 입력창")
+                .performTextInput(stringBuilder.toString())
         }
     }
 }

--- a/presentation/src/main/java/com/pocs/presentation/extension/ContextExt.kt
+++ b/presentation/src/main/java/com/pocs/presentation/extension/ContextExt.kt
@@ -1,0 +1,10 @@
+package com.pocs.presentation.extension
+
+import android.content.Context
+import android.content.res.Configuration
+
+val Context.isDarkMode: Boolean
+    get() {
+        val darkModeFlag = this.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+        return darkModeFlag == Configuration.UI_MODE_NIGHT_YES
+    }

--- a/presentation/src/main/java/com/pocs/presentation/extension/NumExt.kt
+++ b/presentation/src/main/java/com/pocs/presentation/extension/NumExt.kt
@@ -1,0 +1,6 @@
+package com.pocs.presentation.extension
+
+import android.content.res.Resources
+
+val Float.dp: Int
+    get() = (this * Resources.getSystem().displayMetrics.density + 0.5f).toInt()

--- a/presentation/src/main/java/com/pocs/presentation/extension/NumExt.kt
+++ b/presentation/src/main/java/com/pocs/presentation/extension/NumExt.kt
@@ -2,5 +2,4 @@ package com.pocs.presentation.extension
 
 import android.content.res.Resources
 
-val Float.dp: Int
-    get() = (this * Resources.getSystem().displayMetrics.density + 0.5f).toInt()
+fun Float.toDp(): Int = (this * Resources.getSystem().displayMetrics.density + 0.5f).toInt()

--- a/presentation/src/main/java/com/pocs/presentation/extension/ViewExt.kt
+++ b/presentation/src/main/java/com/pocs/presentation/extension/ViewExt.kt
@@ -22,7 +22,7 @@ fun RecyclerView.addDividerDecoration(@DimenRes horizontalPaddingDimen: Int? = n
 }
 
 fun TextView.syncLineHeight(figmaLineHeight: Float, factor: Float = 1.48f) {
-    val lineSpacingExtra = figmaLineHeight.dp - factor * this.textSize
+    val lineSpacingExtra = figmaLineHeight.toDp() - factor * this.textSize
 
     val padding = lineSpacingExtra
         .takeIf { it != 0.0f }

--- a/presentation/src/main/java/com/pocs/presentation/extension/ViewExt.kt
+++ b/presentation/src/main/java/com/pocs/presentation/extension/ViewExt.kt
@@ -2,17 +2,37 @@ package com.pocs.presentation.extension
 
 import android.graphics.drawable.InsetDrawable
 import android.widget.LinearLayout
+import android.widget.TextView
 import androidx.annotation.DimenRes
+import androidx.core.view.updatePadding
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.RecyclerView
+import kotlin.math.roundToInt
 
 fun RecyclerView.addDividerDecoration(@DimenRes horizontalPaddingDimen: Int? = null) {
     val attr = intArrayOf(android.R.attr.listDivider)
     val typeArray = context.obtainStyledAttributes(attr)
     val divider = typeArray.getDrawable(0)
+    typeArray.recycle()
     val inset = horizontalPaddingDimen?.let { resources.getDimensionPixelSize(it) } ?: 0
     val insetDivider = InsetDrawable(divider, inset, 0, inset, 0)
     val decoration = DividerItemDecoration(context, LinearLayout.VERTICAL)
     decoration.setDrawable(insetDivider)
     addItemDecoration(decoration)
+}
+
+fun TextView.syncLineHeight(figmaLineHeight: Float, factor: Float = 1.48f) {
+    val lineSpacingExtra = figmaLineHeight.dp - factor * this.textSize
+
+    val padding = lineSpacingExtra
+        .takeIf { it != 0.0f }
+        ?.div(2)
+        ?.roundToInt()
+        ?: 0
+
+    setLineSpacing(lineSpacingExtra, 1f)
+    updatePadding(
+        top = padding,
+        bottom = padding
+    )
 }

--- a/presentation/src/main/java/com/pocs/presentation/model/post/BasePostEditUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/post/BasePostEditUiState.kt
@@ -1,18 +1,19 @@
 package com.pocs.presentation.model.post
 
+import androidx.compose.ui.text.input.TextFieldValue
 import com.pocs.domain.model.post.PostCategory
 
 interface BasePostEditUiState {
     val title: String
-    val content: String
+    val content: TextFieldValue
     val category: PostCategory
     val isUserAdmin: Boolean
     val isInSaving: Boolean
     val onTitleChange: (String) -> Unit
-    val onContentChange: (String) -> Unit
+    val onContentChange: (TextFieldValue) -> Unit
     val onCategoryChange: (PostCategory) -> Unit
     val onSave: suspend () -> Result<Unit>
 
-    val canSave get() = title.isNotEmpty() && content.isNotEmpty()
-    val isEmpty get() = title.isEmpty() && content.isEmpty()
+    val canSave get() = title.isNotEmpty() && content.text.isNotEmpty()
+    val isEmpty get() = title.isEmpty() && content.text.isEmpty()
 }

--- a/presentation/src/main/java/com/pocs/presentation/model/post/PostCreateUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/post/PostCreateUiState.kt
@@ -1,15 +1,16 @@
 package com.pocs.presentation.model.post
 
+import androidx.compose.ui.text.input.TextFieldValue
 import com.pocs.domain.model.post.PostCategory
 
 data class PostCreateUiState(
     override val title: String = "",
-    override val content: String = "",
+    override val content: TextFieldValue = TextFieldValue(),
     override val category: PostCategory,
     override val isUserAdmin: Boolean,
     override val isInSaving: Boolean = false,
     override val onTitleChange: (String) -> Unit,
-    override val onContentChange: (String) -> Unit,
+    override val onContentChange: (TextFieldValue) -> Unit,
     override val onCategoryChange: (PostCategory) -> Unit,
     override val onSave: suspend () -> Result<Unit>
 ) : BasePostEditUiState

--- a/presentation/src/main/java/com/pocs/presentation/model/post/PostEditUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/post/PostEditUiState.kt
@@ -1,16 +1,17 @@
 package com.pocs.presentation.model.post
 
+import androidx.compose.ui.text.input.TextFieldValue
 import com.pocs.domain.model.post.PostCategory
 
 data class PostEditUiState(
     val postId: Int,
     override val title: String,
-    override val content: String,
+    override val content: TextFieldValue,
     override val category: PostCategory,
     override val isUserAdmin: Boolean,
     override val isInSaving: Boolean = false,
     override val onTitleChange: (String) -> Unit,
-    override val onContentChange: (String) -> Unit,
+    override val onContentChange: (TextFieldValue) -> Unit,
     override val onCategoryChange: (PostCategory) -> Unit,
     override val onSave: suspend () -> Result<Unit>
 ) : BasePostEditUiState

--- a/presentation/src/main/java/com/pocs/presentation/view/component/Markdown.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/Markdown.kt
@@ -1,0 +1,148 @@
+package com.pocs.presentation.view.component
+
+import android.content.Context
+import android.util.TypedValue
+import android.view.View
+import android.widget.TextView
+import androidx.annotation.FontRes
+import androidx.annotation.IdRes
+import androidx.compose.material.LocalContentAlpha
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material.LocalTextStyle
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.takeOrElse
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.content.res.ResourcesCompat
+import coil.ImageLoader
+import io.noties.markwon.Markwon
+import io.noties.markwon.ext.strikethrough.StrikethroughPlugin
+import io.noties.markwon.ext.tables.TablePlugin
+import io.noties.markwon.html.HtmlPlugin
+import io.noties.markwon.image.coil.CoilImagesPlugin
+import io.noties.markwon.linkify.LinkifyPlugin
+import io.noties.markwon.syntax.Prism4jThemeDefault
+import io.noties.markwon.syntax.SyntaxHighlightPlugin
+import io.noties.prism4j.Prism4j
+import io.noties.prism4j.annotations.PrismBundle
+
+@Composable
+fun MarkdownText(
+    markdown: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    textAlign: TextAlign? = null,
+    maxLines: Int = Int.MAX_VALUE,
+    @FontRes fontResource: Int? = null,
+    style: TextStyle = LocalTextStyle.current,
+    @IdRes viewId: Int? = null,
+    onClick: (() -> Unit)? = null,
+    // this option will disable all clicks on links, inside the markdown text
+    // it also enable the parent view to receive the click event
+    disableLinkMovementMethod: Boolean = false,
+) {
+    val defaultColor: Color = LocalContentColor.current.copy(alpha = LocalContentAlpha.current)
+    val context: Context = LocalContext.current
+    val markdownRender: Markwon = remember { Markdown.createMarkdownRender(context) }
+    AndroidView(
+        modifier = modifier,
+        factory = { ctx ->
+            createTextView(
+                context = ctx,
+                color = color,
+                defaultColor = defaultColor,
+                fontSize = fontSize,
+                fontResource = fontResource,
+                maxLines = maxLines,
+                style = style,
+                textAlign = textAlign,
+                viewId = viewId,
+                onClick = onClick,
+            )
+        },
+        update = { textView ->
+            markdownRender.setMarkdown(textView, markdown)
+            if (disableLinkMovementMethod) {
+                textView.movementMethod = null
+            }
+        }
+    )
+}
+
+private fun createTextView(
+    context: Context,
+    color: Color = Color.Unspecified,
+    defaultColor: Color,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    textAlign: TextAlign? = null,
+    maxLines: Int = Int.MAX_VALUE,
+    @FontRes fontResource: Int? = null,
+    style: TextStyle,
+    @IdRes viewId: Int? = null,
+    onClick: (() -> Unit)? = null
+): TextView {
+
+    val textColor = color.takeOrElse { style.color.takeOrElse { defaultColor } }
+    val mergedStyle = style.merge(
+        TextStyle(
+            color = textColor,
+            fontSize = fontSize,
+            textAlign = textAlign,
+        )
+    )
+    return TextView(context).apply {
+        onClick?.let { setOnClickListener { onClick() } }
+        setTextColor(textColor.toArgb())
+        setMaxLines(maxLines)
+        setTextSize(TypedValue.COMPLEX_UNIT_DIP, mergedStyle.fontSize.value)
+
+        viewId?.let { id = viewId }
+        textAlign?.let { align ->
+            textAlignment = when (align) {
+                TextAlign.Left, TextAlign.Start -> View.TEXT_ALIGNMENT_TEXT_START
+                TextAlign.Right, TextAlign.End -> View.TEXT_ALIGNMENT_TEXT_END
+                TextAlign.Center -> View.TEXT_ALIGNMENT_CENTER
+                else -> View.TEXT_ALIGNMENT_TEXT_START
+            }
+        }
+
+        fontResource?.let { font ->
+            typeface = ResourcesCompat.getFont(context, font)
+        }
+    }
+}
+
+@PrismBundle(includeAll = true)
+class Markdown {
+
+    companion object {
+        fun createMarkdownRender(context: Context): Markwon {
+            val imageLoader = ImageLoader.Builder(context)
+                .apply {
+                    crossfade(true)
+                }.build()
+
+            return Markwon.builder(context)
+                .usePlugin(HtmlPlugin.create())
+                .usePlugin(CoilImagesPlugin.create(context, imageLoader))
+                .usePlugin(StrikethroughPlugin.create())
+                .usePlugin(TablePlugin.create(context))
+                .usePlugin(LinkifyPlugin.create())
+                .usePlugin(
+                    SyntaxHighlightPlugin.create(
+                        Prism4j(GrammarLocatorDef()),
+                        Prism4jThemeDefault.create()
+                    )
+                )
+                .build()
+        }
+    }
+}

--- a/presentation/src/main/java/com/pocs/presentation/view/component/Markdown.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/Markdown.kt
@@ -1,24 +1,40 @@
 package com.pocs.presentation.view.component
 
 import android.content.Context
+import android.util.Log
 import android.util.TypedValue
 import android.view.View
 import android.widget.TextView
 import androidx.annotation.FontRes
 import androidx.annotation.IdRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.LocalContentAlpha
 import androidx.compose.material.LocalContentColor
 import androidx.compose.material.LocalTextStyle
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.res.ResourcesCompat
 import coil.ImageLoader
@@ -145,4 +161,64 @@ class Markdown {
                 .build()
         }
     }
+}
+
+
+// TODO: IMAGE 추가하기
+enum class ToolBarItem(val imageVector: ImageVector) {
+    BOLD(Icons.Default.FormatBold),
+    ITALIC(Icons.Default.FormatItalic),
+    LINK(Icons.Default.Link),
+    LIST_ITEM(Icons.Default.List),
+    TASK_LIST_ITEM(Icons.Default.Checklist),
+    HEADING(Icons.Default.HMobiledata),
+    STRIKETHROUGH(Icons.Default.StrikethroughS),
+    QUOTE(Icons.Default.FormatQuote),
+    CODE_HIGHLIGHT(Icons.Default.Code)
+}
+
+@Composable
+fun MarkdownToolBar(textFieldValue: TextFieldValue, onValueChange: (TextFieldValue) -> Unit) {
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .background(color = MaterialTheme.colorScheme.primaryContainer)
+            .horizontalScroll(rememberScrollState())
+    ) {
+        val items = remember { ToolBarItem.values() }
+        for (item in items) {
+            MarkdownToolBarItem(item) {
+                when (item) {
+                    ToolBarItem.BOLD -> {
+                        Log.e("ee", textFieldValue.selection.toString())
+                    }
+                    ToolBarItem.ITALIC -> TODO()
+                    ToolBarItem.LINK -> TODO()
+                    ToolBarItem.LIST_ITEM -> TODO()
+                    ToolBarItem.TASK_LIST_ITEM -> TODO()
+                    ToolBarItem.HEADING -> TODO()
+                    ToolBarItem.STRIKETHROUGH -> TODO()
+                    ToolBarItem.QUOTE -> TODO()
+                    ToolBarItem.CODE_HIGHLIGHT -> TODO()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MarkdownToolBarItem(item: ToolBarItem, onClick: () -> Unit) {
+    Icon(
+        modifier = Modifier
+            .clickable(onClick = onClick)
+            .padding(8.dp),
+        imageVector = item.imageVector,
+        contentDescription = item.name
+    )
+}
+
+@Preview
+@Composable
+private fun MarkdownToolBarPreview() {
+    MarkdownToolBar(textFieldValue = TextFieldValue(), onValueChange = {})
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/component/Markdown.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/Markdown.kt
@@ -41,9 +41,11 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.res.ResourcesCompat
 import coil.ImageLoader
+import com.google.android.material.color.MaterialColors
 import io.noties.markwon.Markwon
 import io.noties.markwon.ext.strikethrough.StrikethroughPlugin
 import io.noties.markwon.ext.tables.TablePlugin
+import io.noties.markwon.ext.tasklist.TaskListPlugin
 import io.noties.markwon.html.HtmlPlugin
 import io.noties.markwon.image.coil.CoilImagesPlugin
 import io.noties.markwon.linkify.LinkifyPlugin
@@ -140,29 +142,45 @@ private fun createTextView(
 }
 
 @PrismBundle(includeAll = true)
-class Markdown {
+private object Markdown {
+    fun createMarkdownRender(context: Context): Markwon {
+        val imageLoader = ImageLoader.Builder(context)
+            .apply {
+                crossfade(true)
+            }.build()
 
-    companion object {
-        fun createMarkdownRender(context: Context): Markwon {
-            val imageLoader = ImageLoader.Builder(context)
-                .apply {
-                    crossfade(true)
-                }.build()
-
-            return Markwon.builder(context)
-                .usePlugin(HtmlPlugin.create())
-                .usePlugin(CoilImagesPlugin.create(context, imageLoader))
-                .usePlugin(StrikethroughPlugin.create())
-                .usePlugin(TablePlugin.create(context))
-                .usePlugin(LinkifyPlugin.create())
-                .usePlugin(
-                    SyntaxHighlightPlugin.create(
-                        Prism4j(GrammarLocatorDef()),
-                        Prism4jThemeDefault.create()
-                    )
+        return Markwon.builder(context)
+            .usePlugin(HtmlPlugin.create())
+            .usePlugin(CoilImagesPlugin.create(context, imageLoader))
+            .usePlugin(StrikethroughPlugin.create())
+            .usePlugin(TablePlugin.create(context))
+            .usePlugin(
+                TaskListPlugin.create(
+                    MaterialColors.getColor(
+                        context,
+                        com.google.android.material.R.attr.colorPrimary,
+                        ""
+                    ),
+                    MaterialColors.getColor(
+                        context,
+                        com.google.android.material.R.attr.colorOnBackground,
+                        ""
+                    ),
+                    MaterialColors.getColor(
+                        context,
+                        com.google.android.material.R.attr.backgroundColor,
+                        ""
+                    ),
                 )
-                .build()
-        }
+            )
+            .usePlugin(LinkifyPlugin.create())
+            .usePlugin(
+                SyntaxHighlightPlugin.create(
+                    Prism4j(GrammarLocatorDef()),
+                    Prism4jThemeDefault.create()
+                )
+            )
+            .build()
     }
 }
 

--- a/presentation/src/main/java/com/pocs/presentation/view/component/markdown/MarkdownText.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/markdown/MarkdownText.kt
@@ -1,6 +1,7 @@
 package com.pocs.presentation.view.component.markdown
 
 import android.content.Context
+import android.text.method.LinkMovementMethod
 import android.util.TypedValue
 import android.view.View
 import android.widget.TextView
@@ -40,7 +41,6 @@ import io.noties.prism4j.annotations.PrismBundle
 import org.commonmark.node.ListItem
 import org.commonmark.node.Paragraph
 
-
 @Composable
 fun MarkdownText(
     markdown: String,
@@ -78,9 +78,6 @@ fun MarkdownText(
         },
         update = { textView ->
             markdownRender.setMarkdown(textView, markdown)
-            if (disableLinkMovementMethod) {
-                textView.movementMethod = null
-            }
         }
     )
 }
@@ -97,7 +94,6 @@ private fun createTextView(
     @IdRes viewId: Int? = null,
     onClick: (() -> Unit)? = null
 ): TextView {
-
     val textColor = color.takeOrElse { style.color.takeOrElse { defaultColor } }
     val mergedStyle = style.merge(
         TextStyle(
@@ -106,11 +102,14 @@ private fun createTextView(
             textAlign = textAlign,
         )
     )
+
     return TextView(context).apply {
         onClick?.let { setOnClickListener { onClick() } }
         setTextColor(textColor.toArgb())
         setMaxLines(maxLines)
         setTextSize(TypedValue.COMPLEX_UNIT_DIP, mergedStyle.fontSize.value)
+        setTextIsSelectable(true)
+        movementMethod = LinkMovementMethod.getInstance()
 
         viewId?.let { id = viewId }
         textAlign?.let { align ->
@@ -152,7 +151,7 @@ private object Markdown {
             .usePlugin(CoilImagesPlugin.create(context, imageLoader))
             .usePlugin(StrikethroughPlugin.create())
             .usePlugin(TablePlugin.create(context))
-            .usePlugin(TaskListPlugin.create(colorOnBackground,colorOnBackground,backgroundColor))
+            .usePlugin(TaskListPlugin.create(colorOnBackground, colorOnBackground, backgroundColor))
             .usePlugin(LinkifyPlugin.create())
             .usePlugin(
                 SyntaxHighlightPlugin.create(

--- a/presentation/src/main/java/com/pocs/presentation/view/component/markdown/MarkdownText.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/markdown/MarkdownText.kt
@@ -1,0 +1,166 @@
+package com.pocs.presentation.view.component.markdown
+
+import android.content.Context
+import android.util.TypedValue
+import android.view.View
+import android.widget.TextView
+import androidx.annotation.FontRes
+import androidx.annotation.IdRes
+import androidx.compose.material.LocalContentAlpha
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material.LocalTextStyle
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.takeOrElse
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.content.res.ResourcesCompat
+import coil.ImageLoader
+import com.google.android.material.color.MaterialColors
+import io.noties.markwon.Markwon
+import io.noties.markwon.ext.strikethrough.StrikethroughPlugin
+import io.noties.markwon.ext.tables.TablePlugin
+import io.noties.markwon.ext.tasklist.TaskListPlugin
+import io.noties.markwon.html.HtmlPlugin
+import io.noties.markwon.image.coil.CoilImagesPlugin
+import io.noties.markwon.linkify.LinkifyPlugin
+import io.noties.markwon.syntax.Prism4jThemeDefault
+import io.noties.markwon.syntax.SyntaxHighlightPlugin
+import io.noties.prism4j.Prism4j
+import io.noties.prism4j.annotations.PrismBundle
+
+@Composable
+fun MarkdownText(
+    markdown: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    textAlign: TextAlign? = null,
+    maxLines: Int = Int.MAX_VALUE,
+    @FontRes fontResource: Int? = null,
+    style: TextStyle = LocalTextStyle.current,
+    @IdRes viewId: Int? = null,
+    onClick: (() -> Unit)? = null,
+    // this option will disable all clicks on links, inside the markdown text
+    // it also enable the parent view to receive the click event
+    disableLinkMovementMethod: Boolean = false,
+) {
+    val defaultColor: Color = LocalContentColor.current.copy(alpha = LocalContentAlpha.current)
+    val context: Context = LocalContext.current
+    val markdownRender: Markwon = remember { Markdown.createMarkdownRender(context) }
+    AndroidView(
+        modifier = modifier,
+        factory = { ctx ->
+            createTextView(
+                context = ctx,
+                color = color,
+                defaultColor = defaultColor,
+                fontSize = fontSize,
+                fontResource = fontResource,
+                maxLines = maxLines,
+                style = style,
+                textAlign = textAlign,
+                viewId = viewId,
+                onClick = onClick,
+            )
+        },
+        update = { textView ->
+            markdownRender.setMarkdown(textView, markdown)
+            if (disableLinkMovementMethod) {
+                textView.movementMethod = null
+            }
+        }
+    )
+}
+
+private fun createTextView(
+    context: Context,
+    color: Color = Color.Unspecified,
+    defaultColor: Color,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    textAlign: TextAlign? = null,
+    maxLines: Int = Int.MAX_VALUE,
+    @FontRes fontResource: Int? = null,
+    style: TextStyle,
+    @IdRes viewId: Int? = null,
+    onClick: (() -> Unit)? = null
+): TextView {
+
+    val textColor = color.takeOrElse { style.color.takeOrElse { defaultColor } }
+    val mergedStyle = style.merge(
+        TextStyle(
+            color = textColor,
+            fontSize = fontSize,
+            textAlign = textAlign,
+        )
+    )
+    return TextView(context).apply {
+        onClick?.let { setOnClickListener { onClick() } }
+        setTextColor(textColor.toArgb())
+        setMaxLines(maxLines)
+        setTextSize(TypedValue.COMPLEX_UNIT_DIP, mergedStyle.fontSize.value)
+
+        viewId?.let { id = viewId }
+        textAlign?.let { align ->
+            textAlignment = when (align) {
+                TextAlign.Left, TextAlign.Start -> View.TEXT_ALIGNMENT_TEXT_START
+                TextAlign.Right, TextAlign.End -> View.TEXT_ALIGNMENT_TEXT_END
+                TextAlign.Center -> View.TEXT_ALIGNMENT_CENTER
+                else -> View.TEXT_ALIGNMENT_TEXT_START
+            }
+        }
+
+        fontResource?.let { font ->
+            typeface = ResourcesCompat.getFont(context, font)
+        }
+    }
+}
+
+@PrismBundle(includeAll = true)
+private object Markdown {
+    fun createMarkdownRender(context: Context): Markwon {
+        val imageLoader = ImageLoader.Builder(context)
+            .apply {
+                crossfade(true)
+            }.build()
+
+        return Markwon.builder(context)
+            .usePlugin(HtmlPlugin.create())
+            .usePlugin(CoilImagesPlugin.create(context, imageLoader))
+            .usePlugin(StrikethroughPlugin.create())
+            .usePlugin(TablePlugin.create(context))
+            .usePlugin(
+                TaskListPlugin.create(
+                    MaterialColors.getColor(
+                        context,
+                        com.google.android.material.R.attr.colorPrimary,
+                        ""
+                    ),
+                    MaterialColors.getColor(
+                        context,
+                        com.google.android.material.R.attr.colorOnBackground,
+                        ""
+                    ),
+                    MaterialColors.getColor(
+                        context,
+                        com.google.android.material.R.attr.backgroundColor,
+                        ""
+                    ),
+                )
+            )
+            .usePlugin(LinkifyPlugin.create())
+            .usePlugin(
+                SyntaxHighlightPlugin.create(
+                    Prism4j(GrammarLocatorDef()),
+                    Prism4jThemeDefault.create()
+                )
+            )
+            .build()
+    }
+}

--- a/presentation/src/main/java/com/pocs/presentation/view/component/markdown/MarkdownText.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/markdown/MarkdownText.kt
@@ -173,7 +173,8 @@ private object Markdown {
             .usePlugin(object : AbstractMarkwonPlugin() {
                 override fun configureSpansFactory(builder: MarkwonSpansFactory.Builder) {
                     builder.appendFactory(BulletList::class.java) { _, _ ->
-                        // https://github.com/noties/Markwon/issues/413 를 해결하기 전에 사용하는 임시 해결책이다.
+                        // TODO: https://github.com/noties/Markwon/issues/413 가 해결되면 수정하기. 아래는
+                        //       임시 해결책임
                         FirstLineSpacingSpan((-24f).toDp())
                     }
                     builder.appendFactory(FencedCodeBlock::class.java) { _, _ ->

--- a/presentation/src/main/java/com/pocs/presentation/view/component/markdown/MarkdownText.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/markdown/MarkdownText.kt
@@ -174,8 +174,8 @@ private object Markdown {
             })
             .usePlugin(object : AbstractMarkwonPlugin() {
                 override fun configureTheme(builder: MarkwonTheme.Builder) {
-                    builder.bulletWidth(20)
-                        .blockMargin(104)
+                    builder.bulletWidth(6f.toDp())
+                        .blockMargin(40f.toDp())
                         .codeBackgroundColor(codeBackgroundColor)
                         .codeBlockMargin(16f.toDp())
                 }

--- a/presentation/src/main/java/com/pocs/presentation/view/component/markdown/MarkdownText.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/markdown/MarkdownText.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.res.ResourcesCompat
 import coil.ImageLoader
 import com.google.android.material.color.MaterialColors
+import com.pocs.presentation.extension.syncLineHeight
 import io.noties.markwon.*
 import io.noties.markwon.core.MarkwonTheme
 import io.noties.markwon.ext.strikethrough.StrikethroughPlugin
@@ -104,6 +105,7 @@ private fun createTextView(
         setTextColor(textColor.toArgb())
         setMaxLines(maxLines)
         setTextSize(TypedValue.COMPLEX_UNIT_DIP, mergedStyle.fontSize.value)
+        syncLineHeight(32f)
         // 링크를 클릭했을 때 이동 가능하게 하려면 아래의 selectable을 먼저 true로 설정하고나서 movement를 설정해야한다.
         setTextIsSelectable(true)
         movementMethod = LinkMovementMethod.getInstance()

--- a/presentation/src/main/java/com/pocs/presentation/view/component/markdown/MarkdownText.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/markdown/MarkdownText.kt
@@ -18,8 +18,6 @@ import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.android.InternalPlatformTextApi
-import androidx.compose.ui.text.android.style.LineHeightSpan
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.viewinterop.AndroidView
@@ -38,8 +36,6 @@ import io.noties.markwon.syntax.Prism4jThemeDefault
 import io.noties.markwon.syntax.SyntaxHighlightPlugin
 import io.noties.prism4j.Prism4j
 import io.noties.prism4j.annotations.PrismBundle
-import org.commonmark.node.ListItem
-import org.commonmark.node.Paragraph
 
 @Composable
 fun MarkdownText(
@@ -108,6 +104,7 @@ private fun createTextView(
         setTextColor(textColor.toArgb())
         setMaxLines(maxLines)
         setTextSize(TypedValue.COMPLEX_UNIT_DIP, mergedStyle.fontSize.value)
+        // 링크를 클릭했을 때 이동 가능하게 하려면 아래의 selectable을 먼저 true로 설정하고나서 movement를 설정해야한다.
         setTextIsSelectable(true)
         movementMethod = LinkMovementMethod.getInstance()
 
@@ -129,7 +126,6 @@ private fun createTextView(
 
 @PrismBundle(includeAll = true)
 private object Markdown {
-    @OptIn(InternalPlatformTextApi::class)
     fun createMarkdownRender(context: Context): Markwon {
         val imageLoader = ImageLoader.Builder(context)
             .apply {
@@ -159,16 +155,6 @@ private object Markdown {
                     Prism4jThemeDefault.create()
                 )
             )
-            .usePlugin(object : AbstractMarkwonPlugin() {
-                override fun configureSpansFactory(builder: MarkwonSpansFactory.Builder) {
-                    builder.appendFactory(Paragraph::class.java) { _, _ ->
-                        LineHeightSpan(72f)
-                    }
-                    builder.appendFactory(ListItem::class.java) { _, _ ->
-                        LineHeightSpan(22f)
-                    }
-                }
-            })
             .usePlugin(object : AbstractMarkwonPlugin() {
                 override fun configureTheme(builder: MarkwonTheme.Builder) {
                     builder.bulletWidth(20).blockMargin(104)

--- a/presentation/src/main/java/com/pocs/presentation/view/component/markdown/MarkdownText.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/markdown/MarkdownText.kt
@@ -148,12 +148,12 @@ private object Markdown {
         val colorOnBackground = MaterialColors.getColor(
             context,
             com.google.android.material.R.attr.colorOnBackground,
-            ""
+            0xffffff // 테스트를 위해 아무 의미없이 사용되는 값이다.
         )
         val backgroundColor = MaterialColors.getColor(
             context,
             com.google.android.material.R.attr.backgroundColor,
-            ""
+            0x000000 // 테스트를 위해 아무 의미없이 사용되는 값이다.
         )
         val codeBackgroundColor = ColorUtils.setAlphaComponent(colorOnBackground, 10)
 

--- a/presentation/src/main/java/com/pocs/presentation/view/component/markdown/MarkdownText.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/markdown/MarkdownText.kt
@@ -29,6 +29,7 @@ import androidx.core.content.res.ResourcesCompat
 import androidx.core.graphics.ColorUtils
 import coil.ImageLoader
 import com.google.android.material.color.MaterialColors
+import com.pocs.presentation.extension.isDarkMode
 import com.pocs.presentation.extension.toDp
 import com.pocs.presentation.extension.syncLineHeight
 import io.noties.markwon.*
@@ -39,6 +40,7 @@ import io.noties.markwon.ext.tasklist.TaskListPlugin
 import io.noties.markwon.html.HtmlPlugin
 import io.noties.markwon.image.coil.CoilImagesPlugin
 import io.noties.markwon.linkify.LinkifyPlugin
+import io.noties.markwon.syntax.Prism4jThemeDarkula
 import io.noties.markwon.syntax.Prism4jThemeDefault
 import io.noties.markwon.syntax.SyntaxHighlightPlugin
 import io.noties.prism4j.Prism4j
@@ -138,6 +140,7 @@ private fun createTextView(
 private object Markdown {
     @OptIn(InternalPlatformTextApi::class)
     fun createMarkdownRender(context: Context): Markwon {
+        val isDarkTheme = context.isDarkMode
         val imageLoader = ImageLoader.Builder(context)
             .apply {
                 crossfade(true)
@@ -164,7 +167,7 @@ private object Markdown {
             .usePlugin(
                 SyntaxHighlightPlugin.create(
                     Prism4j(GrammarLocatorDef()),
-                    Prism4jThemeDefault.create()
+                    if (isDarkTheme) Prism4jThemeDarkula.create() else Prism4jThemeDefault.create()
                 )
             )
             .usePlugin(object : AbstractMarkwonPlugin() {

--- a/presentation/src/main/java/com/pocs/presentation/view/component/markdown/MarkdownText.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/markdown/MarkdownText.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.res.ResourcesCompat
+import androidx.core.graphics.ColorUtils
 import coil.ImageLoader
 import com.google.android.material.color.MaterialColors
 import com.pocs.presentation.extension.toDp
@@ -148,6 +149,7 @@ private object Markdown {
             com.google.android.material.R.attr.backgroundColor,
             ""
         )
+        val codeBackgroundColor = ColorUtils.setAlphaComponent(colorOnBackground, 10)
 
         return Markwon.builder(context)
             .usePlugin(HtmlPlugin.create())
@@ -172,7 +174,10 @@ private object Markdown {
             })
             .usePlugin(object : AbstractMarkwonPlugin() {
                 override fun configureTheme(builder: MarkwonTheme.Builder) {
-                    builder.bulletWidth(20).blockMargin(104)
+                    builder.bulletWidth(20)
+                        .blockMargin(104)
+                        .codeBackgroundColor(codeBackgroundColor)
+                        .codeBlockMargin(16f.toDp())
                 }
             })
             .build()

--- a/presentation/src/main/java/com/pocs/presentation/view/component/markdown/MarkdownToolBar.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/markdown/MarkdownToolBar.kt
@@ -24,7 +24,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
 // TODO: IMAGE 추가하기
-private enum class MarkdownTag(val imageVector: ImageVector) {
+@VisibleForTesting
+enum class MarkdownTag(val imageVector: ImageVector) {
     BOLD(Icons.Default.FormatBold),
     ITALIC(Icons.Default.FormatItalic),
     LINK(Icons.Default.Link),
@@ -55,7 +56,7 @@ fun MarkdownToolBar(textFieldValue: TextFieldValue, onValueChange: (TextFieldVal
 }
 
 @VisibleForTesting
-private fun TextFieldValue.addMarkdownTag(tag: MarkdownTag): TextFieldValue {
+fun TextFieldValue.addMarkdownTag(tag: MarkdownTag): TextFieldValue {
     val text = this.text
     val selection = this.selection
 

--- a/presentation/src/main/java/com/pocs/presentation/view/component/markdown/MarkdownToolBar.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/markdown/MarkdownToolBar.kt
@@ -152,6 +152,9 @@ private fun String.insertAtFrontOfLine(str: String, cursorPosition: Int): String
 }
 
 private fun String.hasHeadingTagAtLine(cursorPosition: Int): Boolean {
+    if (isEmpty()) {
+        return false
+    }
     return this[firstIndexOfLine(cursorPosition)] == '#'
 }
 

--- a/presentation/src/main/java/com/pocs/presentation/view/component/markdown/MarkdownToolBar.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/markdown/MarkdownToolBar.kt
@@ -1,11 +1,5 @@
-package com.pocs.presentation.view.component
+package com.pocs.presentation.view.component.markdown
 
-import android.content.Context
-import android.util.TypedValue
-import android.view.View
-import android.widget.TextView
-import androidx.annotation.FontRes
-import androidx.annotation.IdRes
 import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -14,9 +8,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.material.LocalContentAlpha
-import androidx.compose.material.LocalContentColor
-import androidx.compose.material.LocalTextStyle
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material.icons.outlined.CheckBox
@@ -26,167 +17,14 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.takeOrElse
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.TextRange
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.AndroidView
-import androidx.core.content.res.ResourcesCompat
-import coil.ImageLoader
-import com.google.android.material.color.MaterialColors
-import io.noties.markwon.Markwon
-import io.noties.markwon.ext.strikethrough.StrikethroughPlugin
-import io.noties.markwon.ext.tables.TablePlugin
-import io.noties.markwon.ext.tasklist.TaskListPlugin
-import io.noties.markwon.html.HtmlPlugin
-import io.noties.markwon.image.coil.CoilImagesPlugin
-import io.noties.markwon.linkify.LinkifyPlugin
-import io.noties.markwon.syntax.Prism4jThemeDefault
-import io.noties.markwon.syntax.SyntaxHighlightPlugin
-import io.noties.prism4j.Prism4j
-import io.noties.prism4j.annotations.PrismBundle
-
-@Composable
-fun MarkdownText(
-    markdown: String,
-    modifier: Modifier = Modifier,
-    color: Color = Color.Unspecified,
-    fontSize: TextUnit = TextUnit.Unspecified,
-    textAlign: TextAlign? = null,
-    maxLines: Int = Int.MAX_VALUE,
-    @FontRes fontResource: Int? = null,
-    style: TextStyle = LocalTextStyle.current,
-    @IdRes viewId: Int? = null,
-    onClick: (() -> Unit)? = null,
-    // this option will disable all clicks on links, inside the markdown text
-    // it also enable the parent view to receive the click event
-    disableLinkMovementMethod: Boolean = false,
-) {
-    val defaultColor: Color = LocalContentColor.current.copy(alpha = LocalContentAlpha.current)
-    val context: Context = LocalContext.current
-    val markdownRender: Markwon = remember { Markdown.createMarkdownRender(context) }
-    AndroidView(
-        modifier = modifier,
-        factory = { ctx ->
-            createTextView(
-                context = ctx,
-                color = color,
-                defaultColor = defaultColor,
-                fontSize = fontSize,
-                fontResource = fontResource,
-                maxLines = maxLines,
-                style = style,
-                textAlign = textAlign,
-                viewId = viewId,
-                onClick = onClick,
-            )
-        },
-        update = { textView ->
-            markdownRender.setMarkdown(textView, markdown)
-            if (disableLinkMovementMethod) {
-                textView.movementMethod = null
-            }
-        }
-    )
-}
-
-private fun createTextView(
-    context: Context,
-    color: Color = Color.Unspecified,
-    defaultColor: Color,
-    fontSize: TextUnit = TextUnit.Unspecified,
-    textAlign: TextAlign? = null,
-    maxLines: Int = Int.MAX_VALUE,
-    @FontRes fontResource: Int? = null,
-    style: TextStyle,
-    @IdRes viewId: Int? = null,
-    onClick: (() -> Unit)? = null
-): TextView {
-
-    val textColor = color.takeOrElse { style.color.takeOrElse { defaultColor } }
-    val mergedStyle = style.merge(
-        TextStyle(
-            color = textColor,
-            fontSize = fontSize,
-            textAlign = textAlign,
-        )
-    )
-    return TextView(context).apply {
-        onClick?.let { setOnClickListener { onClick() } }
-        setTextColor(textColor.toArgb())
-        setMaxLines(maxLines)
-        setTextSize(TypedValue.COMPLEX_UNIT_DIP, mergedStyle.fontSize.value)
-
-        viewId?.let { id = viewId }
-        textAlign?.let { align ->
-            textAlignment = when (align) {
-                TextAlign.Left, TextAlign.Start -> View.TEXT_ALIGNMENT_TEXT_START
-                TextAlign.Right, TextAlign.End -> View.TEXT_ALIGNMENT_TEXT_END
-                TextAlign.Center -> View.TEXT_ALIGNMENT_CENTER
-                else -> View.TEXT_ALIGNMENT_TEXT_START
-            }
-        }
-
-        fontResource?.let { font ->
-            typeface = ResourcesCompat.getFont(context, font)
-        }
-    }
-}
-
-@PrismBundle(includeAll = true)
-private object Markdown {
-    fun createMarkdownRender(context: Context): Markwon {
-        val imageLoader = ImageLoader.Builder(context)
-            .apply {
-                crossfade(true)
-            }.build()
-
-        return Markwon.builder(context)
-            .usePlugin(HtmlPlugin.create())
-            .usePlugin(CoilImagesPlugin.create(context, imageLoader))
-            .usePlugin(StrikethroughPlugin.create())
-            .usePlugin(TablePlugin.create(context))
-            .usePlugin(
-                TaskListPlugin.create(
-                    MaterialColors.getColor(
-                        context,
-                        com.google.android.material.R.attr.colorPrimary,
-                        ""
-                    ),
-                    MaterialColors.getColor(
-                        context,
-                        com.google.android.material.R.attr.colorOnBackground,
-                        ""
-                    ),
-                    MaterialColors.getColor(
-                        context,
-                        com.google.android.material.R.attr.backgroundColor,
-                        ""
-                    ),
-                )
-            )
-            .usePlugin(LinkifyPlugin.create())
-            .usePlugin(
-                SyntaxHighlightPlugin.create(
-                    Prism4j(GrammarLocatorDef()),
-                    Prism4jThemeDefault.create()
-                )
-            )
-            .build()
-    }
-}
-
 
 // TODO: IMAGE 추가하기
-enum class MarkdownTag(val imageVector: ImageVector) {
+private enum class MarkdownTag(val imageVector: ImageVector) {
     BOLD(Icons.Default.FormatBold),
     ITALIC(Icons.Default.FormatItalic),
     LINK(Icons.Default.Link),
@@ -217,7 +55,7 @@ fun MarkdownToolBar(textFieldValue: TextFieldValue, onValueChange: (TextFieldVal
 }
 
 @VisibleForTesting
-fun TextFieldValue.addMarkdownTag(tag: MarkdownTag): TextFieldValue {
+private fun TextFieldValue.addMarkdownTag(tag: MarkdownTag): TextFieldValue {
     val text = this.text
     val selection = this.selection
 

--- a/presentation/src/main/java/com/pocs/presentation/view/post/adapter/PostAdapter.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/adapter/PostAdapter.kt
@@ -2,19 +2,36 @@ package com.pocs.presentation.view.post.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import android.widget.TextView
 import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
 import com.pocs.presentation.databinding.ItemPostBinding
 import com.pocs.presentation.model.post.item.PostItemUiState
+import io.noties.markwon.AbstractMarkwonPlugin
+import io.noties.markwon.Markwon
+import io.noties.markwon.utils.NoCopySpannableFactory
 
 class PostAdapter(
     private val onClickItem: (PostItemUiState) -> Unit
 ) : PagingDataAdapter<PostItemUiState, PostViewHolder>(diffCallback) {
 
+    private var markwon: Markwon? = null
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PostViewHolder {
+        if (markwon == null) {
+            markwon = Markwon.builder(parent.context).usePlugin(object : AbstractMarkwonPlugin() {
+                override fun afterSetText(textView: TextView) {
+                    // 마크다운으로 꾸며진 스타일을 제거하기 위해 span을 문자열로 전환하여 넣는다.
+                    val text = textView.text.toString()
+                    textView.text = text
+                }
+            }).build()
+        }
         val layoutInflater = LayoutInflater.from(parent.context)
         val binding = ItemPostBinding.inflate(layoutInflater, parent, false)
-        return PostViewHolder(binding, onClickItem)
+        // 최적화를 하기 위해 아래와 같이 정적 팩토리를 사용한다. 이는 마크다운 제거를 위해 사용된다.
+        binding.content.setSpannableFactory(NoCopySpannableFactory.getInstance())
+        return PostViewHolder(binding, onClickItem, markwon!!)
     }
 
     override fun onBindViewHolder(holder: PostViewHolder, position: Int) {

--- a/presentation/src/main/java/com/pocs/presentation/view/post/adapter/PostViewHolder.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/adapter/PostViewHolder.kt
@@ -15,7 +15,8 @@ class PostViewHolder(
 
     fun bind(uiState: PostItemUiState) = with(binding) {
         title.text = uiState.title
-        // 마크다운 태크를 제거하기 위해서 사용한다.
+        // 마크다운 태그를 제거하기 위해서 사용한다. 게시글 목록에서는 제목을 강조하기 때문에 content는 마크다운 형식 없이
+        // 보여야 한다. 그래서 마크다운 태그를 제거하고 있다.
         markwon.setMarkdown(content, uiState.content)
         content.movementMethod = null
 

--- a/presentation/src/main/java/com/pocs/presentation/view/post/adapter/PostViewHolder.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/adapter/PostViewHolder.kt
@@ -5,15 +5,19 @@ import com.pocs.presentation.R
 import com.pocs.presentation.databinding.ItemPostBinding
 import com.pocs.presentation.extension.koreanStringResource
 import com.pocs.presentation.model.post.item.PostItemUiState
+import io.noties.markwon.*
 
 class PostViewHolder(
     private val binding: ItemPostBinding,
-    private val onClickItem: (PostItemUiState) -> Unit
+    private val onClickItem: (PostItemUiState) -> Unit,
+    private val markwon : Markwon
 ) : RecyclerView.ViewHolder(binding.root) {
 
     fun bind(uiState: PostItemUiState) = with(binding) {
         title.text = uiState.title
-        content.text = uiState.content
+        // 마크다운 태크를 제거하기 위해서 사용한다.
+        markwon.setMarkdown(content, uiState.content)
+        content.movementMethod = null
 
         var subtitleText = uiState.createdAt
         val middleDot = root.context.getString(R.string.middle_dot)

--- a/presentation/src/main/java/com/pocs/presentation/view/post/create/PostCreateViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/create/PostCreateViewModel.kt
@@ -3,6 +3,7 @@ package com.pocs.presentation.view.post.create
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel
 import com.pocs.domain.model.post.PostCategory
 import com.pocs.domain.usecase.auth.IsCurrentUserAdminUseCase
@@ -40,7 +41,7 @@ class PostCreateViewModel @Inject constructor(
         _uiState!!.value = uiState.value.copy(title = title)
     }
 
-    private fun updateContent(content: String) {
+    private fun updateContent(content: TextFieldValue) {
         _uiState!!.value = uiState.value.copy(content = content)
     }
 
@@ -52,7 +53,7 @@ class PostCreateViewModel @Inject constructor(
         _uiState!!.value = uiState.value.copy(isInSaving = true)
         val result = addPostUseCase(
             title = uiState.value.title,
-            content = uiState.value.content,
+            content = uiState.value.content.text,
             category = uiState.value.category
         )
         _uiState!!.value = uiState.value.copy(isInSaving = false)

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -170,9 +171,11 @@ fun PostDetailContent(
                         date = postDetail.date
                     )
                     item {
-                        Text(
-                            modifier = Modifier.padding(20.dp),
-                            text = postDetail.content,
+                        MarkdownText(
+                            modifier = Modifier
+                                .padding(20.dp)
+                                .fillMaxWidth(),
+                            markdown = postDetail.content,
                             style = MaterialTheme.typography.bodyLarge.copy(
                                 color = MaterialTheme.colorScheme.onBackground
                             )
@@ -280,7 +283,8 @@ private fun LazyListScope.headerItems(title: String, writerName: String, date: S
             Text(
                 text = title,
                 style = MaterialTheme.typography.headlineMedium.copy(
-                    color = MaterialTheme.colorScheme.onBackground
+                    color = MaterialTheme.colorScheme.onBackground,
+                    fontWeight = FontWeight.Bold
                 )
             )
             Box(modifier = Modifier.height(8.dp))

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
@@ -1,9 +1,9 @@
 package com.pocs.presentation.view.post.detail
 
-import androidx.annotation.FloatRange
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
@@ -148,17 +148,13 @@ fun PostDetailContent(
             }
         ) { optionModalController ->
             val lazyListState = rememberLazyListState()
-            val titleAlpha = rememberTitleAlphaFromScrollOffset(
-                key = HEADER_KEY,
-                lazyListState = lazyListState
-            )
 
             Scaffold(
                 snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
                 topBar = {
                     PostDetailTopAppBar(
                         uiState,
-                        titleAlpha = titleAlpha.value,
+                        lazyListState = lazyListState,
                         onEditClick = onEditClick,
                         onDeleteClick = { showDeleteDialog = true }
                     )
@@ -228,10 +224,15 @@ fun PostDetailContent(
 @Composable
 fun PostDetailTopAppBar(
     uiState: PostDetailUiState.Success,
-    @FloatRange(from = 0.0, to = 1.0) titleAlpha: Float,
+    lazyListState: LazyListState,
     onEditClick: () -> Unit,
     onDeleteClick: () -> Unit
 ) {
+    val titleAlpha = rememberTitleAlphaFromScrollOffset(
+        key = HEADER_KEY,
+        lazyListState = lazyListState
+    )
+
     SmallTopAppBar(
         navigationIcon = {
             AppBarBackButton()
@@ -239,7 +240,7 @@ fun PostDetailTopAppBar(
         title = {
             Text(
                 text = uiState.postDetail.title,
-                modifier = Modifier.alpha(titleAlpha),
+                modifier = Modifier.alpha(titleAlpha.value),
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
@@ -40,6 +40,7 @@ import com.pocs.presentation.view.component.bottomsheet.*
 import com.pocs.presentation.view.component.button.AppBarBackButton
 import com.pocs.presentation.view.component.button.DropdownButton
 import com.pocs.presentation.view.component.button.DropdownOption
+import com.pocs.presentation.view.component.markdown.MarkdownText
 import kotlinx.coroutines.launch
 
 private const val HEADER_KEY = "header"

--- a/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditScreen.kt
@@ -6,10 +6,12 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.pocs.domain.model.post.PostCategory
@@ -20,6 +22,7 @@ import com.pocs.presentation.extension.koreanStringResource
 import com.pocs.presentation.model.post.BasePostEditUiState
 import com.pocs.presentation.model.post.PostEditUiState
 import com.pocs.presentation.view.component.HorizontalChips
+import com.pocs.presentation.view.component.MarkdownToolBar
 import com.pocs.presentation.view.component.PocsDivider
 import com.pocs.presentation.view.component.RecheckHandler
 import com.pocs.presentation.view.component.appbar.EditContentAppBar
@@ -83,12 +86,11 @@ fun PostEditContent(
         }
     ) { innerPadding ->
         Column(
-            Modifier
-                .padding(innerPadding)
-                .padding(bottom = 16.dp)
+            Modifier.padding(innerPadding)
         ) {
             val titleContentDescription = stringResource(R.string.title_text_field)
             val contentContentDescription = stringResource(R.string.content_text_field)
+            var showToolBar by remember { mutableStateOf(false) }
 
             PostCategoryChips(
                 isUserAdmin = uiState.isUserAdmin,
@@ -115,9 +117,13 @@ fun PostEditContent(
                 onValueChange = uiState.onContentChange,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .fillMaxHeight()
+                    .weight(1.0f)
                     .semantics { contentDescription = contentContentDescription }
+                    .onFocusChanged { showToolBar = it.hasFocus }
             )
+            if (showToolBar) {
+                MarkdownToolBar(textFieldValue = uiState.content, onValueChange = {})
+            }
         }
     }
 }
@@ -152,7 +158,7 @@ fun PostEditContentEmptyPreview() {
         PostEditUiState(
             postId = 1,
             title = "",
-            content = "",
+            content = TextFieldValue(),
             category = PostCategory.STUDY,
             isUserAdmin = true,
             onTitleChange = {},
@@ -172,7 +178,7 @@ fun PostEditContentPreview() {
         PostEditUiState(
             postId = 1,
             title = "공지입니다.",
-            content = "안녕하세요.",
+            content = TextFieldValue("안녕하세요."),
             category = PostCategory.STUDY,
             isUserAdmin = true,
             onTitleChange = {},

--- a/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditScreen.kt
@@ -23,10 +23,10 @@ import com.pocs.presentation.extension.koreanStringResource
 import com.pocs.presentation.model.post.BasePostEditUiState
 import com.pocs.presentation.model.post.PostEditUiState
 import com.pocs.presentation.view.component.HorizontalChips
-import com.pocs.presentation.view.component.MarkdownToolBar
 import com.pocs.presentation.view.component.PocsDivider
 import com.pocs.presentation.view.component.RecheckHandler
 import com.pocs.presentation.view.component.appbar.EditContentAppBar
+import com.pocs.presentation.view.component.markdown.MarkdownToolBar
 import com.pocs.presentation.view.component.textfield.SimpleTextField
 import kotlinx.coroutines.launch
 

--- a/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditScreen.kt
@@ -1,6 +1,7 @@
 package com.pocs.presentation.view.post.edit
 
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.*
@@ -121,8 +122,11 @@ fun PostEditContent(
                     .semantics { contentDescription = contentContentDescription }
                     .onFocusChanged { showToolBar = it.hasFocus }
             )
-            if (showToolBar) {
-                MarkdownToolBar(textFieldValue = uiState.content, onValueChange = {})
+            AnimatedVisibility(visible = showToolBar) {
+                MarkdownToolBar(
+                    textFieldValue = uiState.content,
+                    onValueChange = uiState.onContentChange
+                )
             }
         }
     }

--- a/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditViewModel.kt
@@ -1,6 +1,7 @@
 package com.pocs.presentation.view.post.edit
 
 import androidx.compose.runtime.*
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel
 import com.pocs.domain.model.post.PostCategory
 import com.pocs.domain.usecase.auth.IsCurrentUserAdminUseCase
@@ -27,7 +28,7 @@ class PostEditViewModel @Inject constructor(
             PostEditUiState(
                 postId = id,
                 title = title,
-                content = content,
+                content = TextFieldValue(content),
                 category = category,
                 isUserAdmin = isCurrentUserAdminUseCase(),
                 onTitleChange = ::updateTitle,
@@ -42,7 +43,7 @@ class PostEditViewModel @Inject constructor(
         _uiState!!.value = uiState.value.copy(title = title)
     }
 
-    private fun updateContent(content: String) {
+    private fun updateContent(content: TextFieldValue) {
         _uiState!!.value = uiState.value.copy(content = content)
     }
 
@@ -55,7 +56,7 @@ class PostEditViewModel @Inject constructor(
         val result = updatePostUseCase(
             id = uiState.value.postId,
             title = uiState.value.title,
-            content = uiState.value.content,
+            content = uiState.value.content.text,
             category = uiState.value.category
         )
         if (result.isFailure) {

--- a/presentation/src/main/res/values-night/themes.xml
+++ b/presentation/src/main/res/values-night/themes.xml
@@ -1,6 +1,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
     <style name="Base.Theme.PocsBlog" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="backgroundColor">@color/md_theme_dark_background</item>
         <item name="colorPrimary">@color/md_theme_dark_primary</item>
         <item name="colorOnPrimary">@color/md_theme_dark_onPrimary</item>
         <item name="colorPrimaryContainer">@color/md_theme_dark_primaryContainer</item>

--- a/presentation/src/main/res/values/themes.xml
+++ b/presentation/src/main/res/values/themes.xml
@@ -1,6 +1,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
     <style name="Base.Theme.PocsBlog" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="backgroundColor">@color/md_theme_light_background</item>
         <item name="colorPrimary">@color/md_theme_light_primary</item>
         <item name="colorOnPrimary">@color/md_theme_light_onPrimary</item>
         <item name="colorPrimaryContainer">@color/md_theme_light_primaryContainer</item>

--- a/presentation/src/test/java/com/pocs/presentation/MarkdownToolBarTest.kt
+++ b/presentation/src/test/java/com/pocs/presentation/MarkdownToolBarTest.kt
@@ -111,6 +111,127 @@ class MarkdownToolBarTest {
                         selection = TextRange(6)
                     )
                 ),
+                arrayOf(
+                    MarkdownTag.HEADING,
+                    TextFieldValue(
+                        "",
+                        selection = TextRange(0)
+                    ),
+                    TextFieldValue(
+                        "# ",
+                        selection = TextRange(2)
+                    )
+                ),
+                arrayOf(
+                    MarkdownTag.HEADING,
+                    TextFieldValue(
+                        "# hi nice to meet you",
+                        selection = TextRange(5)
+                    ),
+                    TextFieldValue(
+                        "## hi nice to meet you",
+                        selection = TextRange(6)
+                    )
+                ),
+                arrayOf(
+                    MarkdownTag.HEADING,
+                    TextFieldValue(
+                        "hello\nnice to meet you",
+                        selection = TextRange(10)
+                    ),
+                    TextFieldValue(
+                        "hello\n# nice to meet you",
+                        selection = TextRange(12)
+                    )
+                ),
+                arrayOf(
+                    MarkdownTag.STRIKETHROUGH,
+                    TextFieldValue(
+                        "",
+                        selection = TextRange(0)
+                    ),
+                    TextFieldValue(
+                        "~~~~",
+                        selection = TextRange(2)
+                    )
+                ),
+                arrayOf(
+                    MarkdownTag.STRIKETHROUGH,
+                    TextFieldValue(
+                        "hello nice to meet you",
+                        selection = TextRange(6, 10)
+                    ),
+                    TextFieldValue(
+                        "hello ~~nice~~ to meet you",
+                        selection = TextRange(12)
+                    )
+                ),
+                arrayOf(
+                    MarkdownTag.QUOTE,
+                    TextFieldValue(
+                        "",
+                        selection = TextRange(0)
+                    ),
+                    TextFieldValue(
+                        "> ",
+                        selection = TextRange(2)
+                    )
+                ),
+                arrayOf(
+                    MarkdownTag.QUOTE,
+                    TextFieldValue(
+                        "He said,\nThis is an apple.",
+                        selection = TextRange(10)
+                    ),
+                    TextFieldValue(
+                        "He said,\n> This is an apple.",
+                        selection = TextRange(12)
+                    )
+                ),
+                arrayOf(
+                    MarkdownTag.CODE_HIGHLIGHT,
+                    TextFieldValue(
+                        "",
+                        selection = TextRange(0)
+                    ),
+                    TextFieldValue(
+                        "``",
+                        selection = TextRange(1)
+                    )
+                ),
+                arrayOf(
+                    MarkdownTag.CODE_HIGHLIGHT,
+                    TextFieldValue(
+                        "Use foo, please",
+                        selection = TextRange(4, 7)
+                    ),
+                    TextFieldValue(
+                        "Use `foo`, please",
+                        selection = TextRange(8)
+                    )
+                ),
+                arrayOf(
+                    MarkdownTag.CODE_BLOCK,
+                    TextFieldValue(
+                        "",
+                        selection = TextRange(0)
+                    ),
+                    TextFieldValue(
+                        "```\n\n```",
+                        selection = TextRange(3)
+                    )
+                ),
+                arrayOf(
+                    MarkdownTag.CODE_BLOCK,
+                    TextFieldValue(
+                        "fun main() {\n\tprint(\"hi\")\n}",
+                        selection = TextRange(0, 27)
+                    ),
+                    TextFieldValue(
+                        "```\nfun main() {\n\tprint(\"hi\")\n}\n```",
+                        selection = TextRange(3)
+                    )
+                ),
             )
         }
     }

--- a/presentation/src/test/java/com/pocs/presentation/MarkdownToolBarTest.kt
+++ b/presentation/src/test/java/com/pocs/presentation/MarkdownToolBarTest.kt
@@ -1,0 +1,122 @@
+package com.pocs.presentation
+
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import com.pocs.presentation.view.component.markdown.MarkdownTag
+import com.pocs.presentation.view.component.markdown.addMarkdownTag
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class MarkdownToolBarTest {
+
+    @Parameterized.Parameter(value = 0)
+    lateinit var tag: MarkdownTag
+
+    @Parameterized.Parameter(value = 1)
+    lateinit var textFieldValue: TextFieldValue
+
+    @Parameterized.Parameter(value = 2)
+    lateinit var expected: TextFieldValue
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Array<Any?>> {
+            return listOf(
+                arrayOf(
+                    MarkdownTag.BOLD,
+                    TextFieldValue(""),
+                    TextFieldValue("****", selection = TextRange(2))
+                ),
+                arrayOf(
+                    MarkdownTag.BOLD,
+                    TextFieldValue("hello nice to meet you", selection = TextRange(6, 10)),
+                    TextFieldValue("hello **nice** to meet you", selection = TextRange(12))
+                ),
+                arrayOf(
+                    MarkdownTag.ITALIC,
+                    TextFieldValue(""),
+                    TextFieldValue("__", selection = TextRange(1))
+                ),
+                arrayOf(
+                    MarkdownTag.ITALIC,
+                    TextFieldValue("hello nice to meet you", selection = TextRange(6, 10)),
+                    TextFieldValue("hello _nice_ to meet you", selection = TextRange(11))
+                ),
+                arrayOf(
+                    MarkdownTag.LINK,
+                    TextFieldValue(""),
+                    TextFieldValue("[]()", selection = TextRange(4))
+                ),
+                arrayOf(
+                    MarkdownTag.LINK,
+                    TextFieldValue("hello\ngoogle link", selection = TextRange(6, 12)),
+                    TextFieldValue("hello\n[google]() link", selection = TextRange(16))
+                ),
+                arrayOf(
+                    MarkdownTag.LIST_ITEM,
+                    TextFieldValue(""),
+                    TextFieldValue("- ", selection = TextRange(2))
+                ),
+                arrayOf(
+                    MarkdownTag.LIST_ITEM,
+                    TextFieldValue("welcome\n\nhello nice to meet you.\ngood bye", TextRange(13)),
+                    TextFieldValue(
+                        "welcome\n\n- hello nice to meet you.\ngood bye",
+                        selection = TextRange(15)
+                    )
+                ),
+                arrayOf(
+                    MarkdownTag.TASK_LIST_ITEM,
+                    TextFieldValue(""),
+                    TextFieldValue("- [ ] ", selection = TextRange(6))
+                ),
+                arrayOf(
+                    MarkdownTag.TASK_LIST_ITEM,
+                    TextFieldValue("- [ ] "),
+                    TextFieldValue("- [x] ")
+                ),
+                arrayOf(
+                    MarkdownTag.TASK_LIST_ITEM,
+                    TextFieldValue("- [x] "),
+                    TextFieldValue("- [ ] ")
+                ),
+                arrayOf(
+                    MarkdownTag.TASK_LIST_ITEM,
+                    TextFieldValue("- [X] "),
+                    TextFieldValue("- [ ] ")
+                ),
+                arrayOf(
+                    MarkdownTag.TASK_LIST_ITEM,
+                    TextFieldValue(
+                        "hi\n\n\n- [X] content well..\n\nbye",
+                        selection = TextRange(15)
+                    ),
+                    TextFieldValue(
+                        "hi\n\n\n- [ ] content well..\n\nbye",
+                        selection = TextRange(15)
+                    )
+                ),
+                arrayOf(
+                    MarkdownTag.TASK_LIST_ITEM,
+                    TextFieldValue(
+                        "hi\n\n\n- [x] content well..\n\nbye",
+                        selection = TextRange(0)
+                    ),
+                    TextFieldValue(
+                        "- [ ] hi\n\n\n- [x] content well..\n\nbye",
+                        selection = TextRange(6)
+                    )
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun addMarkdownTagTest() {
+        assertEquals(expected, textFieldValue.addMarkdownTag(tag))
+    }
+}


### PR DESCRIPTION
Resolves #187 

마크다운 스타일을 커스텀하기가 상당히 까다로웠습니다..

- `toDp()` extension을 만들어 다른 화면 밀도를 가진 다양한 기기에서 동일한 간격을 적용하도록 했습니다. 이는 Markwon 라이브러리가 Compose로 구현되지 않고 View로 구현되었기 때문에 커스텀시 float와 같은 일반 숫자로 값을 넣어야하기 때문입니다.
- 깃헙 앱과 같은 툴바를 만들어 사용자가 쉽게 마크다운 문법을 적용할 수 있도록 했습니다.

|상세화면1|상세화면2|
|---|---|
|![image](https://user-images.githubusercontent.com/57604817/185868181-76511210-82c5-4375-b187-4d2d0cbc4759.png)|![image](https://user-images.githubusercontent.com/57604817/185868214-095edb78-a714-4a53-859b-df01493c4912.png)|

## 편집 툴바

https://user-images.githubusercontent.com/57604817/185869770-82c9e98c-473c-49f4-81f1-3c70b1dfce86.mov



## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [x] Action에서 진행하는 테스트를 모두 통과했는가?
- [x] 수정 사항을 검증할 테스트를 추가하였는가?
- [ ] 리뷰를 받았는가?