### PR TITLE
댓글 API 구현

### DIFF
--- a/data/src/main/java/com/pocs/data/api/CommentApi.kt
+++ b/data/src/main/java/com/pocs/data/api/CommentApi.kt
@@ -1,0 +1,14 @@
+package com.pocs.data.api
+
+import com.pocs.data.model.ResponseBody
+import com.pocs.data.model.comment.CommentsDto
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+interface CommentApi {
+    @GET("comments/{postId}")
+    suspend fun getAllBy(
+        @Path("postId") postId: Int
+    ): Response<ResponseBody<CommentsDto>>
+}

--- a/data/src/main/java/com/pocs/data/api/CommentApi.kt
+++ b/data/src/main/java/com/pocs/data/api/CommentApi.kt
@@ -17,6 +17,12 @@ interface CommentApi {
         @Body commentAddBody: CommentAddBody
     ): Response<ResponseBody<Unit>>
 
+    @PATCH("comments/{commentId}")
+    suspend fun update(
+        @Path("commentId") commentId: Int,
+        @Body content: String
+    ): Response<ResponseBody<Unit>>
+
     @PATCH("comments/{commentId}/delete")
     suspend fun delete(
         @Path("commentId") commentId: Int

--- a/data/src/main/java/com/pocs/data/api/CommentApi.kt
+++ b/data/src/main/java/com/pocs/data/api/CommentApi.kt
@@ -2,6 +2,7 @@ package com.pocs.data.api
 
 import com.pocs.data.model.ResponseBody
 import com.pocs.data.model.comment.CommentAddBody
+import com.pocs.data.model.comment.CommentUpdateBody
 import com.pocs.data.model.comment.CommentsDto
 import retrofit2.Response
 import retrofit2.http.*
@@ -20,7 +21,7 @@ interface CommentApi {
     @PATCH("comments/{commentId}")
     suspend fun update(
         @Path("commentId") commentId: Int,
-        @Body content: String
+        @Body commentUpdateBody: CommentUpdateBody
     ): Response<ResponseBody<Unit>>
 
     @PATCH("comments/{commentId}/delete")

--- a/data/src/main/java/com/pocs/data/api/CommentApi.kt
+++ b/data/src/main/java/com/pocs/data/api/CommentApi.kt
@@ -1,9 +1,12 @@
 package com.pocs.data.api
 
 import com.pocs.data.model.ResponseBody
+import com.pocs.data.model.comment.CommentAddBody
 import com.pocs.data.model.comment.CommentsDto
 import retrofit2.Response
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.POST
 import retrofit2.http.Path
 
 interface CommentApi {
@@ -11,4 +14,9 @@ interface CommentApi {
     suspend fun getAllBy(
         @Path("postId") postId: Int
     ): Response<ResponseBody<CommentsDto>>
+
+    @POST("comments")
+    suspend fun add(
+        @Body commentAddBody: CommentAddBody
+    ): Response<ResponseBody<Unit>>
 }

--- a/data/src/main/java/com/pocs/data/api/CommentApi.kt
+++ b/data/src/main/java/com/pocs/data/api/CommentApi.kt
@@ -4,10 +4,7 @@ import com.pocs.data.model.ResponseBody
 import com.pocs.data.model.comment.CommentAddBody
 import com.pocs.data.model.comment.CommentsDto
 import retrofit2.Response
-import retrofit2.http.Body
-import retrofit2.http.GET
-import retrofit2.http.POST
-import retrofit2.http.Path
+import retrofit2.http.*
 
 interface CommentApi {
     @GET("comments/{postId}")
@@ -18,5 +15,10 @@ interface CommentApi {
     @POST("comments")
     suspend fun add(
         @Body commentAddBody: CommentAddBody
+    ): Response<ResponseBody<Unit>>
+
+    @PATCH("comments/{commentId}/delete")
+    suspend fun delete(
+        @Path("commentId") commentId: Int
     ): Response<ResponseBody<Unit>>
 }

--- a/data/src/main/java/com/pocs/data/di/NetworkModule.kt
+++ b/data/src/main/java/com/pocs/data/di/NetworkModule.kt
@@ -1,10 +1,7 @@
 package com.pocs.data.di
 
 import com.pocs.data.BuildConfig
-import com.pocs.data.api.AdminApi
-import com.pocs.data.api.AuthApi
-import com.pocs.data.api.PostApi
-import com.pocs.data.api.UserApi
+import com.pocs.data.api.*
 import com.pocs.data.mapper.EnumConverterFactory
 import com.pocs.data.source.AuthLocalDataSource
 import dagger.Module
@@ -67,6 +64,12 @@ class NetworkModule {
     @Singleton
     fun providePostApiService(retrofit: Retrofit): PostApi {
         return retrofit.create(PostApi::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun provideCommentApiService(retrofit: Retrofit): CommentApi {
+        return retrofit.create(CommentApi::class.java)
     }
 
     @Provides

--- a/data/src/main/java/com/pocs/data/di/RemoteModule.kt
+++ b/data/src/main/java/com/pocs/data/di/RemoteModule.kt
@@ -1,9 +1,6 @@
 package com.pocs.data.di
 
-import com.pocs.data.api.AdminApi
-import com.pocs.data.api.AuthApi
-import com.pocs.data.api.PostApi
-import com.pocs.data.api.UserApi
+import com.pocs.data.api.*
 import com.pocs.data.source.*
 import dagger.Module
 import dagger.Provides
@@ -19,6 +16,12 @@ class RemoteModule {
     @Provides
     fun providePostRemoteDataSource(api: PostApi): PostRemoteDataSource {
         return PostRemoteDataSourceImpl(api)
+    }
+
+    @Singleton
+    @Provides
+    fun provideCommentRemoteDataSource(api: CommentApi): CommentRemoteDataSource {
+        return CommentRemoteDataSourceImpl(api)
     }
 
     @Singleton

--- a/data/src/main/java/com/pocs/data/di/RepositoryModule.kt
+++ b/data/src/main/java/com/pocs/data/di/RepositoryModule.kt
@@ -3,15 +3,9 @@ package com.pocs.data.di
 import com.pocs.data.api.AdminApi
 import com.pocs.data.api.PostApi
 import com.pocs.data.api.UserApi
-import com.pocs.data.repository.AdminRepositoryImpl
-import com.pocs.data.repository.AuthRepositoryImpl
-import com.pocs.data.repository.PostRepositoryImpl
-import com.pocs.data.repository.UserRepositoryImpl
+import com.pocs.data.repository.*
 import com.pocs.data.source.*
-import com.pocs.domain.repository.AdminRepository
-import com.pocs.domain.repository.AuthRepository
-import com.pocs.domain.repository.PostRepository
-import com.pocs.domain.repository.UserRepository
+import com.pocs.domain.repository.*
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -26,6 +20,12 @@ class RepositoryModule {
     @Provides
     fun providePostRepository(api: PostApi, dataSource: PostRemoteDataSource): PostRepository {
         return PostRepositoryImpl(api = api, dataSource = dataSource)
+    }
+
+    @Singleton
+    @Provides
+    fun provideCommentRepository(dataSource: CommentRemoteDataSource): CommentRepository {
+        return CommentRepositoryImpl(dataSource = dataSource)
     }
 
     @Singleton

--- a/data/src/main/java/com/pocs/data/mapper/CommentMapper.kt
+++ b/data/src/main/java/com/pocs/data/mapper/CommentMapper.kt
@@ -1,0 +1,23 @@
+package com.pocs.data.mapper
+
+import com.pocs.data.model.comment.CommentDto
+import com.pocs.data.model.comment.CommentWriterDto
+import com.pocs.domain.model.comment.Comment
+import com.pocs.domain.model.comment.CommentWriter
+
+fun CommentDto.toEntity() = Comment(
+    id = id,
+    parentId = parentId,
+    childrenCount = childrenCount,
+    postId = postId,
+    writer = writer.toEntity(),
+    content = content,
+    createdAt = createdAt,
+    updatedAt = updatedAt,
+    canceledAt = canceledAt
+)
+
+fun CommentWriterDto.toEntity() = CommentWriter(
+    name = name,
+    userId = userId
+)

--- a/data/src/main/java/com/pocs/data/mapper/CommentMapper.kt
+++ b/data/src/main/java/com/pocs/data/mapper/CommentMapper.kt
@@ -6,7 +6,7 @@ import com.pocs.domain.model.comment.Comment
 import com.pocs.domain.model.comment.CommentWriter
 
 fun CommentDto.toEntity() = Comment(
-    id = id,
+    id = commentId,
     parentId = parentId,
     childrenCount = childrenCount,
     postId = postId,

--- a/data/src/main/java/com/pocs/data/model/comment/CommentAddBody.kt
+++ b/data/src/main/java/com/pocs/data/model/comment/CommentAddBody.kt
@@ -1,0 +1,7 @@
+package com.pocs.data.model.comment
+
+data class CommentAddBody(
+    val postId: Int,
+    val parentId: Int?,
+    val content: String
+)

--- a/data/src/main/java/com/pocs/data/model/comment/CommentDto.kt
+++ b/data/src/main/java/com/pocs/data/model/comment/CommentDto.kt
@@ -2,7 +2,7 @@ package com.pocs.data.model.comment
 
 data class CommentDto(
     val commentId: Int,
-    val parentId: Int?,
+    val parentId: Int,
     val childrenCount: Int,
     val postId: Int,
     val writer: CommentWriterDto,

--- a/data/src/main/java/com/pocs/data/model/comment/CommentDto.kt
+++ b/data/src/main/java/com/pocs/data/model/comment/CommentDto.kt
@@ -1,0 +1,13 @@
+package com.pocs.data.model.comment
+
+data class CommentDto(
+    val id: Int,
+    val parentId: Int?,
+    val childrenCount: Int,
+    val postId: Int,
+    val writer: CommentWriterDto,
+    val content: String,
+    val createdAt: String,
+    val updatedAt: String? = null,
+    val canceledAt: String? = null
+)

--- a/data/src/main/java/com/pocs/data/model/comment/CommentDto.kt
+++ b/data/src/main/java/com/pocs/data/model/comment/CommentDto.kt
@@ -1,7 +1,7 @@
 package com.pocs.data.model.comment
 
 data class CommentDto(
-    val id: Int,
+    val commentId: Int,
     val parentId: Int?,
     val childrenCount: Int,
     val postId: Int,

--- a/data/src/main/java/com/pocs/data/model/comment/CommentUpdateBody.kt
+++ b/data/src/main/java/com/pocs/data/model/comment/CommentUpdateBody.kt
@@ -1,0 +1,5 @@
+package com.pocs.data.model.comment
+
+data class CommentUpdateBody(
+    val content: String
+)

--- a/data/src/main/java/com/pocs/data/model/comment/CommentWriterDto.kt
+++ b/data/src/main/java/com/pocs/data/model/comment/CommentWriterDto.kt
@@ -1,0 +1,6 @@
+package com.pocs.data.model.comment
+
+data class CommentWriterDto(
+    val userId: Int,
+    val name: String
+)

--- a/data/src/main/java/com/pocs/data/model/comment/CommentsDto.kt
+++ b/data/src/main/java/com/pocs/data/model/comment/CommentsDto.kt
@@ -1,0 +1,5 @@
+package com.pocs.data.model.comment
+
+data class CommentsDto(
+    val comments: List<CommentDto>
+)

--- a/data/src/main/java/com/pocs/data/repository/CommentRepositoryImpl.kt
+++ b/data/src/main/java/com/pocs/data/repository/CommentRepositoryImpl.kt
@@ -43,4 +43,17 @@ class CommentRepositoryImpl @Inject constructor(
             Result.failure(e)
         }
     }
+
+    override suspend fun delete(commentId: Int): Result<Unit> {
+        return try {
+            val response = dataSource.delete(commentId = commentId)
+            if (response.isSuccessful) {
+                Result.success(Unit)
+            } else {
+                throw Exception(response.errorMessage)
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
 }

--- a/data/src/main/java/com/pocs/data/repository/CommentRepositoryImpl.kt
+++ b/data/src/main/java/com/pocs/data/repository/CommentRepositoryImpl.kt
@@ -44,6 +44,19 @@ class CommentRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun update(commentId: Int, content: String): Result<Unit> {
+        return try {
+            val response = dataSource.update(commentId = commentId, content = content)
+            if (response.isSuccessful) {
+                Result.success(Unit)
+            } else {
+                throw  Exception(response.errorMessage)
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
     override suspend fun delete(commentId: Int): Result<Unit> {
         return try {
             val response = dataSource.delete(commentId = commentId)

--- a/data/src/main/java/com/pocs/data/repository/CommentRepositoryImpl.kt
+++ b/data/src/main/java/com/pocs/data/repository/CommentRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.pocs.data.repository
 import com.pocs.data.extension.errorMessage
 import com.pocs.data.mapper.toEntity
 import com.pocs.data.model.comment.CommentAddBody
+import com.pocs.data.model.comment.CommentUpdateBody
 import com.pocs.data.source.CommentRemoteDataSource
 import com.pocs.domain.model.comment.Comment
 import com.pocs.domain.repository.CommentRepository
@@ -46,7 +47,10 @@ class CommentRepositoryImpl @Inject constructor(
 
     override suspend fun update(commentId: Int, content: String): Result<Unit> {
         return try {
-            val response = dataSource.update(commentId = commentId, content = content)
+            val response = dataSource.update(
+                commentId = commentId,
+                commentUpdateBody = CommentUpdateBody(content = content)
+            )
             if (response.isSuccessful) {
                 Result.success(Unit)
             } else {

--- a/data/src/main/java/com/pocs/data/repository/CommentRepositoryImpl.kt
+++ b/data/src/main/java/com/pocs/data/repository/CommentRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.pocs.data.repository
 
 import com.pocs.data.extension.errorMessage
 import com.pocs.data.mapper.toEntity
+import com.pocs.data.model.comment.CommentAddBody
 import com.pocs.data.source.CommentRemoteDataSource
 import com.pocs.domain.model.comment.Comment
 import com.pocs.domain.repository.CommentRepository
@@ -17,6 +18,24 @@ class CommentRepositoryImpl @Inject constructor(
             if (response.isSuccessful) {
                 val comments = response.body()!!.data.comments.map { it.toEntity() }
                 Result.success(comments)
+            } else {
+                throw Exception(response.errorMessage)
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun add(content: String, postId: Int, parentId: Int?): Result<Unit> {
+        return try {
+            val requestBody = CommentAddBody(
+                content = content,
+                postId = postId,
+                parentId = parentId
+            )
+            val response = dataSource.add(requestBody)
+            if (response.isSuccessful) {
+                Result.success(Unit)
             } else {
                 throw Exception(response.errorMessage)
             }

--- a/data/src/main/java/com/pocs/data/repository/CommentRepositoryImpl.kt
+++ b/data/src/main/java/com/pocs/data/repository/CommentRepositoryImpl.kt
@@ -1,0 +1,27 @@
+package com.pocs.data.repository
+
+import com.pocs.data.extension.errorMessage
+import com.pocs.data.mapper.toEntity
+import com.pocs.data.source.CommentRemoteDataSource
+import com.pocs.domain.model.comment.Comment
+import com.pocs.domain.repository.CommentRepository
+import javax.inject.Inject
+
+class CommentRepositoryImpl @Inject constructor(
+    private val dataSource: CommentRemoteDataSource
+) : CommentRepository {
+
+    override suspend fun getAllBy(postId: Int): Result<List<Comment>> {
+        return try {
+            val response = dataSource.getAllBy(postId = postId)
+            if (response.isSuccessful) {
+                val comments = response.body()!!.data.comments.map { it.toEntity() }
+                Result.success(comments)
+            } else {
+                throw Exception(response.errorMessage)
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}

--- a/data/src/main/java/com/pocs/data/source/CommentRemoteDataSource.kt
+++ b/data/src/main/java/com/pocs/data/source/CommentRemoteDataSource.kt
@@ -8,5 +8,6 @@ import retrofit2.Response
 interface CommentRemoteDataSource {
     suspend fun getAllBy(postId: Int): Response<ResponseBody<CommentsDto>>
     suspend fun add(commentAddBody: CommentAddBody): Response<ResponseBody<Unit>>
+    suspend fun update(commentId: Int, content: String): Response<ResponseBody<Unit>>
     suspend fun delete(commentId: Int): Response<ResponseBody<Unit>>
 }

--- a/data/src/main/java/com/pocs/data/source/CommentRemoteDataSource.kt
+++ b/data/src/main/java/com/pocs/data/source/CommentRemoteDataSource.kt
@@ -2,12 +2,20 @@ package com.pocs.data.source
 
 import com.pocs.data.model.ResponseBody
 import com.pocs.data.model.comment.CommentAddBody
+import com.pocs.data.model.comment.CommentUpdateBody
 import com.pocs.data.model.comment.CommentsDto
 import retrofit2.Response
 
 interface CommentRemoteDataSource {
+
     suspend fun getAllBy(postId: Int): Response<ResponseBody<CommentsDto>>
+
     suspend fun add(commentAddBody: CommentAddBody): Response<ResponseBody<Unit>>
-    suspend fun update(commentId: Int, content: String): Response<ResponseBody<Unit>>
+
+    suspend fun update(
+        commentId: Int,
+        commentUpdateBody: CommentUpdateBody
+    ): Response<ResponseBody<Unit>>
+
     suspend fun delete(commentId: Int): Response<ResponseBody<Unit>>
 }

--- a/data/src/main/java/com/pocs/data/source/CommentRemoteDataSource.kt
+++ b/data/src/main/java/com/pocs/data/source/CommentRemoteDataSource.kt
@@ -1,9 +1,11 @@
 package com.pocs.data.source
 
 import com.pocs.data.model.ResponseBody
+import com.pocs.data.model.comment.CommentAddBody
 import com.pocs.data.model.comment.CommentsDto
 import retrofit2.Response
 
 interface CommentRemoteDataSource {
     suspend fun getAllBy(postId: Int): Response<ResponseBody<CommentsDto>>
+    suspend fun add(commentAddBody: CommentAddBody): Response<ResponseBody<Unit>>
 }

--- a/data/src/main/java/com/pocs/data/source/CommentRemoteDataSource.kt
+++ b/data/src/main/java/com/pocs/data/source/CommentRemoteDataSource.kt
@@ -1,0 +1,9 @@
+package com.pocs.data.source
+
+import com.pocs.data.model.ResponseBody
+import com.pocs.data.model.comment.CommentsDto
+import retrofit2.Response
+
+interface CommentRemoteDataSource {
+    suspend fun getAllBy(postId: Int): Response<ResponseBody<CommentsDto>>
+}

--- a/data/src/main/java/com/pocs/data/source/CommentRemoteDataSource.kt
+++ b/data/src/main/java/com/pocs/data/source/CommentRemoteDataSource.kt
@@ -8,4 +8,5 @@ import retrofit2.Response
 interface CommentRemoteDataSource {
     suspend fun getAllBy(postId: Int): Response<ResponseBody<CommentsDto>>
     suspend fun add(commentAddBody: CommentAddBody): Response<ResponseBody<Unit>>
+    suspend fun delete(commentId: Int): Response<ResponseBody<Unit>>
 }

--- a/data/src/main/java/com/pocs/data/source/CommentRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/pocs/data/source/CommentRemoteDataSourceImpl.kt
@@ -2,6 +2,7 @@ package com.pocs.data.source
 
 import com.pocs.data.api.CommentApi
 import com.pocs.data.model.comment.CommentAddBody
+import com.pocs.data.model.comment.CommentUpdateBody
 import javax.inject.Inject
 
 class CommentRemoteDataSourceImpl @Inject constructor(
@@ -12,8 +13,8 @@ class CommentRemoteDataSourceImpl @Inject constructor(
 
     override suspend fun add(commentAddBody: CommentAddBody) = api.add(commentAddBody)
 
-    override suspend fun update(commentId: Int, content: String) =
-        api.update(commentId = commentId, content = content)
+    override suspend fun update(commentId: Int, commentUpdateBody: CommentUpdateBody) =
+        api.update(commentId = commentId, commentUpdateBody = commentUpdateBody)
 
     override suspend fun delete(commentId: Int) = api.delete(commentId = commentId)
 }

--- a/data/src/main/java/com/pocs/data/source/CommentRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/pocs/data/source/CommentRemoteDataSourceImpl.kt
@@ -1,0 +1,10 @@
+package com.pocs.data.source
+
+import com.pocs.data.api.CommentApi
+import javax.inject.Inject
+
+class CommentRemoteDataSourceImpl @Inject constructor(
+    private val api: CommentApi
+) : CommentRemoteDataSource {
+    override suspend fun getAllBy(postId: Int) = api.getAllBy(postId = postId)
+}

--- a/data/src/main/java/com/pocs/data/source/CommentRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/pocs/data/source/CommentRemoteDataSourceImpl.kt
@@ -7,7 +7,13 @@ import javax.inject.Inject
 class CommentRemoteDataSourceImpl @Inject constructor(
     private val api: CommentApi
 ) : CommentRemoteDataSource {
+
     override suspend fun getAllBy(postId: Int) = api.getAllBy(postId = postId)
+
     override suspend fun add(commentAddBody: CommentAddBody) = api.add(commentAddBody)
+
+    override suspend fun update(commentId: Int, content: String) =
+        api.update(commentId = commentId, content = content)
+
     override suspend fun delete(commentId: Int) = api.delete(commentId = commentId)
 }

--- a/data/src/main/java/com/pocs/data/source/CommentRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/pocs/data/source/CommentRemoteDataSourceImpl.kt
@@ -1,9 +1,7 @@
 package com.pocs.data.source
 
 import com.pocs.data.api.CommentApi
-import com.pocs.data.model.ResponseBody
 import com.pocs.data.model.comment.CommentAddBody
-import retrofit2.Response
 import javax.inject.Inject
 
 class CommentRemoteDataSourceImpl @Inject constructor(
@@ -11,4 +9,5 @@ class CommentRemoteDataSourceImpl @Inject constructor(
 ) : CommentRemoteDataSource {
     override suspend fun getAllBy(postId: Int) = api.getAllBy(postId = postId)
     override suspend fun add(commentAddBody: CommentAddBody) = api.add(commentAddBody)
+    override suspend fun delete(commentId: Int) = api.delete(commentId = commentId)
 }

--- a/data/src/main/java/com/pocs/data/source/CommentRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/pocs/data/source/CommentRemoteDataSourceImpl.kt
@@ -1,10 +1,14 @@
 package com.pocs.data.source
 
 import com.pocs.data.api.CommentApi
+import com.pocs.data.model.ResponseBody
+import com.pocs.data.model.comment.CommentAddBody
+import retrofit2.Response
 import javax.inject.Inject
 
 class CommentRemoteDataSourceImpl @Inject constructor(
     private val api: CommentApi
 ) : CommentRemoteDataSource {
     override suspend fun getAllBy(postId: Int) = api.getAllBy(postId = postId)
+    override suspend fun add(commentAddBody: CommentAddBody) = api.add(commentAddBody)
 }

--- a/domain/src/main/java/com/pocs/domain/model/comment/Comment.kt
+++ b/domain/src/main/java/com/pocs/domain/model/comment/Comment.kt
@@ -2,7 +2,7 @@ package com.pocs.domain.model.comment
 
 data class Comment(
     val id: Int,
-    val parentId: Int?,
+    val parentId: Int,
     val childrenCount: Int,
     val postId: Int,
     val writer: CommentWriter,

--- a/domain/src/main/java/com/pocs/domain/repository/CommentRepository.kt
+++ b/domain/src/main/java/com/pocs/domain/repository/CommentRepository.kt
@@ -4,4 +4,5 @@ import com.pocs.domain.model.comment.Comment
 
 interface CommentRepository {
     suspend fun getAllBy(postId: Int): Result<List<Comment>>
+    suspend fun add(content: String, postId: Int, parentId: Int?): Result<Unit>
 }

--- a/domain/src/main/java/com/pocs/domain/repository/CommentRepository.kt
+++ b/domain/src/main/java/com/pocs/domain/repository/CommentRepository.kt
@@ -5,4 +5,5 @@ import com.pocs.domain.model.comment.Comment
 interface CommentRepository {
     suspend fun getAllBy(postId: Int): Result<List<Comment>>
     suspend fun add(content: String, postId: Int, parentId: Int?): Result<Unit>
+    suspend fun delete(commentId: Int): Result<Unit>
 }

--- a/domain/src/main/java/com/pocs/domain/repository/CommentRepository.kt
+++ b/domain/src/main/java/com/pocs/domain/repository/CommentRepository.kt
@@ -5,5 +5,6 @@ import com.pocs.domain.model.comment.Comment
 interface CommentRepository {
     suspend fun getAllBy(postId: Int): Result<List<Comment>>
     suspend fun add(content: String, postId: Int, parentId: Int?): Result<Unit>
+    suspend fun update(commentId: Int, content: String): Result<Unit>
     suspend fun delete(commentId: Int): Result<Unit>
 }

--- a/domain/src/main/java/com/pocs/domain/repository/CommentRepository.kt
+++ b/domain/src/main/java/com/pocs/domain/repository/CommentRepository.kt
@@ -1,0 +1,7 @@
+package com.pocs.domain.repository
+
+import com.pocs.domain.model.comment.Comment
+
+interface CommentRepository {
+    suspend fun getAllBy(postId: Int): Result<List<Comment>>
+}

--- a/domain/src/main/java/com/pocs/domain/usecase/comment/AddCommentUseCase.kt
+++ b/domain/src/main/java/com/pocs/domain/usecase/comment/AddCommentUseCase.kt
@@ -1,0 +1,11 @@
+package com.pocs.domain.usecase.comment
+
+import com.pocs.domain.repository.CommentRepository
+import javax.inject.Inject
+
+class AddCommentUseCase @Inject constructor(
+    private val repository: CommentRepository
+) {
+    suspend operator fun invoke(content: String, postId: Int, parentId: Int?) =
+        repository.add(content = content, postId = postId, parentId = parentId)
+}

--- a/domain/src/main/java/com/pocs/domain/usecase/comment/DeleteCommentUseCase.kt
+++ b/domain/src/main/java/com/pocs/domain/usecase/comment/DeleteCommentUseCase.kt
@@ -1,0 +1,10 @@
+package com.pocs.domain.usecase.comment
+
+import com.pocs.domain.repository.CommentRepository
+import javax.inject.Inject
+
+class DeleteCommentUseCase @Inject constructor(
+    private val repository: CommentRepository
+) {
+    suspend operator fun invoke(commentId: Int) = repository.delete(commentId = commentId)
+}

--- a/domain/src/main/java/com/pocs/domain/usecase/comment/GetCommentsUseCase.kt
+++ b/domain/src/main/java/com/pocs/domain/usecase/comment/GetCommentsUseCase.kt
@@ -1,34 +1,10 @@
 package com.pocs.domain.usecase.comment
 
-import com.pocs.domain.model.comment.Comment
-import com.pocs.domain.model.comment.CommentWriter
-import kotlinx.coroutines.delay
+import com.pocs.domain.repository.CommentRepository
 import javax.inject.Inject
 
-// TODO: 임시 목업 객체임. API 완성되면 data 모듈단에서 구현후 이곳에 연결해야함.
-class GetCommentsUseCase @Inject constructor() {
-
-    suspend operator fun invoke(postId: Int): Result<List<Comment>> {
-        delay(1000)
-        val mockComment = Comment(
-            id = 10,
-            parentId = null,
-            childrenCount = 0,
-            postId = postId,
-            writer = CommentWriter(
-                userId = 1,
-                name = "홍길동"
-            ),
-            content = "댓글 내용입니다.",
-            createdAt = "2022-09-02 13:09",
-            updatedAt = null
-        )
-        return Result.success(
-            listOf(
-                mockComment,
-                mockComment.copy(id = 11, childrenCount = 1),
-                mockComment.copy(id = 12, parentId = 11)
-            )
-        )
-    }
+class GetCommentsUseCase @Inject constructor(
+    private val repository: CommentRepository
+) {
+    suspend operator fun invoke(postId: Int) = repository.getAllBy(postId = postId)
 }

--- a/domain/src/main/java/com/pocs/domain/usecase/comment/UpdateCommentUseCase.kt
+++ b/domain/src/main/java/com/pocs/domain/usecase/comment/UpdateCommentUseCase.kt
@@ -1,0 +1,11 @@
+package com.pocs.domain.usecase.comment
+
+import com.pocs.domain.repository.CommentRepository
+import javax.inject.Inject
+
+class UpdateCommentUseCase @Inject constructor(
+    private val repository: CommentRepository
+) {
+    suspend operator fun invoke(commentId: Int, content: String) =
+        repository.update(commentId = commentId, content = content)
+}

--- a/presentation/src/androidTest/java/com/pocs/presentation/PostDetailActivityTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/PostDetailActivityTest.kt
@@ -8,6 +8,7 @@ import androidx.test.core.app.launchActivity
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import com.pocs.domain.model.user.UserType
 import com.pocs.domain.usecase.auth.GetCurrentUserUseCase
+import com.pocs.domain.usecase.comment.AddCommentUseCase
 import com.pocs.domain.usecase.comment.GetCommentsUseCase
 import com.pocs.domain.usecase.post.CanDeletePostUseCase
 import com.pocs.domain.usecase.post.CanEditPostUseCase
@@ -17,6 +18,7 @@ import com.pocs.presentation.view.post.detail.PostDetailActivity
 import com.pocs.presentation.view.post.detail.PostDetailViewModel
 import com.pocs.test_library.fake.FakeAuthRepositoryImpl
 import com.pocs.test_library.fake.FakePostRepositoryImpl
+import com.pocs.test_library.fake.source.FakeCommentRepositoryImpl
 import com.pocs.test_library.mock.mockNormalUserDetail
 import com.pocs.test_library.mock.mockPostDetail1
 import dagger.hilt.android.testing.BindValue
@@ -42,12 +44,16 @@ class PostDetailActivityTest {
     val authRepository = FakeAuthRepositoryImpl()
 
     @BindValue
+    val commentRepository = FakeCommentRepositoryImpl()
+
+    @BindValue
     val viewModel = PostDetailViewModel(
         GetPostDetailUseCase(postRepository),
         DeletePostUseCase(postRepository = postRepository, authRepository = authRepository),
         CanEditPostUseCase(authRepository),
         CanDeletePostUseCase(authRepository),
-        GetCommentsUseCase(),
+        GetCommentsUseCase(commentRepository),
+        AddCommentUseCase(commentRepository),
         GetCurrentUserUseCase(authRepository)
     )
 

--- a/presentation/src/androidTest/java/com/pocs/presentation/PostDetailActivityTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/PostDetailActivityTest.kt
@@ -11,6 +11,7 @@ import com.pocs.domain.usecase.auth.GetCurrentUserUseCase
 import com.pocs.domain.usecase.comment.AddCommentUseCase
 import com.pocs.domain.usecase.comment.DeleteCommentUseCase
 import com.pocs.domain.usecase.comment.GetCommentsUseCase
+import com.pocs.domain.usecase.comment.UpdateCommentUseCase
 import com.pocs.domain.usecase.post.CanDeletePostUseCase
 import com.pocs.domain.usecase.post.CanEditPostUseCase
 import com.pocs.domain.usecase.post.DeletePostUseCase
@@ -55,6 +56,7 @@ class PostDetailActivityTest {
         CanDeletePostUseCase(authRepository),
         GetCommentsUseCase(commentRepository),
         AddCommentUseCase(commentRepository),
+        UpdateCommentUseCase(commentRepository),
         DeleteCommentUseCase(commentRepository),
         GetCurrentUserUseCase(authRepository)
     )

--- a/presentation/src/androidTest/java/com/pocs/presentation/PostDetailActivityTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/PostDetailActivityTest.kt
@@ -20,7 +20,7 @@ import com.pocs.presentation.view.post.detail.PostDetailActivity
 import com.pocs.presentation.view.post.detail.PostDetailViewModel
 import com.pocs.test_library.fake.FakeAuthRepositoryImpl
 import com.pocs.test_library.fake.FakePostRepositoryImpl
-import com.pocs.test_library.fake.source.FakeCommentRepositoryImpl
+import com.pocs.test_library.fake.FakeCommentRepositoryImpl
 import com.pocs.test_library.mock.mockNormalUserDetail
 import com.pocs.test_library.mock.mockPostDetail1
 import dagger.hilt.android.testing.BindValue

--- a/presentation/src/androidTest/java/com/pocs/presentation/PostDetailActivityTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/PostDetailActivityTest.kt
@@ -9,6 +9,7 @@ import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import com.pocs.domain.model.user.UserType
 import com.pocs.domain.usecase.auth.GetCurrentUserUseCase
 import com.pocs.domain.usecase.comment.AddCommentUseCase
+import com.pocs.domain.usecase.comment.DeleteCommentUseCase
 import com.pocs.domain.usecase.comment.GetCommentsUseCase
 import com.pocs.domain.usecase.post.CanDeletePostUseCase
 import com.pocs.domain.usecase.post.CanEditPostUseCase
@@ -54,6 +55,7 @@ class PostDetailActivityTest {
         CanDeletePostUseCase(authRepository),
         GetCommentsUseCase(commentRepository),
         AddCommentUseCase(commentRepository),
+        DeleteCommentUseCase(commentRepository),
         GetCurrentUserUseCase(authRepository)
     )
 

--- a/presentation/src/androidTest/java/com/pocs/presentation/PostDetailScreenTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/PostDetailScreenTest.kt
@@ -16,8 +16,9 @@ import com.pocs.presentation.model.comment.CommentsUiState
 import com.pocs.presentation.model.post.PostDetailUiState
 import com.pocs.presentation.view.component.bottomsheet.CommentModalController
 import com.pocs.presentation.view.post.detail.PostDetailContent
-import com.pocs.test_library.mock.mockCommentItemUiState
+import com.pocs.test_library.mock.mockComment
 import com.pocs.test_library.mock.mockPostDetail1
+import com.pocs.test_library.mock.mockReply
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
@@ -28,9 +29,7 @@ class PostDetailScreenTest {
     @get:Rule(order = 0)
     val composeRule = createComposeRule()
 
-    private val commentItem = mockCommentItemUiState
-
-    private val commentsUiState = CommentsUiState.Success(listOf(commentItem))
+    private val commentsUiState = CommentsUiState.Success(listOf(mockComment))
 
     private val uiState = PostDetailUiState.Success(
         postDetail = mockPostDetail1.toUiState(),
@@ -65,7 +64,7 @@ class PostDetailScreenTest {
                 )
             }
 
-            onNodeWithText(commentItem.content).performClick()
+            onNodeWithText(mockComment.content).performClick()
 
             onNodeWithText(getString(R.string.add_reply)).assertIsDisplayed()
         }
@@ -94,11 +93,10 @@ class PostDetailScreenTest {
         }
     }
 
-
     @Test
     fun shouldShowReplyCommentBottomSheet_WhenClickReplyComment() {
         composeRule.run {
-            val comment = commentItem.copy(parentId = 2)
+            val comment = mockReply
 
             setContent {
                 val snackbarHostState = remember { SnackbarHostState() }
@@ -182,7 +180,7 @@ class PostDetailScreenTest {
     fun shouldExistControllerParentId_WhenClickComment() {
         composeRule.run {
             val commentModalController = CommentModalController()
-            val comment = commentItem.copy(parentId = null)
+            val comment = mockComment
 
             setContent {
                 val snackbarHostState = remember { SnackbarHostState() }
@@ -213,8 +211,7 @@ class PostDetailScreenTest {
     fun replyParentIdIsSameWithControllerParentId_WhenClickReplyComment() {
         composeRule.run {
             val commentModalController = CommentModalController()
-            val parentId = 23
-            val replyComment = commentItem.copy(parentId = parentId)
+            val replyComment = mockReply
 
             setContent {
                 val snackbarHostState = remember { SnackbarHostState() }

--- a/presentation/src/androidTest/java/com/pocs/presentation/PostDetailScreenTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/PostDetailScreenTest.kt
@@ -96,7 +96,7 @@ class PostDetailScreenTest {
     @Test
     fun shouldShowReplyCommentBottomSheet_WhenClickReplyComment() {
         composeRule.run {
-            val comment = mockReply
+            val reply = mockReply
 
             setContent {
                 val snackbarHostState = remember { SnackbarHostState() }
@@ -104,7 +104,7 @@ class PostDetailScreenTest {
                 PostDetailContent(
                     uiState = uiState.copy(
                         comments = commentsUiState.copy(
-                            comments = listOf(comment)
+                            comments = listOf(reply)
                         )
                     ),
                     snackbarHostState = snackbarHostState,
@@ -116,7 +116,7 @@ class PostDetailScreenTest {
                 )
             }
 
-            onNodeWithText(comment.content).performClick()
+            onNodeWithText(reply.content).performClick()
 
             onNodeWithText(getString(R.string.add_reply)).assertIsDisplayed()
         }
@@ -510,7 +510,7 @@ class PostDetailScreenTest {
                 PostDetailContent(
                     uiState = uiState.copy(
                         comments = commentsUiState.copy(
-                            comments = listOf(mockComment.copy(isDeleted = true))
+                            comments = listOf(mockComment.copy(isDeleted = true, childrenCount = 2))
                         )
                     ),
                     snackbarHostState = snackbarHostState,

--- a/presentation/src/androidTest/java/com/pocs/presentation/PostDetailScreenTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/PostDetailScreenTest.kt
@@ -501,6 +501,31 @@ class PostDetailScreenTest {
         }
     }
 
+    @Test
+    fun shouldShowDeletedComment_WhenCommentWasDeleted() {
+        composeRule.run {
+            setContent {
+                val snackbarHostState = remember { SnackbarHostState() }
+
+                PostDetailContent(
+                    uiState = uiState.copy(
+                        comments = commentsUiState.copy(
+                            comments = listOf(mockComment.copy(isDeleted = true))
+                        )
+                    ),
+                    snackbarHostState = snackbarHostState,
+                    onEditClick = {},
+                    onDeleteClick = {},
+                    onCommentDelete = {},
+                    onCommentCreated = { _, _ -> },
+                    onCommentUpdated = { _, _ -> }
+                )
+            }
+
+            onNodeWithText(getString(R.string.deleted_comment)).assertIsDisplayed()
+        }
+    }
+
     @Suppress("SameParameterValue")
     private fun findVisibleTexts(text: String): List<SemanticsNode> {
         return composeRule.onAllNodes(hasText(text)).fetchSemanticsNodes().filter { semanticsNode ->

--- a/presentation/src/androidTest/java/com/pocs/presentation/comment/CommentTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/comment/CommentTest.kt
@@ -10,7 +10,8 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocs.presentation.view.component.Comment
-import com.pocs.test_library.mock.mockCommentItemUiState
+import com.pocs.test_library.mock.mockComment
+import com.pocs.test_library.mock.mockReply
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -34,7 +35,7 @@ class CommentTest {
         composeRule.run {
             setContent {
                 Comment(
-                    uiState = mockCommentItemUiState.copy(parentId = null),
+                    uiState = mockComment,
                     onClick = {}, onMoreButtonClick = {}, onReplyIconClick = {}
                 )
             }
@@ -48,7 +49,7 @@ class CommentTest {
         composeRule.run {
             setContent {
                 Comment(
-                    uiState = mockCommentItemUiState.copy(parentId = 2),
+                    uiState = mockReply,
                     onClick = {}, onMoreButtonClick = {}, onReplyIconClick = {}
                 )
             }
@@ -62,7 +63,7 @@ class CommentTest {
         composeRule.run {
             setContent {
                 Comment(
-                    uiState = mockCommentItemUiState.copy(parentId = null, childrenCount = 1),
+                    uiState = mockComment.copy(childrenCount = 1),
                     onClick = {}, onMoreButtonClick = {}, onReplyIconClick = {}
                 )
             }
@@ -76,7 +77,7 @@ class CommentTest {
         composeRule.run {
             setContent {
                 Comment(
-                    uiState = mockCommentItemUiState.copy(parentId = null, childrenCount = 0),
+                    uiState = mockComment.copy(childrenCount = 0),
                     onClick = {}, onMoreButtonClick = {}, onReplyIconClick = {}
                 )
             }
@@ -90,7 +91,7 @@ class CommentTest {
         composeRule.run {
             setContent {
                 Comment(
-                    uiState = mockCommentItemUiState.copy(canEdit = true, canDelete = false),
+                    uiState = mockComment.copy(canEdit = true, canDelete = false),
                     onClick = {}, onMoreButtonClick = {}, onReplyIconClick = {}
                 )
             }
@@ -104,7 +105,7 @@ class CommentTest {
         composeRule.run {
             setContent {
                 Comment(
-                    uiState = mockCommentItemUiState.copy(canEdit = false, canDelete = true),
+                    uiState = mockComment.copy(canEdit = false, canDelete = true),
                     onClick = {}, onMoreButtonClick = {}, onReplyIconClick = {}
                 )
             }
@@ -118,7 +119,7 @@ class CommentTest {
         composeRule.run {
             setContent {
                 Comment(
-                    uiState = mockCommentItemUiState.copy(canEdit = false, canDelete = false),
+                    uiState = mockComment.copy(canEdit = false, canDelete = false),
                     onClick = {}, onMoreButtonClick = {}, onReplyIconClick = {}
                 )
             }

--- a/presentation/src/main/java/com/pocs/presentation/mapper/CommentMapper.kt
+++ b/presentation/src/main/java/com/pocs/presentation/mapper/CommentMapper.kt
@@ -16,6 +16,7 @@ fun Comment.toUiState(currentUserId: Int?, isAdmin: Boolean): CommentItemUiState
         canEdit = isMine,
         canDelete = isMine || isAdmin,
         content = content,
-        date = createFormattedDateText(createdAt, updatedAt)
+        date = createFormattedDateText(createdAt, updatedAt),
+        isDeleted = canceledAt != null
     )
 }

--- a/presentation/src/main/java/com/pocs/presentation/model/comment/item/CommentItemUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/comment/item/CommentItemUiState.kt
@@ -2,7 +2,7 @@ package com.pocs.presentation.model.comment.item
 
 data class CommentItemUiState(
     val id: Int,
-    val parentId: Int?,
+    val parentId: Int,
     val childrenCount: Int,
     val postId: Int,
     val writer: CommentWriterUiState,

--- a/presentation/src/main/java/com/pocs/presentation/model/comment/item/CommentItemUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/comment/item/CommentItemUiState.kt
@@ -9,7 +9,8 @@ data class CommentItemUiState(
     val canEdit: Boolean,
     val canDelete: Boolean,
     val content: String,
-    val date: String
+    val date: String,
+    val isDeleted: Boolean
 ) {
     val isReply: Boolean get() = id != parentId
     val showMoreInfoButton: Boolean get() = canDelete || canEdit

--- a/presentation/src/main/java/com/pocs/presentation/model/comment/item/CommentItemUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/comment/item/CommentItemUiState.kt
@@ -11,5 +11,6 @@ data class CommentItemUiState(
     val content: String,
     val date: String
 ) {
+    val isReply: Boolean get() = id != parentId
     val showMoreInfoButton: Boolean get() = canDelete || canEdit
 }

--- a/presentation/src/main/java/com/pocs/presentation/model/post/PostDetailUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/post/PostDetailUiState.kt
@@ -1,5 +1,6 @@
 package com.pocs.presentation.model.post
 
+import androidx.annotation.StringRes
 import com.pocs.presentation.model.comment.CommentsUiState
 import com.pocs.presentation.model.post.item.PostDetailItemUiState
 
@@ -10,6 +11,7 @@ sealed class PostDetailUiState {
         val canDeletePost: Boolean,
         val isDeleteSuccess: Boolean = false,
         val userMessage: String? = null,
+        @StringRes val userMessageRes: Int? = null,
         val comments: CommentsUiState = CommentsUiState.Loading
     ) : PostDetailUiState()
 

--- a/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
@@ -100,8 +100,6 @@ fun Comment(
     onReplyIconClick: () -> Unit,
     onMoreButtonClick: () -> Unit
 ) {
-    val isReply = uiState.parentId != null
-
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -111,13 +109,13 @@ fun Comment(
                 interactionSource = remember { MutableInteractionSource() }
             )
             .background(
-                color = if (isReply) {
+                color = if (uiState.isReply) {
                     MaterialTheme.colorScheme.onBackground.copy(alpha = 0.03f)
                 } else {
                     MaterialTheme.colorScheme.background
                 }
             )
-            .padding(start = if (isReply) 20.dp else 0.dp)
+            .padding(start = if (uiState.isReply) 20.dp else 0.dp)
     ) {
         Row(
             modifier = Modifier.padding(top = 20.dp, start = 20.dp),
@@ -149,7 +147,7 @@ fun Comment(
                 }
             }
         }
-        if (isReply) {
+        if (uiState.isReply) {
             Box(modifier = Modifier.height(16.dp))
         } else {
             Row(

--- a/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
@@ -40,7 +40,9 @@ fun LazyListScope.commentItems(
     when (uiState) {
         is CommentsUiState.Failure -> {
             item {
-                CommentFailureContent()
+                CommentFailureContent(
+                    uiState.message ?: stringResource(R.string.failed_to_load_comment)
+                )
             }
         }
         CommentsUiState.Loading -> {
@@ -53,7 +55,7 @@ fun LazyListScope.commentItems(
                 val comment = uiState.comments[index]
 
                 Column {
-                    if (comment.isDeleted){
+                    if (comment.isDeleted) {
                         DeletedComment()
                     } else {
                         Comment(
@@ -184,14 +186,14 @@ private fun DeletedComment() {
 }
 
 @Composable
-private fun CommentFailureContent() {
+private fun CommentFailureContent(errorMessage: String) {
     Box(
         Modifier
             .fillMaxSize()
             .padding(20.dp)
     ) {
         Text(
-            text = stringResource(R.string.failed_to_load_comment),
+            text = errorMessage,
             style = MaterialTheme.typography.bodyLarge.copy(
                 color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.8f)
             )

--- a/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
@@ -242,7 +242,7 @@ fun CommentPreview() {
     Comment(
         uiState = CommentItemUiState(
             id = 10,
-            parentId = null,
+            parentId = 10,
             childrenCount = 2,
             postId = 1,
             canEdit = true,

--- a/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
@@ -53,12 +53,16 @@ fun LazyListScope.commentItems(
                 val comment = uiState.comments[index]
 
                 Column {
-                    Comment(
-                        uiState = comment,
-                        onClick = { onCommentClick(comment) },
-                        onReplyIconClick = { onReplyIconClick(comment) },
-                        onMoreButtonClick = { onMoreButtonClick(comment) }
-                    )
+                    if (comment.isDeleted){
+                        DeletedComment()
+                    } else {
+                        Comment(
+                            uiState = comment,
+                            onClick = { onCommentClick(comment) },
+                            onReplyIconClick = { onReplyIconClick(comment) },
+                            onMoreButtonClick = { onMoreButtonClick(comment) }
+                        )
+                    }
                     PocsDivider()
                 }
             }
@@ -167,6 +171,19 @@ fun Comment(
 }
 
 @Composable
+private fun DeletedComment() {
+    Text(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(20.dp),
+        text = stringResource(R.string.deleted_comment),
+        style = MaterialTheme.typography.bodyMedium.copy(
+            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f)
+        )
+    )
+}
+
+@Composable
 private fun CommentFailureContent() {
     Box(
         Modifier
@@ -187,7 +204,7 @@ private fun CommentFailureContent() {
 fun CommentsPreview() {
     val mockComment = CommentItemUiState(
         id = 10,
-        parentId = null,
+        parentId = 10,
         childrenCount = 0,
         postId = 1,
         canEdit = true,
@@ -197,11 +214,12 @@ fun CommentsPreview() {
             name = "홍길동"
         ),
         content = "댓글 내용입니다.",
-        date = "오늘"
+        date = "오늘",
+        isDeleted = false
     )
     val uiState = CommentsUiState.Success(
         comments = listOf(
-            mockComment,
+            mockComment.copy(isDeleted = true),
             mockComment.copy(childrenCount = 1),
             mockComment.copy(parentId = 10, id = 11),
             mockComment
@@ -234,10 +252,17 @@ fun CommentPreview() {
                 name = "홍길동"
             ),
             content = "댓글 내용입니다.",
-            date = "오늘"
+            date = "오늘",
+            isDeleted = false
         ),
         onClick = {},
         onMoreButtonClick = {},
         onReplyIconClick = {}
     )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun RemovedCommentPreview() {
+    DeletedComment()
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
@@ -99,11 +99,13 @@ fun CommentModalBottomSheet(
     }
 
     var showRecheckDialog by remember { mutableStateOf(false) }
+
+    val isNotEmpty = textFieldValueState.value.text.isNotEmpty()
     val canSend by rememberUpdatedState(
         if (controller.isUpdate) {
-            textFieldValueState.value.text != controller.commentToBeUpdated!!.content
+            isNotEmpty && textFieldValueState.value.text != controller.commentToBeUpdated!!.content
         } else {
-            textFieldValueState.value.text.isNotEmpty()
+            isNotEmpty
         }
     )
 

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
@@ -366,7 +366,7 @@ private fun PostDetailFailureContent(uiState: PostDetailUiState.Failure) {
 private fun PostDetailContentPreview() {
     val mockComment = CommentItemUiState(
         id = 10,
-        parentId = null,
+        parentId = 10,
         childrenCount = 0,
         postId = 1,
         canEdit = true,

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
@@ -64,9 +64,14 @@ fun PostDetailScreen(
             if (uiState.isDeleteSuccess) {
                 onDeleteSuccess()
             }
-            if (uiState.userMessage != null) {
-                LaunchedEffect(uiState.userMessage) {
-                    snackbarHostState.showSnackbar(uiState.userMessage)
+
+            var message = uiState.userMessage
+            if (message == null && uiState.userMessageRes != null) {
+                message = stringResource(id = uiState.userMessageRes)
+            }
+            if (message != null) {
+                LaunchedEffect(message) {
+                    snackbarHostState.showSnackbar(message)
                     viewModel.userMessageShown()
                 }
             }

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
@@ -92,7 +92,7 @@ fun PostDetailContent(
     snackbarHostState: SnackbarHostState,
     onEditClick: () -> Unit,
     onDeleteClick: () -> Unit,
-    onCommentDelete: (CommentItemUiState) -> Unit,
+    onCommentDelete: (commentId: Int) -> Unit,
     onCommentCreated: CommentCreateCallback,
     onCommentUpdated: CommentUpdateCallback
 ) {
@@ -114,7 +114,7 @@ fun PostDetailContent(
         RecheckDialog(
             title = stringResource(id = R.string.are_you_sure_you_want_to_delete),
             onOkClick = {
-                commentToBeDeleted?.let { onCommentDelete(it) }
+                commentToBeDeleted?.let { onCommentDelete(it.id) }
                 commentToBeDeleted = null
             },
             onDismissRequest = { commentToBeDeleted = null },

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
@@ -371,7 +371,8 @@ private fun PostDetailContentPreview() {
             name = "홍길동"
         ),
         content = "댓글 내용입니다.",
-        date = "오늘"
+        date = "오늘",
+        isDeleted = false
     )
     val commentsUiState = CommentsUiState.Success(
         comments = listOf(

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.pocs.domain.model.user.UserType
 import com.pocs.domain.usecase.auth.GetCurrentUserUseCase
 import com.pocs.domain.usecase.comment.AddCommentUseCase
+import com.pocs.domain.usecase.comment.DeleteCommentUseCase
 import com.pocs.domain.usecase.comment.GetCommentsUseCase
 import com.pocs.domain.usecase.post.CanDeletePostUseCase
 import com.pocs.domain.usecase.post.CanEditPostUseCase
@@ -24,12 +25,18 @@ import javax.inject.Inject
 
 @HiltViewModel
 class PostDetailViewModel @Inject constructor(
+    // post
     private val getPostDetailUseCase: GetPostDetailUseCase,
     private val deletePostUseCase: DeletePostUseCase,
     private val canEditPostUseCase: CanEditPostUseCase,
     private val canDeletePostUseCase: CanDeletePostUseCase,
+
+    // comment
     private val getCommentsUseCase: GetCommentsUseCase,
     private val addCommentUseCase: AddCommentUseCase,
+    private val deleteCommentUseCase: DeleteCommentUseCase,
+
+    // user
     private val getCurrentUserUseCase: GetCurrentUserUseCase
 ) : ViewModel() {
 
@@ -104,9 +111,10 @@ class PostDetailViewModel @Inject constructor(
             )
             if (result.isSuccess) {
                 fetchComments()
+                // TODO: StringRes로 바꾸기
                 showUserMessage(message = "댓글 추가됨")
             } else {
-                showUserMessage(message = result.exceptionOrNull()?.message ?: "댓글 추가에 실패함")
+                showUserMessage(message = result.exceptionOrNull()?.message ?: "댓글 추가에 실패함") // TODO: StringRes로 바꾸기
             }
         }
     }
@@ -115,8 +123,18 @@ class PostDetailViewModel @Inject constructor(
         // TODO: 구현하기
     }
 
-    fun deleteComment(comment: CommentItemUiState) {
-        // TODO: 구현하기
+    fun deleteComment(commentId: Int) {
+        viewModelScope.launch {
+            val result = deleteCommentUseCase(commentId = commentId)
+            if (result.isSuccess) {
+                fetchComments()
+                // TODO: StringRes로 바꾸기
+                showUserMessage("댓글 삭제됨")
+            } else {
+                // TODO: StringRes로 바꾸기
+                showUserMessage("댓글 삭제에 실패함")
+            }
+        }
     }
 
     fun requestPostDeleting(id: Int) {
@@ -128,7 +146,7 @@ class PostDetailViewModel @Inject constructor(
                     (it as PostDetailUiState.Success).copy(isDeleteSuccess = true)
                 }
             } else {
-                val errorMessage = result.exceptionOrNull()!!.message ?: "게시글 삭제에 실패함"
+                val errorMessage = result.exceptionOrNull()!!.message ?: "게시글 삭제에 실패함" // TODO: StringRes로 바꾸기
                 showUserMessage(errorMessage)
             }
         }

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailViewModel.kt
@@ -7,13 +7,13 @@ import com.pocs.domain.usecase.auth.GetCurrentUserUseCase
 import com.pocs.domain.usecase.comment.AddCommentUseCase
 import com.pocs.domain.usecase.comment.DeleteCommentUseCase
 import com.pocs.domain.usecase.comment.GetCommentsUseCase
+import com.pocs.domain.usecase.comment.UpdateCommentUseCase
 import com.pocs.domain.usecase.post.CanDeletePostUseCase
 import com.pocs.domain.usecase.post.CanEditPostUseCase
 import com.pocs.domain.usecase.post.DeletePostUseCase
 import com.pocs.domain.usecase.post.GetPostDetailUseCase
 import com.pocs.presentation.mapper.toUiState
 import com.pocs.presentation.model.comment.CommentsUiState
-import com.pocs.presentation.model.comment.item.CommentItemUiState
 import com.pocs.presentation.model.post.PostDetailUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
@@ -34,6 +34,7 @@ class PostDetailViewModel @Inject constructor(
     // comment
     private val getCommentsUseCase: GetCommentsUseCase,
     private val addCommentUseCase: AddCommentUseCase,
+    private val updateCommentUseCase: UpdateCommentUseCase,
     private val deleteCommentUseCase: DeleteCommentUseCase,
 
     // user
@@ -119,8 +120,18 @@ class PostDetailViewModel @Inject constructor(
         }
     }
 
-    fun updateComment(id: Int, comment: String) {
-        // TODO: 구현하기
+    fun updateComment(id: Int, content: String) {
+        viewModelScope.launch {
+            val result = updateCommentUseCase(commentId = id, content = content)
+            if (result.isSuccess) {
+                fetchComments()
+                // TODO: StringRes로 바꾸기
+                showUserMessage("댓글 수정됨")
+            } else {
+                // TODO: StringRes로 바꾸기
+                showUserMessage(result.exceptionOrNull()?.message ?: "댓글 수정 실패함")
+            }
+        }
     }
 
     fun deleteComment(commentId: Int) {
@@ -132,7 +143,7 @@ class PostDetailViewModel @Inject constructor(
                 showUserMessage("댓글 삭제됨")
             } else {
                 // TODO: StringRes로 바꾸기
-                showUserMessage("댓글 삭제에 실패함")
+                showUserMessage(result.exceptionOrNull()?.message ?: "댓글 삭제에 실패함")
             }
         }
     }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -107,6 +107,7 @@
     <string name="search_by_name">이름 검색</string>
     <string name="query_min_length_error">2글자 이상 입력하세요.</string>
     <string name="views">조회수</string>
+    <string name="deleted_comment">삭제된 댓글입니다.</string>
     <string-array name="admin_tab">
         <item>전체 게시글</item>
         <item>회원목록</item>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -108,6 +108,13 @@
     <string name="query_min_length_error">2글자 이상 입력하세요.</string>
     <string name="views">조회수</string>
     <string name="deleted_comment">삭제된 댓글입니다.</string>
+    <string name="comment_added">댓글 추가됨</string>
+    <string name="failed_to_add_comment">댓글 추가에 실패함</string>
+    <string name="failed_to_edit_comment">댓글 수정 실패함</string>
+    <string name="comment_edited">댓글 수정됨</string>
+    <string name="comment_deleted">댓글 삭제됨</string>
+    <string name="failed_to_delete_comment">댓글 삭제에 실패함</string>
+    <string name="failed_to_delete_post">게시글 삭제에 실패함</string>
     <string-array name="admin_tab">
         <item>전체 게시글</item>
         <item>회원목록</item>

--- a/presentation/src/test/java/com/pocs/presentation/PostDetailViewModelTest.kt
+++ b/presentation/src/test/java/com/pocs/presentation/PostDetailViewModelTest.kt
@@ -1,15 +1,18 @@
 package com.pocs.presentation
 
 import com.pocs.domain.usecase.auth.GetCurrentUserUseCase
+import com.pocs.domain.usecase.comment.AddCommentUseCase
 import com.pocs.domain.usecase.comment.GetCommentsUseCase
 import com.pocs.domain.usecase.post.CanDeletePostUseCase
 import com.pocs.domain.usecase.post.CanEditPostUseCase
 import com.pocs.domain.usecase.post.DeletePostUseCase
 import com.pocs.domain.usecase.post.GetPostDetailUseCase
+import com.pocs.presentation.model.comment.CommentsUiState
 import com.pocs.presentation.model.post.PostDetailUiState
 import com.pocs.presentation.view.post.detail.PostDetailViewModel
 import com.pocs.test_library.fake.FakeAuthRepositoryImpl
 import com.pocs.test_library.fake.FakePostRepositoryImpl
+import com.pocs.test_library.fake.source.FakeCommentRepositoryImpl
 import com.pocs.test_library.mock.mockNormalUserDetail
 import com.pocs.test_library.mock.mockPostDetail1
 import com.pocs.test_library.rule.JodaRule
@@ -22,8 +25,7 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -38,13 +40,15 @@ class PostDetailViewModelTest {
 
     private val authRepository = FakeAuthRepositoryImpl()
     private val postRepository = FakePostRepositoryImpl()
+    private val commentRepository = FakeCommentRepositoryImpl()
 
     private val viewModel = PostDetailViewModel(
         GetPostDetailUseCase(postRepository),
         DeletePostUseCase(postRepository, authRepository),
         CanEditPostUseCase(authRepository),
         CanDeletePostUseCase(authRepository),
-        GetCommentsUseCase(),
+        GetCommentsUseCase(commentRepository),
+        AddCommentUseCase(commentRepository),
         GetCurrentUserUseCase(authRepository)
     )
 
@@ -119,5 +123,97 @@ class PostDetailViewModelTest {
         viewModel.requestPostDeleting(1)
 
         assertEquals(true, (viewModel.uiState.value as PostDetailUiState.Success).isDeleteSuccess)
+    }
+
+    @Test
+    fun shouldFetchComments_WhenSuccessToFetchPost() = runTest {
+        postRepository.postDetailResult = Result.success(mockPostDetail1)
+        commentRepository.isSuccessToGetAllBy = true
+        val collectJob = launch(UnconfinedTestDispatcher()) {
+            viewModel.uiState.collect()
+        }
+
+        viewModel.fetchPost(mockPostDetail1.id)
+
+        val uiState = viewModel.uiState.value as PostDetailUiState.Success
+        assertTrue(uiState.comments is CommentsUiState.Success)
+
+        collectJob.cancel()
+    }
+
+    @Test
+    fun shouldCommentsUiStateIsFailure_WhenFailedToFetchComment() = runTest {
+        postRepository.postDetailResult = Result.success(mockPostDetail1)
+        commentRepository.isSuccessToGetAllBy = false
+        val collectJob = launch(UnconfinedTestDispatcher()) {
+            viewModel.uiState.collect()
+        }
+
+        viewModel.fetchPost(mockPostDetail1.id)
+
+        val uiState = viewModel.uiState.value as PostDetailUiState.Success
+        assertTrue(uiState.comments is CommentsUiState.Failure)
+
+        collectJob.cancel()
+    }
+
+    @Test
+    fun shouldCommentIsAdded_WhenSuccessToAdd() = runTest {
+        postRepository.postDetailResult = Result.success(mockPostDetail1)
+        commentRepository.isSuccessToGetAllBy = true
+        commentRepository.isSuccessToAdd = true
+        val collectJob = launch(UnconfinedTestDispatcher()) {
+            viewModel.uiState.collect()
+        }
+        viewModel.fetchPost(mockPostDetail1.id)
+
+        var uiState = viewModel.uiState.value as PostDetailUiState.Success
+        assertEquals(0, (uiState.comments as CommentsUiState.Success).comments.size)
+
+        viewModel.addComment(null, "test")
+
+        uiState = viewModel.uiState.value as PostDetailUiState.Success
+        assertEquals(1, (uiState.comments as CommentsUiState.Success).comments.size)
+
+        collectJob.cancel()
+    }
+
+    @Test
+    fun shouldCommentIsNotAdded_WhenFailedToAdd() = runTest {
+        postRepository.postDetailResult = Result.success(mockPostDetail1)
+        commentRepository.isSuccessToGetAllBy = true
+        commentRepository.isSuccessToAdd = false
+        val collectJob = launch(UnconfinedTestDispatcher()) {
+            viewModel.uiState.collect()
+        }
+        viewModel.fetchPost(mockPostDetail1.id)
+
+        var uiState = viewModel.uiState.value as PostDetailUiState.Success
+        assertEquals(0, (uiState.comments as CommentsUiState.Success).comments.size)
+
+        viewModel.addComment(null, "test")
+
+        uiState = viewModel.uiState.value as PostDetailUiState.Success
+        assertEquals(0, (uiState.comments as CommentsUiState.Success).comments.size)
+
+        collectJob.cancel()
+    }
+
+    @Test
+    fun shouldHaveErrorMessage_WhenFailedToAddComment() = runTest {
+        postRepository.postDetailResult = Result.success(mockPostDetail1)
+        commentRepository.isSuccessToGetAllBy = true
+        commentRepository.isSuccessToAdd = false
+        val collectJob = launch(UnconfinedTestDispatcher()) {
+            viewModel.uiState.collect()
+        }
+        viewModel.fetchPost(mockPostDetail1.id)
+
+        viewModel.addComment(null, "test")
+
+        val uiState = viewModel.uiState.value as PostDetailUiState.Success
+        assertNotNull(uiState.userMessage)
+
+        collectJob.cancel()
     }
 }

--- a/presentation/src/test/java/com/pocs/presentation/PostDetailViewModelTest.kt
+++ b/presentation/src/test/java/com/pocs/presentation/PostDetailViewModelTest.kt
@@ -14,7 +14,7 @@ import com.pocs.presentation.model.post.PostDetailUiState
 import com.pocs.presentation.view.post.detail.PostDetailViewModel
 import com.pocs.test_library.fake.FakeAuthRepositoryImpl
 import com.pocs.test_library.fake.FakePostRepositoryImpl
-import com.pocs.test_library.fake.source.FakeCommentRepositoryImpl
+import com.pocs.test_library.fake.FakeCommentRepositoryImpl
 import com.pocs.test_library.mock.mockNormalUserDetail
 import com.pocs.test_library.mock.mockPostDetail1
 import com.pocs.test_library.rule.JodaRule

--- a/test-library/src/main/java/com/pocs/test_library/di/FakeRemoteModule.kt
+++ b/test-library/src/main/java/com/pocs/test_library/di/FakeRemoteModule.kt
@@ -1,14 +1,8 @@
 package com.pocs.test_library.di
 
 import com.pocs.data.di.RemoteModule
-import com.pocs.data.source.AdminRemoteDataSource
-import com.pocs.data.source.AuthRemoteDataSource
-import com.pocs.data.source.PostRemoteDataSource
-import com.pocs.data.source.UserRemoteDataSource
-import com.pocs.test_library.fake.source.remote.FakeAdminRemoteDataSource
-import com.pocs.test_library.fake.source.remote.FakeAuthRemoteDataSource
-import com.pocs.test_library.fake.source.remote.FakePostRemoteDataSource
-import com.pocs.test_library.fake.source.remote.FakeUserRemoteDataSource
+import com.pocs.data.source.*
+import com.pocs.test_library.fake.source.remote.*
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.components.SingletonComponent
@@ -25,6 +19,10 @@ abstract class FakeRemoteModule {
     @Singleton
     @Binds
     abstract fun providePostRemoteDataSource(fakePostRemoteDataSource: FakePostRemoteDataSource): PostRemoteDataSource
+
+    @Singleton
+    @Binds
+    abstract fun provideCommentRemoteDataSource(fakeCommentRemoteDataSource: FakeCommentRemoteDataSource): CommentRemoteDataSource
 
     @Singleton
     @Binds

--- a/test-library/src/main/java/com/pocs/test_library/di/FakeRepositoryModule.kt
+++ b/test-library/src/main/java/com/pocs/test_library/di/FakeRepositoryModule.kt
@@ -1,14 +1,12 @@
 package com.pocs.test_library.di
 
 import com.pocs.data.di.RepositoryModule
-import com.pocs.domain.repository.AdminRepository
-import com.pocs.domain.repository.AuthRepository
-import com.pocs.domain.repository.PostRepository
-import com.pocs.domain.repository.UserRepository
+import com.pocs.domain.repository.*
 import com.pocs.test_library.fake.FakeAdminRepositoryImpl
 import com.pocs.test_library.fake.FakeAuthRepositoryImpl
 import com.pocs.test_library.fake.FakePostRepositoryImpl
 import com.pocs.test_library.fake.FakeUserRepositoryImpl
+import com.pocs.test_library.fake.source.FakeCommentRepositoryImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.components.SingletonComponent
@@ -25,6 +23,10 @@ abstract class FakeRepositoryModule {
     @Singleton
     @Binds
     abstract fun providePostRepository(fakePostRepositoryImpl: FakePostRepositoryImpl): PostRepository
+
+    @Singleton
+    @Binds
+    abstract fun provideCommentRepository(fakeCommentRepositoryImpl: FakeCommentRepositoryImpl): CommentRepository
 
     @Singleton
     @Binds

--- a/test-library/src/main/java/com/pocs/test_library/di/FakeRepositoryModule.kt
+++ b/test-library/src/main/java/com/pocs/test_library/di/FakeRepositoryModule.kt
@@ -6,7 +6,7 @@ import com.pocs.test_library.fake.FakeAdminRepositoryImpl
 import com.pocs.test_library.fake.FakeAuthRepositoryImpl
 import com.pocs.test_library.fake.FakePostRepositoryImpl
 import com.pocs.test_library.fake.FakeUserRepositoryImpl
-import com.pocs.test_library.fake.source.FakeCommentRepositoryImpl
+import com.pocs.test_library.fake.FakeCommentRepositoryImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.components.SingletonComponent

--- a/test-library/src/main/java/com/pocs/test_library/fake/FakeCommentRepositoryImpl.kt
+++ b/test-library/src/main/java/com/pocs/test_library/fake/FakeCommentRepositoryImpl.kt
@@ -1,4 +1,4 @@
-package com.pocs.test_library.fake.source
+package com.pocs.test_library.fake
 
 import com.pocs.domain.model.comment.Comment
 import com.pocs.domain.model.comment.CommentWriter

--- a/test-library/src/main/java/com/pocs/test_library/fake/FakeCommentRepositoryImpl.kt
+++ b/test-library/src/main/java/com/pocs/test_library/fake/FakeCommentRepositoryImpl.kt
@@ -26,9 +26,10 @@ class FakeCommentRepositoryImpl @Inject constructor() : CommentRepository {
             return Result.failure(Exception("error"))
         }
         val parentIndex = comments.indexOfFirst { it.id == parentId }
+        val id = idCounter++
         val newComment = Comment(
-            id = idCounter++,
-            parentId = parentId,
+            id = id,
+            parentId = parentId ?: id,
             childrenCount = 0,
             postId = postId,
             writer = CommentWriter(
@@ -41,6 +42,7 @@ class FakeCommentRepositoryImpl @Inject constructor() : CommentRepository {
         )
         var index = 0
         if (parentIndex != -1) {
+            // 답글 목록의 최하단 인덱스로 이동한다.
             while (comments.size < index && comments[parentIndex + index].parentId == parentId) {
                 ++index
             }

--- a/test-library/src/main/java/com/pocs/test_library/fake/FakeCommentRepositoryImpl.kt
+++ b/test-library/src/main/java/com/pocs/test_library/fake/FakeCommentRepositoryImpl.kt
@@ -55,9 +55,9 @@ class FakeCommentRepositoryImpl @Inject constructor() : CommentRepository {
         if (!isSuccessToUpdate) {
             return Result.failure(Exception("error"))
         }
-        val prevComment = comments.first { it.id == commentId }
-        val newComment = prevComment.copy(content = content)
-        val index = comments.indexOf(prevComment)
+        val oldComment = comments.first { it.id == commentId }
+        val newComment = oldComment.copy(content = content)
+        val index = comments.indexOf(oldComment)
         comments[index] = newComment
         return Result.success(Unit)
     }

--- a/test-library/src/main/java/com/pocs/test_library/fake/source/FakeCommentRepositoryImpl.kt
+++ b/test-library/src/main/java/com/pocs/test_library/fake/source/FakeCommentRepositoryImpl.kt
@@ -14,6 +14,7 @@ class FakeCommentRepositoryImpl @Inject constructor() : CommentRepository {
 
     var isSuccessToGetAllBy = true
     var isSuccessToAdd = true
+    var isSuccessToUpdate = true
     var isSuccessToDelete = true
 
     override suspend fun getAllBy(postId: Int): Result<List<Comment>> {
@@ -45,6 +46,17 @@ class FakeCommentRepositoryImpl @Inject constructor() : CommentRepository {
             }
         }
         comments.add(index, newComment)
+        return Result.success(Unit)
+    }
+
+    override suspend fun update(commentId: Int, content: String): Result<Unit> {
+        if (!isSuccessToUpdate) {
+            return Result.failure(Exception("error"))
+        }
+        val prevComment = comments.first { it.id == commentId }
+        val newComment = prevComment.copy(content = content)
+        val index = comments.indexOf(prevComment)
+        comments[index] = newComment
         return Result.success(Unit)
     }
 

--- a/test-library/src/main/java/com/pocs/test_library/fake/source/FakeCommentRepositoryImpl.kt
+++ b/test-library/src/main/java/com/pocs/test_library/fake/source/FakeCommentRepositoryImpl.kt
@@ -7,12 +7,14 @@ import javax.inject.Inject
 
 class FakeCommentRepositoryImpl @Inject constructor() : CommentRepository {
 
-    private var idCounter = 0
+    var idCounter = 0
+        private set
 
     private val comments = mutableListOf<Comment>()
 
     var isSuccessToGetAllBy = true
     var isSuccessToAdd = true
+    var isSuccessToDelete = true
 
     override suspend fun getAllBy(postId: Int): Result<List<Comment>> {
         return if (isSuccessToGetAllBy) Result.success(comments) else Result.failure(Exception("ee"))
@@ -43,6 +45,14 @@ class FakeCommentRepositoryImpl @Inject constructor() : CommentRepository {
             }
         }
         comments.add(index, newComment)
+        return Result.success(Unit)
+    }
+
+    override suspend fun delete(commentId: Int): Result<Unit> {
+        if (!isSuccessToDelete) {
+            return Result.failure(Exception("ee"))
+        }
+        comments.removeAll { it.id == commentId }
         return Result.success(Unit)
     }
 }

--- a/test-library/src/main/java/com/pocs/test_library/fake/source/FakeCommentRepositoryImpl.kt
+++ b/test-library/src/main/java/com/pocs/test_library/fake/source/FakeCommentRepositoryImpl.kt
@@ -1,0 +1,48 @@
+package com.pocs.test_library.fake.source
+
+import com.pocs.domain.model.comment.Comment
+import com.pocs.domain.model.comment.CommentWriter
+import com.pocs.domain.repository.CommentRepository
+import javax.inject.Inject
+
+class FakeCommentRepositoryImpl @Inject constructor() : CommentRepository {
+
+    private var idCounter = 0
+
+    private val comments = mutableListOf<Comment>()
+
+    var isSuccessToGetAllBy = true
+    var isSuccessToAdd = true
+
+    override suspend fun getAllBy(postId: Int): Result<List<Comment>> {
+        return if (isSuccessToGetAllBy) Result.success(comments) else Result.failure(Exception("ee"))
+    }
+
+    override suspend fun add(content: String, postId: Int, parentId: Int?): Result<Unit> {
+        if (!isSuccessToAdd) {
+            return Result.failure(Exception("error"))
+        }
+        val parentIndex = comments.indexOfFirst { it.id == parentId }
+        val newComment = Comment(
+            id = idCounter++,
+            parentId = parentId,
+            childrenCount = 0,
+            postId = postId,
+            writer = CommentWriter(
+                userId = 1,
+                name = "홍길동"
+            ),
+            content = content,
+            createdAt = "2022-09-02 13:09",
+            updatedAt = null
+        )
+        var index = 0
+        if (parentIndex != -1) {
+            while (comments.size < index && comments[parentIndex + index].parentId == parentId) {
+                ++index
+            }
+        }
+        comments.add(index, newComment)
+        return Result.success(Unit)
+    }
+}

--- a/test-library/src/main/java/com/pocs/test_library/fake/source/remote/FakeCommentRemoteDataSource.kt
+++ b/test-library/src/main/java/com/pocs/test_library/fake/source/remote/FakeCommentRemoteDataSource.kt
@@ -15,4 +15,8 @@ class FakeCommentRemoteDataSource @Inject constructor() : CommentRemoteDataSourc
     override suspend fun add(commentAddBody: CommentAddBody): Response<ResponseBody<Unit>> {
         TODO("Not yet implemented")
     }
+
+    override suspend fun delete(commentId: Int): Response<ResponseBody<Unit>> {
+        TODO("Not yet implemented")
+    }
 }

--- a/test-library/src/main/java/com/pocs/test_library/fake/source/remote/FakeCommentRemoteDataSource.kt
+++ b/test-library/src/main/java/com/pocs/test_library/fake/source/remote/FakeCommentRemoteDataSource.kt
@@ -2,6 +2,7 @@ package com.pocs.test_library.fake.source.remote
 
 import com.pocs.data.model.ResponseBody
 import com.pocs.data.model.comment.CommentAddBody
+import com.pocs.data.model.comment.CommentUpdateBody
 import com.pocs.data.model.comment.CommentsDto
 import com.pocs.data.source.CommentRemoteDataSource
 import retrofit2.Response
@@ -16,7 +17,10 @@ class FakeCommentRemoteDataSource @Inject constructor() : CommentRemoteDataSourc
         TODO("Not yet implemented")
     }
 
-    override suspend fun update(commentId: Int, content: String): Response<ResponseBody<Unit>> {
+    override suspend fun update(
+        commentId: Int,
+        commentUpdateBody: CommentUpdateBody
+    ): Response<ResponseBody<Unit>> {
         TODO("Not yet implemented")
     }
 

--- a/test-library/src/main/java/com/pocs/test_library/fake/source/remote/FakeCommentRemoteDataSource.kt
+++ b/test-library/src/main/java/com/pocs/test_library/fake/source/remote/FakeCommentRemoteDataSource.kt
@@ -1,0 +1,18 @@
+package com.pocs.test_library.fake.source.remote
+
+import com.pocs.data.model.ResponseBody
+import com.pocs.data.model.comment.CommentAddBody
+import com.pocs.data.model.comment.CommentsDto
+import com.pocs.data.source.CommentRemoteDataSource
+import retrofit2.Response
+import javax.inject.Inject
+
+class FakeCommentRemoteDataSource @Inject constructor() : CommentRemoteDataSource {
+    override suspend fun getAllBy(postId: Int): Response<ResponseBody<CommentsDto>> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun add(commentAddBody: CommentAddBody): Response<ResponseBody<Unit>> {
+        TODO("Not yet implemented")
+    }
+}

--- a/test-library/src/main/java/com/pocs/test_library/fake/source/remote/FakeCommentRemoteDataSource.kt
+++ b/test-library/src/main/java/com/pocs/test_library/fake/source/remote/FakeCommentRemoteDataSource.kt
@@ -16,6 +16,10 @@ class FakeCommentRemoteDataSource @Inject constructor() : CommentRemoteDataSourc
         TODO("Not yet implemented")
     }
 
+    override suspend fun update(commentId: Int, content: String): Response<ResponseBody<Unit>> {
+        TODO("Not yet implemented")
+    }
+
     override suspend fun delete(commentId: Int): Response<ResponseBody<Unit>> {
         TODO("Not yet implemented")
     }

--- a/test-library/src/main/java/com/pocs/test_library/mock/Comment.kt
+++ b/test-library/src/main/java/com/pocs/test_library/mock/Comment.kt
@@ -3,9 +3,9 @@ package com.pocs.test_library.mock
 import com.pocs.presentation.model.comment.item.CommentItemUiState
 import com.pocs.presentation.model.comment.item.CommentWriterUiState
 
-val mockCommentItemUiState = CommentItemUiState(
+val mockComment = CommentItemUiState(
     id = 10,
-    parentId = null,
+    parentId = 10,
     childrenCount = 0,
     postId = 1,
     canEdit = true,
@@ -15,5 +15,22 @@ val mockCommentItemUiState = CommentItemUiState(
         name = "홍길동"
     ),
     content = "댓글 내용입니다.",
-    date = "오늘"
+    date = "오늘",
+    isDeleted = false
+)
+
+val mockReply = CommentItemUiState(
+    id = 13,
+    parentId = 10,
+    childrenCount = 0,
+    postId = 1,
+    canEdit = true,
+    canDelete = true,
+    writer = CommentWriterUiState(
+        userId = 1,
+        name = "홍길동"
+    ),
+    content = "댓글 내용입니다.",
+    date = "오늘",
+    isDeleted = false
 )


### PR DESCRIPTION
Resolves #176 

- commentId와 parentId가 동일한 경우에 댓글로 판단하기로 벡엔드에서 수정했습니다. 이전에는 parentId가 `null`이면 댓글로 판단했습니다. null로 하는건 구현이 어렵다고 합니다.
- 삭제 **안된** 답글이 존재하는 **삭제된** 댓글의 경우 아래와 같이 `삭제된 댓글입니다.` 문구가 보입니다.
  ![image](https://user-images.githubusercontent.com/57604817/185973995-797ee4c0-ba55-41ec-b695-5cf5c09aa404.png)


## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [x] Action에서 진행하는 테스트를 모두 통과했는가?
- [x] 수정 사항을 검증할 테스트를 추가하였는가?
- [ ] 리뷰를 받았는가?