### PR TITLE
관리자로 로그인 했을 때 내 댓글이 아닌 댓글은 편집할 수 없도록 수정

### DIFF
--- a/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/OptionModalBottomSheet.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/OptionModalBottomSheet.kt
@@ -22,14 +22,14 @@ import com.pocs.presentation.model.comment.item.CommentItemUiState
 import kotlinx.coroutines.launch
 
 @Immutable
-data class Option(
+data class Option<T>(
     val imageVector: ImageVector,
     @StringRes val stringResId: Int,
-    val onClick: (CommentItemUiState) -> Unit
+    val onClick: (onClickCallBackData: T) -> Unit
 )
 
 @Composable
-private fun OptionBottomSheet(controller: OptionModalController) {
+private fun <T> OptionBottomSheet(controller: OptionModalController<T>) {
     val options = controller.options
 
     if (options == null || options.isEmpty()) {
@@ -46,7 +46,7 @@ private fun OptionBottomSheet(controller: OptionModalController) {
 }
 
 @Composable
-fun OptionBottomSheetItem(option: Option, controller: OptionModalController) {
+fun <T> OptionBottomSheetItem(option: Option<T>, controller: OptionModalController<T>) {
     val coroutineScope = rememberCoroutineScope()
     val interactionSource = remember { MutableInteractionSource() }
     val label = stringResource(id = option.stringResId)
@@ -60,7 +60,7 @@ fun OptionBottomSheetItem(option: Option, controller: OptionModalController) {
                 indication = rememberRipple(bounded = true),
                 role = Role.Button,
                 onClick = {
-                    option.onClick(requireNotNull(controller.comment))
+                    option.onClick(requireNotNull(controller.onClickCallBackData))
                     coroutineScope.launch {
                         controller.hide()
                     }
@@ -83,9 +83,9 @@ fun OptionBottomSheetItem(option: Option, controller: OptionModalController) {
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
-fun OptionModalBottomSheet(
-    optionBuilder: (CommentItemUiState?) -> List<Option>,
-    controller: OptionModalController,
+fun <T> OptionModalBottomSheet(
+    optionBuilder: (T?) -> List<Option<T>>,
+    controller: OptionModalController<T>,
     content: @Composable () -> Unit
 ) {
     val bottomSheetState = rememberModalBottomSheetState(ModalBottomSheetValue.Hidden)
@@ -111,22 +111,22 @@ fun OptionModalBottomSheet(
 }
 
 @OptIn(ExperimentalMaterialApi::class)
-class OptionModalController {
+class OptionModalController<T> {
 
     private lateinit var modalBottomSheetState: ModalBottomSheetState
-    private lateinit var optionBuilder: (CommentItemUiState?) -> List<Option>
+    private lateinit var optionBuilder: (T?) -> List<Option<T>>
 
     private var inited: Boolean = false
 
-    private var _comment: CommentItemUiState? = null
-    val comment get() = _comment
+    private var _onClickCallBackData: T? = null
+    val onClickCallBackData get() = _onClickCallBackData
 
-    var options by mutableStateOf<List<Option>?>(null)
+    var options by mutableStateOf<List<Option<T>>?>(null)
         private set
 
     fun init(
         modalBottomSheetState: ModalBottomSheetState,
-        optionBuilder: (CommentItemUiState?) -> List<Option>
+        optionBuilder: (T?) -> List<Option<T>>
     ) {
         check(!inited) { "이미 초기화되었습니다." }
         inited = true
@@ -134,16 +134,16 @@ class OptionModalController {
         this.optionBuilder = optionBuilder
     }
 
-    suspend fun show(comment: CommentItemUiState) {
-        options = optionBuilder(comment)
-        _comment = comment
+    suspend fun show(onClickCallBackData: T) {
+        options = optionBuilder(onClickCallBackData)
+        _onClickCallBackData = onClickCallBackData
         modalBottomSheetState.show()
     }
 
     suspend fun hide() {
         modalBottomSheetState.hide()
         options = null
-        _comment = null
+        _onClickCallBackData = null
     }
 }
 
@@ -151,7 +151,11 @@ class OptionModalController {
 @Composable
 private fun OptionBottomSheetItemPreview() {
     OptionBottomSheetItem(
-        Option(imageVector = Icons.Default.Edit, stringResId = R.string.edit, onClick = {}),
-        controller = OptionModalController()
+        Option(
+            imageVector = Icons.Default.Edit,
+            stringResId = R.string.edit,
+            onClick = {}
+        ),
+        controller = OptionModalController<CommentItemUiState>()
     )
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/PocsModalBottomSheet.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/PocsModalBottomSheet.kt
@@ -1,5 +1,6 @@
 package com.pocs.presentation.view.component.bottomsheet
 
+import androidx.annotation.VisibleForTesting
 import androidx.compose.animation.core.TweenSpec
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.Canvas
@@ -15,6 +16,7 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.dismiss
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Dp
@@ -23,6 +25,9 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.math.max
 import kotlin.math.roundToInt
+
+@VisibleForTesting
+const val MODAL_BOTTOM_SHEET_CONTENT_TAG = "ModalBottomSheetContent"
 
 /**
  * [ModalBottomSheetLayout]로 원하는 구현을 할 수 없어서 복사한 컴포즈 함수이다.
@@ -79,6 +84,7 @@ fun PocsModalBottomSheetLayout(
         }
         Surface(
             Modifier
+                .testTag(MODAL_BOTTOM_SHEET_CONTENT_TAG)
                 .fillMaxWidth()
                 .alpha(sheetAlpha)
                 .offset {

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
@@ -94,7 +94,7 @@ fun PostDetailScreen(
 fun PostDetailContent(
     uiState: PostDetailUiState.Success,
     commentModalController: CommentModalController = remember { CommentModalController() },
-    optionModalController: OptionModalController = remember { OptionModalController() },
+    optionModalController: OptionModalController<CommentItemUiState> = remember { OptionModalController() },
     snackbarHostState: SnackbarHostState,
     onEditClick: () -> Unit,
     onDeleteClick: () -> Unit,
@@ -137,7 +137,7 @@ fun PostDetailContent(
         OptionModalBottomSheet(
             controller = optionModalController,
             optionBuilder = { comment ->
-                val options = mutableListOf<Option>()
+                val options = mutableListOf<Option<CommentItemUiState>>()
                 if (comment?.canEdit == true) {
                     options.add(Option(
                         imageVector = Icons.Default.Edit,
@@ -210,7 +210,7 @@ fun PostDetailContent(
                         uiState = uiState.comments,
                         onMoreButtonClick = {
                             coroutineScope.launch {
-                                optionModalController.show(comment = it)
+                                optionModalController.show(onClickCallBackData = it)
                             }
                         },
                         onReplyIconClick = {

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
@@ -94,6 +94,7 @@ fun PostDetailScreen(
 fun PostDetailContent(
     uiState: PostDetailUiState.Success,
     commentModalController: CommentModalController = remember { CommentModalController() },
+    optionModalController: OptionModalController = remember { OptionModalController() },
     snackbarHostState: SnackbarHostState,
     onEditClick: () -> Unit,
     onDeleteClick: () -> Unit,
@@ -134,9 +135,11 @@ fun PostDetailContent(
         onUpdated = onCommentUpdated
     ) {
         OptionModalBottomSheet(
-            options = remember {
-                listOf(
-                    Option(
+            controller = optionModalController,
+            optionBuilder = { comment ->
+                val options = mutableListOf<Option>()
+                if (comment?.canEdit == true) {
+                    options.add(Option(
                         imageVector = Icons.Default.Edit,
                         stringResId = R.string.edit,
                         onClick = {
@@ -144,15 +147,18 @@ fun PostDetailContent(
                                 commentModalController.showForUpdate(it)
                             }
                         }
-                    ),
-                    Option(
+                    ))
+                }
+                if (comment?.canDelete == true) {
+                    options.add(Option(
                         imageVector = Icons.Default.Delete,
                         stringResId = R.string.delete,
                         onClick = { commentToBeDeleted = it }
-                    )
-                )
+                    ))
+                }
+                return@OptionModalBottomSheet options
             }
-        ) { optionModalController ->
+        ) {
             val lazyListState = rememberLazyListState()
 
             Scaffold(


### PR DESCRIPTION
Fixes #192 

- 기존에는 `OptionModalBottomSheet`의 매개변수로 정적인 `option`을 받았기 때문에 댓글마다 버튼을 다르게 보이는것이 불가능했습니다. 이는 `optionBuilder`라는 콜백함수를 전달하도록 하여 댓글마다 다른 옵션메뉴들을 보이도록 했습니다. 예를 들어 내가 작성한 댓글인 경우 편집, 삭제 두 버튼이 모두 보이고, 관리자이지만 내 댓글이 아닌 경우 삭제버튼만 보입니다.
- `OptionModalBottomSheet`를 템플릿을 적용하여 추후에 댓글이 아닌 경우에도 이용할 수 있도록 했습니다.

|관리자이고 남의 댓글일때|나의 댓글일때|
|---|---|
|![image](https://user-images.githubusercontent.com/57604817/186405157-d57459d2-28d7-4409-aca8-7cd55505dca1.png)|![image](https://user-images.githubusercontent.com/57604817/186405180-434e6328-e132-4aa3-aa8b-fb5276c24f06.png)|


## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [x] Action에서 진행하는 테스트를 모두 통과했는가?
- [x] 수정 사항을 검증할 테스트를 추가하였는가?
- [x] 리뷰를 받았는가?