### PR TITLE
익명 회원이 API응답으로 주어진 모든 게시글 열람 가능하도록 수정

### DIFF
--- a/domain/src/main/java/com/pocs/domain/model/post/PostCategory.kt
+++ b/domain/src/main/java/com/pocs/domain/model/post/PostCategory.kt
@@ -1,10 +1,10 @@
 package com.pocs.domain.model.post
 
-enum class PostCategory(val canAnonymousSee: Boolean = false) {
+enum class PostCategory {
     NOTICE,
     STUDY,
     MEMORY,
     KNOWHOW,
     REFERENCE,
-    QNA(canAnonymousSee = true),
+    QNA,
 }

--- a/presentation/src/androidTest/java/com/pocs/presentation/HomeActivityTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/HomeActivityTest.kt
@@ -1,14 +1,10 @@
 package com.pocs.presentation
 
-import androidx.paging.PagingData
 import androidx.test.core.app.launchActivity
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.DrawerActions
 import androidx.test.espresso.matcher.ViewMatchers.*
-import com.pocs.domain.model.post.PostCategory
-import com.pocs.domain.model.post.PostFilterType
 import com.pocs.domain.usecase.auth.GetCurrentUserTypeUseCase
 import com.pocs.domain.usecase.auth.IsCurrentUserAnonymousUseCase
 import com.pocs.domain.usecase.post.GetAllPostsUseCase
@@ -19,16 +15,13 @@ import com.pocs.test_library.fake.FakeAuthRepositoryImpl
 import com.pocs.test_library.fake.FakePostRepositoryImpl
 import com.pocs.test_library.mock.mockAnonymousUser
 import com.pocs.test_library.mock.mockMemberUserDetail
-import com.pocs.test_library.mock.mockPost
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.hamcrest.Matchers.not
 import org.junit.After
@@ -63,35 +56,6 @@ class HomeActivityTest {
     @After
     fun tearDown() {
         Dispatchers.resetMain()
-    }
-
-    @Test
-    fun shouldShowNoPermissionSnackBar_WhenAnonymousClickNonQnaPost() = runTest {
-        val post = mockPost
-        val pagingData = PagingData.from(listOf(post.copy(category = PostCategory.NOTICE)))
-        authRepository.currentUser.value = mockAnonymousUser
-        postRepository.postPagingDataFlow = MutableStateFlow(pagingData)
-        initViewModels()
-        launchActivity<HomeActivity>()
-
-        onView(withText(post.title)).perform(click())
-
-        onView(withText(R.string.can_see_only_member)).check(matches(isDisplayed()))
-    }
-
-    @Test
-    fun shouldShowNoPermissionSnackBar_WhenAnonymousClickPost_WhenSelectedChipIsNotice() = runTest {
-        val post = mockPost
-        val pagingData = PagingData.from(listOf(post.copy(category = PostCategory.NOTICE)))
-        authRepository.currentUser.value = mockAnonymousUser
-        postRepository.postPagingDataFlow = MutableStateFlow(pagingData)
-        initViewModels()
-        postViewModel.updatePostFilterType(PostFilterType.NOTICE)
-        launchActivity<HomeActivity>()
-
-        onView(withText(post.title)).perform(click())
-
-        onView(withText(R.string.can_see_only_member)).check(matches(isDisplayed()))
     }
 
     @Test

--- a/presentation/src/androidTest/java/com/pocs/presentation/UserFragmentTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/UserFragmentTest.kt
@@ -2,7 +2,7 @@ package com.pocs.presentation
 
 import android.content.Context
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.paging.PagingData
 import androidx.test.espresso.Espresso.onView
@@ -43,7 +43,7 @@ class UserFragmentTest {
     val hiltRule = HiltAndroidRule(this)
 
     @get:Rule(order = 1)
-    val composeRule = createEmptyComposeRule()
+    val composeRule = createComposeRule()
 
     @BindValue
     val userRepository = FakeUserRepositoryImpl()

--- a/presentation/src/main/java/com/pocs/presentation/view/home/post/PostFragment.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/home/post/PostFragment.kt
@@ -105,10 +105,6 @@ class PostFragment : ViewBindingFragment<FragmentPostBinding>() {
     }
 
     private fun onClickPost(postItemUiState: PostItemUiState) {
-        if (postViewModel.uiState.value.isUserAnonymous && !postItemUiState.category.canAnonymousSee) {
-            showSnackBar(getString(R.string.can_see_only_member))
-            return
-        }
         val intent = PostDetailActivity.getIntent(
             requireContext(),
             id = postItemUiState.id

--- a/presentation/src/main/java/com/pocs/presentation/view/home/study/StudyFragment.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/home/study/StudyFragment.kt
@@ -81,10 +81,6 @@ class StudyFragment : ViewBindingFragment<FragmentPostBinding>() {
     }
 
     private fun onClickPost(postItemUiState: PostItemUiState) {
-        if (studyViewModel.uiState.value.isUserAnonymous) {
-            showSnackBar(getString(R.string.can_see_only_member))
-            return
-        }
         val intent = PostDetailActivity.getIntent(
             requireContext(),
             id = postItemUiState.id

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -110,7 +110,6 @@
     <string name="views">조회수</string>
     <string name="create_a_temporary_account">임시계정 생성하기</string>
     <string name="anonymous_user">익명 회원</string>
-    <string name="can_see_only_member">회원만 열람할 수 있습니다.</string>
     <string name="deleted_comment">삭제된 댓글입니다.</string>
     <string name="comment_added">댓글 추가됨</string>
     <string name="failed_to_add_comment">댓글 추가에 실패함</string>


### PR DESCRIPTION
Resolves #202 

API 응답에서 익명회원이 볼 수 없는 게시글은 자동으로 필터링 되기 때문에 응답으로 주어진 모든 게시글을 열람 가능하도록 수정했습니다. 
또한 이제 필요 없어진 `PostCategory`의 `canAnonymousSee` 속성을 제거했습니다.

## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [x] Action에서 진행하는 테스트를 모두 통과했는가?
- [ ] 수정 사항을 검증할 테스트를 추가하였는가?
- [x] 리뷰를 받았는가?