### PR TITLE
댓글 추가 후 댓글 입력 창에 이전에 입력했던 댓글 남아있던 버그 수정

### DIFF
--- a/presentation/src/androidTest/java/com/pocs/presentation/PostDetailScreenTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/PostDetailScreenTest.kt
@@ -442,8 +442,12 @@ class PostDetailScreenTest {
                 text
             )
             onNodeWithContentDescription(getString(R.string.send_comment)).performClick()
+            mainClock.autoAdvance = false
+            mainClock.advanceTimeByFrame() // trigger recomposition
+            waitForIdle() // await layout pass to set up animation
+            mainClock.advanceTimeByFrame() // give animation a start time
+            mainClock.advanceTimeBy(10)
 
-            keyboardHelper.waitForKeyboardVisibility(false)
             assertFalse(keyboardHelper.isSoftwareKeyboardShown())
         }
     }

--- a/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
@@ -176,12 +176,11 @@ fun CommentModalBottomSheet(
                     }
 
                     coroutineScope.launch {
-                        controller.hide()
-                        // 댓글 추가 후 키보드를 숨기는 함수 호출 때문인지 가끔씩 입력한 텍스트 필드 값이 남아있는 버그가 존재한다.
+                        // 키보드를 숨기는 함수 호출 때문인지 가끔씩 입력한 텍스트 필드 그대로 값이 남아있는 버그가 존재한다.
+                        // 따라서 아래의 키보드를 숨기는 함수가 suspend 함수가 아니어도 이 코루틴 스코프 내에 위치해야 한다.
                         // https://github.com/hansung-pocs/blog-android/issues/177
-                        // 이는 아래와 같이 조금의 딜레이를 통해 해결할 수 있다.
-                        delay(10)
                         keyboardController?.hide()
+                        controller.hide()
                     }
                 },
                 hint = stringResource(

--- a/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
@@ -89,14 +89,7 @@ fun CommentModalBottomSheet(
         initialValue = ModalBottomSheetValue.Hidden,
         animationSpec = TweenSpec(durationMillis = 0)
     )
-    val textFieldValueState = remember {
-        mutableStateOf(TextFieldValue()).also {
-            controller.init(
-                textFieldValueState = it,
-                bottomSheetState = bottomSheetState
-            )
-        }
-    }
+    val textFieldValueState = remember { mutableStateOf(TextFieldValue()) }
 
     var showRecheckDialog by remember { mutableStateOf(false) }
 
@@ -136,6 +129,13 @@ fun CommentModalBottomSheet(
                 controller.clear()
             }
         }
+    }
+
+    LaunchedEffect(controller) {
+        controller.init(
+            textFieldValueState = textFieldValueState,
+            bottomSheetState = bottomSheetState
+        )
     }
 
     LaunchedEffect(Unit) {

--- a/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
@@ -175,9 +175,13 @@ fun CommentModalBottomSheet(
                         onCreated(controller.parentId, it)
                     }
 
-                    keyboardController?.hide()
                     coroutineScope.launch {
                         controller.hide()
+                        // 댓글 추가 후 키보드를 숨기는 함수 호출 때문인지 가끔씩 입력한 텍스트 필드 값이 남아있는 버그가 존재한다.
+                        // https://github.com/hansung-pocs/blog-android/issues/177
+                        // 이는 아래와 같이 조금의 딜레이를 통해 해결할 수 있다.
+                        delay(10)
+                        keyboardController?.hide()
                     }
                 },
                 hint = stringResource(

--- a/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/bottomsheet/CommentModalBottomSheet.kt
@@ -224,7 +224,7 @@ class CommentModalController {
 
     suspend fun showForCreate(parentComment: CommentItemUiState? = null) {
         if (parentComment != null) {
-            parentId = parentComment.parentId ?: parentComment.id
+            parentId = parentComment.parentId
         }
         show()
     }


### PR DESCRIPTION
Fixes #177 

회귀 테스트는 구현에 실패했습니다... 버그가 존재하는 상태에서 실패를 하는 테스트를 구현하기 어렵네요. #177 처럼 상황을 따라하며 테스트를 만들려 해봤으나 구현할 수 없었습니다. 좋은 방법 있으시다면 의견 부탁드립니다.


https://user-images.githubusercontent.com/57604817/186709874-4a1c5ada-c869-42ad-ae50-80d679c2b3b2.mov


## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [x] Action에서 진행하는 테스트를 모두 통과했는가?
- [ ] 수정 사항을 검증할 테스트를 추가하였는가?
- [ ] 리뷰를 받았는가?