### PR TITLE
비회원 계정 생성 페이지 UI수정

### DIFF
--- a/presentation/src/main/java/com/pocs/presentation/view/user/anonymous/AnonymousCreateScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/user/anonymous/AnonymousCreateScreen.kt
@@ -73,7 +73,7 @@ fun AnonymousCreateScreen(
         ) {
             Box(Modifier.height(8.dp))
             Text(
-                stringResource(R.string.anonymous_precautions),
+                stringResource(R.string.anonymous_guideline),
                 fontSize = 12.sp,
                 modifier = Modifier.fillMaxWidth(),
                 textAlign = TextAlign.Center

--- a/presentation/src/main/java/com/pocs/presentation/view/user/anonymous/AnonymousCreateScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/user/anonymous/AnonymousCreateScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.pocs.presentation.R
 import com.pocs.presentation.constant.MAX_USER_ID_LEN
 import com.pocs.presentation.model.user.anonymous.AnonymousCreateInfoUiState
@@ -75,6 +76,7 @@ fun AnonymousCreateScreen(
                 style = MaterialTheme.typography.bodyMedium.copy(
                     color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f)
                 ),
+                lineHeight = 24.sp,
                 modifier = Modifier.fillMaxWidth()
             )
             Box(Modifier.height(8.dp))

--- a/presentation/src/main/java/com/pocs/presentation/view/user/anonymous/AnonymousCreateScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/user/anonymous/AnonymousCreateScreen.kt
@@ -74,9 +74,10 @@ fun AnonymousCreateScreen(
             Box(Modifier.height(8.dp))
             Text(
                 stringResource(R.string.anonymous_guideline),
-                fontSize = 12.sp,
-                modifier = Modifier.fillMaxWidth(),
-                textAlign = TextAlign.Center
+                style = MaterialTheme.typography.bodySmall.copy(
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f)
+                ),
+                modifier = Modifier.fillMaxWidth()
             )
             Box(Modifier.height(8.dp))
             PocsOutlineTextField(

--- a/presentation/src/main/java/com/pocs/presentation/view/user/anonymous/AnonymousCreateScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/user/anonymous/AnonymousCreateScreen.kt
@@ -72,7 +72,7 @@ fun AnonymousCreateScreen(
             Box(Modifier.height(8.dp))
             Text(
                 stringResource(R.string.anonymous_guideline),
-                style = MaterialTheme.typography.bodySmall.copy(
+                style = MaterialTheme.typography.bodyMedium.copy(
                     color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f)
                 ),
                 modifier = Modifier.fillMaxWidth()

--- a/presentation/src/main/java/com/pocs/presentation/view/user/anonymous/AnonymousCreateScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/user/anonymous/AnonymousCreateScreen.kt
@@ -9,10 +9,8 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.pocs.presentation.R
 import com.pocs.presentation.constant.MAX_USER_ID_LEN
 import com.pocs.presentation.model.user.anonymous.AnonymousCreateInfoUiState

--- a/presentation/src/main/java/com/pocs/presentation/view/user/anonymous/AnonymousCreateScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/user/anonymous/AnonymousCreateScreen.kt
@@ -5,14 +5,21 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.pocs.presentation.R
 import com.pocs.presentation.constant.MAX_USER_ID_LEN
+import com.pocs.presentation.constant.MAX_USER_PASSWORD_LEN
 import com.pocs.presentation.model.user.anonymous.AnonymousCreateInfoUiState
 import com.pocs.presentation.model.user.anonymous.AnonymousCreateUiState
 import com.pocs.presentation.view.component.RecheckHandler
@@ -29,6 +36,7 @@ fun AnonymousCreateScreen(
     onSuccessToCreate: () -> Unit
 ) {
     val snackBarHostState = remember { SnackbarHostState() }
+    var passwordVisible by remember { mutableStateOf(false) }
 
     if (uiState.isSuccessToCreate) {
         onSuccessToCreate()
@@ -69,15 +77,6 @@ fun AnonymousCreateScreen(
                 .verticalScroll(scrollState)
                 .fillMaxWidth()
         ) {
-            Box(Modifier.height(8.dp))
-            Text(
-                stringResource(R.string.anonymous_guideline),
-                style = MaterialTheme.typography.bodyMedium.copy(
-                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f)
-                ),
-                modifier = Modifier.fillMaxWidth()
-            )
-            Box(Modifier.height(8.dp))
             PocsOutlineTextField(
                 value = createInfo.userName,
                 label = stringResource(R.string.id),
@@ -107,6 +106,7 @@ fun AnonymousCreateScreen(
                 onClick = { uiState.onCreate() }
             )
             Box(Modifier.height(8.dp))
+            // TODO : TEXT 주의사항 추가하기
         }
     }
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/user/anonymous/AnonymousCreateScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/user/anonymous/AnonymousCreateScreen.kt
@@ -5,21 +5,16 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Visibility
-import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.pocs.presentation.R
 import com.pocs.presentation.constant.MAX_USER_ID_LEN
-import com.pocs.presentation.constant.MAX_USER_PASSWORD_LEN
 import com.pocs.presentation.model.user.anonymous.AnonymousCreateInfoUiState
 import com.pocs.presentation.model.user.anonymous.AnonymousCreateUiState
 import com.pocs.presentation.view.component.RecheckHandler
@@ -36,7 +31,6 @@ fun AnonymousCreateScreen(
     onSuccessToCreate: () -> Unit
 ) {
     val snackBarHostState = remember { SnackbarHostState() }
-    var passwordVisible by remember { mutableStateOf(false) }
 
     if (uiState.isSuccessToCreate) {
         onSuccessToCreate()
@@ -77,6 +71,14 @@ fun AnonymousCreateScreen(
                 .verticalScroll(scrollState)
                 .fillMaxWidth()
         ) {
+            Box(Modifier.height(8.dp))
+            Text(
+                stringResource(R.string.anonymous_precautions),
+                fontSize = 12.sp,
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Center
+            )
+            Box(Modifier.height(8.dp))
             PocsOutlineTextField(
                 value = createInfo.userName,
                 label = stringResource(R.string.id),
@@ -106,7 +108,6 @@ fun AnonymousCreateScreen(
                 onClick = { uiState.onCreate() }
             )
             Box(Modifier.height(8.dp))
-            // TODO : TEXT 주의사항 추가하기
         }
     }
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/user/anonymous/AnonymousCreateScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/user/anonymous/AnonymousCreateScreen.kt
@@ -5,13 +5,16 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.*
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.pocs.presentation.R
@@ -19,10 +22,10 @@ import com.pocs.presentation.constant.MAX_USER_ID_LEN
 import com.pocs.presentation.constant.MAX_USER_PASSWORD_LEN
 import com.pocs.presentation.model.user.anonymous.AnonymousCreateInfoUiState
 import com.pocs.presentation.model.user.anonymous.AnonymousCreateUiState
-import com.pocs.presentation.view.admin.user.create.EditGroupLabel
 import com.pocs.presentation.view.component.RecheckHandler
 import com.pocs.presentation.view.component.button.AppBarBackButton
 import com.pocs.presentation.view.component.button.PocsButton
+import com.pocs.presentation.view.component.textfield.PasswordOutlineTextField
 import com.pocs.presentation.view.component.textfield.PocsOutlineTextField
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -33,6 +36,7 @@ fun AnonymousCreateScreen(
     onSuccessToCreate: () -> Unit
 ) {
     val snackBarHostState = remember { SnackbarHostState() }
+    var passwordVisible by remember { mutableStateOf(false) }
 
     if (uiState.isSuccessToCreate) {
         onSuccessToCreate()
@@ -73,7 +77,6 @@ fun AnonymousCreateScreen(
                 .verticalScroll(scrollState)
                 .fillMaxWidth()
         ) {
-            EditGroupLabel("필수")
             PocsOutlineTextField(
                 value = createInfo.userName,
                 label = stringResource(R.string.id),
@@ -86,20 +89,15 @@ fun AnonymousCreateScreen(
                     uiState.updateCreateInfo { it.copy(userName = "") }
                 }
             )
-            PocsOutlineTextField(
-                value = createInfo.password,
-                label = stringResource(R.string.password),
-                maxLength = MAX_USER_PASSWORD_LEN,
-                keyboardOptions = KeyboardOptions(
-                    keyboardType = KeyboardType.Password,
-                    imeAction = ImeAction.Next
-                ),
-                onValueChange = { password ->
+            PasswordOutlineTextField(
+                password = createInfo.password,
+                onPasswordChange = { password ->
                     uiState.updateCreateInfo { it.copy(password = password) }
                 },
                 onClearClick = {
                     uiState.updateCreateInfo { it.copy(password = "") }
-                }
+                },
+                onSend = { uiState.onCreate() }
             )
             Box(modifier = Modifier.height(16.dp))
             PocsButton(

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -120,7 +120,6 @@
     <string name="failed_to_delete_comment">댓글 삭제에 실패함</string>
     <string name="failed_to_delete_post">게시글 삭제에 실패함</string>
     <string name="anonymous_guideline">임시 계정은 조회할 수 있는 게시글에 제한이 있어요. 또한 임시 계정으로는 질문 답변 게시글만 작성 가능해요.</string>
-    <string name="user_list_only_member">유저 목록(회원 전용)</string>
     <string-array name="admin_tab">
         <item>전체 게시글</item>
         <item>회원목록</item>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -120,6 +120,7 @@
     <string name="failed_to_delete_comment">댓글 삭제에 실패함</string>
     <string name="failed_to_delete_post">게시글 삭제에 실패함</string>
     <string name="anonymous_guideline">임시 계정은 조회할 수 있는 게시글에 제한이 있어요. 또한 임시 계정으로는 질문 답변 게시글만 작성 가능해요.</string>
+    <string name="user_list_only_member">유저 목록(회원 전용)</string>
     <string-array name="admin_tab">
         <item>전체 게시글</item>
         <item>회원목록</item>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -119,8 +119,8 @@
     <string name="comment_deleted">댓글 삭제됨</string>
     <string name="failed_to_delete_comment">댓글 삭제에 실패함</string>
     <string name="failed_to_delete_post">게시글 삭제에 실패함</string>
+    <string name="anonymous_guideline">임시 계정은 조회할 수 있는 게시글에 제한이 있어요. 또한 임시 계정으로는 질문 답변 게시글만 작성 가능해요.</string>
     <string name="user_list_only_member">유저 목록(회원 전용)</string>
-    <string name="anonymous_precautions">임시 계정은 조회할 수 있는 게시글에 제한이 있어요. \n또한 임시 계정으로는 질문 답변 게시글만 작성 가능해요.</string>
     <string-array name="admin_tab">
         <item>전체 게시글</item>
         <item>회원목록</item>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -119,7 +119,7 @@
     <string name="comment_deleted">댓글 삭제됨</string>
     <string name="failed_to_delete_comment">댓글 삭제에 실패함</string>
     <string name="failed_to_delete_post">게시글 삭제에 실패함</string>
-    <string name="anonymous_guideline">임시 계정은 조회할 수 있는 게시글에 제한이 있어요. \n또한 임시 계정으로는 질문 답변 게시글만 작성 가능해요.</string>
+    <string name="anonymous_guideline">임시 계정은 조회할 수 있는 게시글에 제한이 있어요. 또한 임시 계정으로는 질문 답변 게시글만 작성 가능해요.</string>
     <string-array name="admin_tab">
         <item>전체 게시글</item>
         <item>회원목록</item>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -120,6 +120,7 @@
     <string name="failed_to_delete_comment">댓글 삭제에 실패함</string>
     <string name="failed_to_delete_post">게시글 삭제에 실패함</string>
     <string name="user_list_only_member">유저 목록(회원 전용)</string>
+    <string name="anonymous_precautions">임시 계정은 조회할 수 있는 게시글에 제한이 있어요. \n또한 임시 계정으로는 질문 답변 게시글만 작성 가능해요.</string>
     <string-array name="admin_tab">
         <item>전체 게시글</item>
         <item>회원목록</item>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -119,7 +119,7 @@
     <string name="comment_deleted">댓글 삭제됨</string>
     <string name="failed_to_delete_comment">댓글 삭제에 실패함</string>
     <string name="failed_to_delete_post">게시글 삭제에 실패함</string>
-    <string name="anonymous_guideline">임시 계정은 조회할 수 있는 게시글에 제한이 있어요. 또한 임시 계정으로는 질문 답변 게시글만 작성 가능해요.</string>
+    <string name="anonymous_precautions">임시 계정은 조회할 수 있는 게시글에 제한이 있어요. \n또한 임시 계정으로는 질문 답변 게시글만 작성 가능해요.</string>
     <string-array name="admin_tab">
         <item>전체 게시글</item>
         <item>회원목록</item>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -119,7 +119,7 @@
     <string name="comment_deleted">댓글 삭제됨</string>
     <string name="failed_to_delete_comment">댓글 삭제에 실패함</string>
     <string name="failed_to_delete_post">게시글 삭제에 실패함</string>
-    <string name="anonymous_precautions">임시 계정은 조회할 수 있는 게시글에 제한이 있어요. \n또한 임시 계정으로는 질문 답변 게시글만 작성 가능해요.</string>
+    <string name="anonymous_guideline">임시 계정은 조회할 수 있는 게시글에 제한이 있어요. \n또한 임시 계정으로는 질문 답변 게시글만 작성 가능해요.</string>
     <string-array name="admin_tab">
         <item>전체 게시글</item>
         <item>회원목록</item>


### PR DESCRIPTION
<!-- 이곳에 PR 내용을 작성하세요 -->
기존에  필요하지않았던 '필수' 라벨을 삭제하였고, 비밀번호 텍스트 박스에 비밀번호를 감추었습니다.
로그인페이지에 사용되었던 PasswordOutlineTextField를 재사용하였기에 로직에서는 큰 차이가 없습니다.
Resolves #199 
<img width="392" alt="스크린샷 2022-08-26 오후 6 49 25" src="https://user-images.githubusercontent.com/58154638/186877967-2c691be0-8017-4b2d-9822-42aac9afd4c4.png">



## Merge 전 체크리스트

- [X] 코딩 컨벤션을 지켰는가?
- [ ] Action에서 진행하는 테스트를 모두 통과했는가?
- [ ] 수정 사항을 검증할 테스트를 추가하였는가?
- [ ] 리뷰를 받았는가?