### PR TITLE
회원 전용 게시글에는 PostDetailScreen에 "회원 전용" 문구 보이도록 수정

### DIFF
--- a/presentation/src/androidTest/java/com/pocs/presentation/PostDetailScreenTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/PostDetailScreenTest.kt
@@ -677,6 +677,52 @@ class PostDetailScreenTest {
         }
     }
 
+    @Test
+    fun shouldShowOnlyMemberText_WhenPostIsForOnlyMember() {
+        composeRule.run {
+            setContent {
+                val snackbarHostState = remember { SnackbarHostState() }
+
+                PostDetailContent(
+                    uiState = uiState.copy(
+                        postDetail = mockPostDetail1.copy(onlyMember = true).toUiState()
+                    ),
+                    snackbarHostState = snackbarHostState,
+                    onEditClick = {},
+                    onDeleteClick = {},
+                    onCommentDelete = {},
+                    onCommentCreated = { _, _ -> },
+                    onCommentUpdated = { _, _ -> }
+                )
+            }
+
+            onNodeWithText(getString(R.string.can_see_only_member)).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun shouldNotShowOnlyMemberText_WhenPostIsForOnlyMember() {
+        composeRule.run {
+            setContent {
+                val snackbarHostState = remember { SnackbarHostState() }
+
+                PostDetailContent(
+                    uiState = uiState.copy(
+                        postDetail = mockPostDetail1.copy(onlyMember = false).toUiState()
+                    ),
+                    snackbarHostState = snackbarHostState,
+                    onEditClick = {},
+                    onDeleteClick = {},
+                    onCommentDelete = {},
+                    onCommentCreated = { _, _ -> },
+                    onCommentUpdated = { _, _ -> }
+                )
+            }
+
+            onNodeWithText(getString(R.string.can_see_only_member)).assertDoesNotExist()
+        }
+    }
+
     @Suppress("SameParameterValue")
     private fun findVisibleTexts(text: String): List<SemanticsNode> {
         return findVisibleNode(hasText(text))

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
@@ -303,10 +303,6 @@ private fun LazyListScope.headerItems(
 ) {
     item(HEADER_KEY) {
         Column(modifier = Modifier.padding(20.dp)) {
-            val subtitleStyle = MaterialTheme.typography.bodyMedium.copy(
-                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
-            )
-
             Text(
                 text = title,
                 style = MaterialTheme.typography.headlineMedium.copy(
@@ -321,7 +317,9 @@ private fun LazyListScope.headerItems(
                     writerName,
                     date
                 ),
-                style = subtitleStyle
+                style = MaterialTheme.typography.bodyMedium.copy(
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
+                )
             )
             if (onlyMember) {
                 Box(modifier = Modifier.height(8.dp))

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
@@ -177,7 +177,8 @@ fun PostDetailContent(
                     headerItems(
                         title = postDetail.title,
                         writerName = postDetail.writer.name ?: anonymousString,
-                        date = postDetail.date
+                        date = postDetail.date,
+                        onlyMember = postDetail.onlyMember
                     )
                     item {
                         MarkdownText(
@@ -294,9 +295,18 @@ fun PostDetailTopAppBar(
     )
 }
 
-private fun LazyListScope.headerItems(title: String, writerName: String, date: String) {
+private fun LazyListScope.headerItems(
+    title: String,
+    writerName: String,
+    date: String,
+    onlyMember: Boolean
+) {
     item(HEADER_KEY) {
         Column(modifier = Modifier.padding(20.dp)) {
+            val subtitleStyle = MaterialTheme.typography.bodyMedium.copy(
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
+            )
+
             Text(
                 text = title,
                 style = MaterialTheme.typography.headlineMedium.copy(
@@ -311,10 +321,17 @@ private fun LazyListScope.headerItems(title: String, writerName: String, date: S
                     writerName,
                     date
                 ),
-                style = MaterialTheme.typography.bodyMedium.copy(
-                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
-                )
+                style = subtitleStyle
             )
+            if (onlyMember) {
+                Box(modifier = Modifier.height(8.dp))
+                Text(
+                    text = stringResource(id = R.string.can_see_only_member),
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.6f)
+                    )
+                )
+            }
         }
     }
     item {


### PR DESCRIPTION
Resolves #213 

![image](https://user-images.githubusercontent.com/57604817/187040815-cfcc489a-2de1-4b9e-8fc4-b5a65fd79fc8.png)

회원 전용 문구는 색상을 달리하여 눈에 띌 수 있도록했습니다.

## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [ ] Action에서 진행하는 테스트를 모두 통과했는가?
- [x] 수정 사항을 검증할 테스트를 추가하였는가?
- [ ] 리뷰를 받았는가?