### PR TITLE
익명 회원의 경우 유저 목록으로 이동하는 버튼 비활성화

### DIFF
--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -114,6 +114,7 @@ dependencies {
     implementation 'androidx.navigation:navigation-ui-ktx:2.5.1'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.4.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation 'androidx.test:core-ktx:1.4.0'
 }

--- a/presentation/src/main/java/com/pocs/presentation/model/post/HomeUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/post/HomeUiState.kt
@@ -1,6 +1,11 @@
 package com.pocs.presentation.model.post
 
+import com.pocs.domain.model.user.UserType
+
 data class HomeUiState(
-    val isCurrentUserAdmin: Boolean,
+    val currentUserType: UserType,
     val userMessage: String? = null
-)
+) {
+    val isCurrentUserAdmin: Boolean get() = currentUserType == UserType.ADMIN
+    val isCurrentUserAnonymous: Boolean get() = currentUserType == UserType.ANONYMOUS
+}

--- a/presentation/src/main/java/com/pocs/presentation/model/user/UserUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/user/UserUiState.kt
@@ -13,6 +13,4 @@ data class UserUiState(
     val searchPagingData: PagingData<UserItemUiState> = PagingData.empty(),
     private val currentUserType: UserType,
     @StringRes val errorMessageRes: Int? = null
-) {
-    val isUserAnonymous get() = currentUserType == UserType.ANONYMOUS
-}
+)

--- a/presentation/src/main/java/com/pocs/presentation/view/home/HomeActivity.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/home/HomeActivity.kt
@@ -62,8 +62,18 @@ class HomeActivity : ViewBindingActivity<ActivityHomeBinding>() {
 
     private fun initNavigationView() {
         with(binding) {
-            val adminMenu = navigationView.menu.findItem(R.id.action_admin)
-            adminMenu.isVisible = viewModel.uiState.value.isCurrentUserAdmin
+            val uiState = viewModel.uiState.value
+
+            navigationView.menu.findItem(R.id.action_admin).apply {
+                isVisible = uiState.isCurrentUserAdmin
+            }
+            if (uiState.isCurrentUserAnonymous) {
+                navigationView.menu.findItem(R.id.action_user_list).apply {
+                    title = getString(R.string.user_list_only_member)
+                    isEnabled = false
+                }
+            }
+
             navigationView.setNavigationItemSelectedListener(::onSelectNavigationItem)
         }
     }

--- a/presentation/src/main/java/com/pocs/presentation/view/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/home/HomeViewModel.kt
@@ -1,7 +1,7 @@
 package com.pocs.presentation.view.home
 
 import androidx.lifecycle.ViewModel
-import com.pocs.domain.usecase.auth.IsCurrentUserAdminUseCase
+import com.pocs.domain.usecase.auth.GetCurrentUserTypeUseCase
 import com.pocs.presentation.model.post.HomeUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -12,11 +12,11 @@ import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
-    isCurrentUserAdminUseCase: IsCurrentUserAdminUseCase
+    getCurrentUserTypeUseCase: GetCurrentUserTypeUseCase
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<HomeUiState> = MutableStateFlow(
-        HomeUiState(isCurrentUserAdmin = isCurrentUserAdminUseCase())
+        HomeUiState(currentUserType = getCurrentUserTypeUseCase())
     )
     val uiState: StateFlow<HomeUiState> get() = _uiState.asStateFlow()
 

--- a/presentation/src/main/java/com/pocs/presentation/view/user/UserFragment.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/user/UserFragment.kt
@@ -78,10 +78,6 @@ class UserFragment : ViewBindingFragment<FragmentUserBinding>() {
     }
 
     private fun onClickCard(userId: Int) {
-        if (viewModel.uiState.value.isUserAnonymous) {
-            showSnackBar(getString(R.string.can_see_only_member))
-            return
-        }
         val intent = UserDetailActivity.getIntent(requireContext(), userId)
         launcher?.launch(intent)
     }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -119,6 +119,7 @@
     <string name="comment_deleted">댓글 삭제됨</string>
     <string name="failed_to_delete_comment">댓글 삭제에 실패함</string>
     <string name="failed_to_delete_post">게시글 삭제에 실패함</string>
+    <string name="user_list_only_member">유저 목록(회원 전용)</string>
     <string-array name="admin_tab">
         <item>전체 게시글</item>
         <item>회원목록</item>

--- a/presentation/src/test/java/com/pocs/presentation/HomeViewModelTest.kt
+++ b/presentation/src/test/java/com/pocs/presentation/HomeViewModelTest.kt
@@ -2,7 +2,6 @@ package com.pocs.presentation
 
 import com.pocs.domain.model.user.UserType
 import com.pocs.domain.usecase.auth.GetCurrentUserTypeUseCase
-import com.pocs.domain.usecase.auth.IsCurrentUserAdminUseCase
 import com.pocs.presentation.view.home.HomeViewModel
 import com.pocs.test_library.fake.FakeAuthRepositoryImpl
 import com.pocs.test_library.mock.mockAdminUserDetail
@@ -33,8 +32,6 @@ class HomeViewModelTest {
     }
 
     private fun initViewModel() {
-        viewModel = HomeViewModel(
-            IsCurrentUserAdminUseCase(GetCurrentUserTypeUseCase(authRepository))
-        )
+        viewModel = HomeViewModel(GetCurrentUserTypeUseCase(authRepository))
     }
 }


### PR DESCRIPTION
Resolves #201 

아예 drawer 버튼을 안보이게 하려 했으나 구현에 실패하여 아래와 같이 비활성화하기로 했습니다.

![image](https://user-images.githubusercontent.com/57604817/186823376-a2ad81a4-a4db-46e9-8d19-770b604ba76b.png)


## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [ ] Action에서 진행하는 테스트를 모두 통과했는가?
- [x] 수정 사항을 검증할 테스트를 추가하였는가?
- [ ] 리뷰를 받았는가?