### PR TITLE
유저 강퇴 후 회원 목록 화면에서 그대로 남아있던 문제 해결

### DIFF
--- a/presentation/src/androidTest/java/com/pocs/presentation/UserDetailScreenTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/UserDetailScreenTest.kt
@@ -26,9 +26,16 @@ class UserDetailScreenTest {
             isCurrentUserAdmin = false,
             shownErrorMessage = {},
             isMyInfo = true,
+            successToKick = false,
             onKickClick = {}
         )
-        composeTestRule.setContent { UserDetailScreen(uiState = uiState, onEdited = {}) }
+        composeTestRule.setContent {
+            UserDetailScreen(
+                uiState = uiState,
+                onEdited = {},
+                onSuccessToKick = {}
+            )
+        }
 
         composeTestRule.onNodeWithText(userDetail.defaultInfo!!.email).assertIsDisplayed()
     }
@@ -37,7 +44,13 @@ class UserDetailScreenTest {
     fun showFailureContent_WhenUiStateIsFailure() {
         val exception = Exception("에러")
         val uiState = UserDetailUiState.Failure(exception, onRetryClick = {})
-        composeTestRule.setContent { UserDetailScreen(uiState = uiState, onEdited = {}) }
+        composeTestRule.setContent {
+            UserDetailScreen(
+                uiState = uiState,
+                onEdited = {},
+                onSuccessToKick = {}
+            )
+        }
 
         composeTestRule.onNodeWithText(userDetail.defaultInfo!!.email).assertDoesNotExist()
         composeTestRule.onNodeWithText(exception.message!!).assertIsDisplayed()
@@ -50,11 +63,12 @@ class UserDetailScreenTest {
             isCurrentUserAdmin = true,
             shownErrorMessage = {},
             isMyInfo = true,
+            successToKick = false,
             onKickClick = {}
         )
 
         composeTestRule.run {
-            setContent { UserDetailScreen(uiState = uiState, onEdited = {}) }
+            setContent { UserDetailScreen(uiState = uiState, onEdited = {}, onSuccessToKick = {}) }
 
             onNodeWithContentDescription("더보기 버튼").assertIsDisplayed()
         }
@@ -67,11 +81,12 @@ class UserDetailScreenTest {
             isCurrentUserAdmin = false,
             shownErrorMessage = {},
             isMyInfo = true,
+            successToKick = false,
             onKickClick = {}
         )
 
         composeTestRule.run {
-            setContent { UserDetailScreen(uiState = uiState, onEdited = {}) }
+            setContent { UserDetailScreen(uiState = uiState, onEdited = {}, onSuccessToKick = {}) }
 
             onNodeWithContentDescription("더보기 버튼").assertDoesNotExist()
         }
@@ -84,11 +99,12 @@ class UserDetailScreenTest {
             isCurrentUserAdmin = true,
             shownErrorMessage = {},
             isMyInfo = true,
+            successToKick = false,
             onKickClick = {}
         )
 
         composeTestRule.run {
-            setContent { UserDetailScreen(uiState = uiState, onEdited = {}) }
+            setContent { UserDetailScreen(uiState = uiState, onEdited = {}, onSuccessToKick = {}) }
 
             onNodeWithContentDescription("더보기 버튼").performClick()
             onNodeWithText("강퇴하기").performClick()
@@ -106,11 +122,12 @@ class UserDetailScreenTest {
             errorMessage = errorMessage,
             shownErrorMessage = {},
             isMyInfo = true,
+            successToKick = false,
             onKickClick = {}
         )
 
         composeTestRule.run {
-            setContent { UserDetailScreen(uiState = uiState, onEdited = {}) }
+            setContent { UserDetailScreen(uiState = uiState, onEdited = {}, onSuccessToKick = {}) }
 
             onNodeWithText(errorMessage).assertIsDisplayed()
         }

--- a/presentation/src/main/java/com/pocs/presentation/model/user/UserDetailUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/user/UserDetailUiState.kt
@@ -10,6 +10,7 @@ sealed class UserDetailUiState {
         val errorMessage: String? = null,
         val shownErrorMessage: () -> Unit,
         val onKickClick: () -> Unit,
+        val successToKick: Boolean
     ) : UserDetailUiState()
 
     class Failure(val e: Throwable, val onRetryClick: () -> Unit) : UserDetailUiState()

--- a/presentation/src/main/java/com/pocs/presentation/view/user/detail/UserDetailActivity.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/user/detail/UserDetailActivity.kt
@@ -35,6 +35,9 @@ class UserDetailActivity : AppCompatActivity() {
                     onEdited = {
                         fetchUserDetail()
                         setResultRefresh()
+                    },
+                    onSuccessToKick = {
+                        setResultRefresh()
                     }
                 )
             }

--- a/presentation/src/main/java/com/pocs/presentation/view/user/detail/UserDetailScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/user/detail/UserDetailScreen.kt
@@ -39,7 +39,11 @@ import kotlinx.coroutines.launch
 private const val URL_TAG = "url"
 
 @Composable
-fun UserDetailScreen(uiState: UserDetailUiState, onEdited: () -> Unit) {
+fun UserDetailScreen(
+    uiState: UserDetailUiState,
+    onEdited: () -> Unit,
+    onSuccessToKick: () -> Unit
+) {
     when (uiState) {
         is UserDetailUiState.Loading -> {
             LoadingContent()
@@ -51,6 +55,12 @@ fun UserDetailScreen(uiState: UserDetailUiState, onEdited: () -> Unit) {
                 LaunchedEffect(uiState.errorMessage) {
                     snackBarHostState.showSnackbar(uiState.errorMessage)
                     uiState.shownErrorMessage()
+                }
+            }
+
+            if (uiState.successToKick) {
+                LaunchedEffect(uiState.successToKick) {
+                    onSuccessToKick()
                 }
             }
 

--- a/presentation/src/main/java/com/pocs/presentation/view/user/detail/UserDetailScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/user/detail/UserDetailScreen.kt
@@ -163,12 +163,25 @@ fun UserDetailContent(
                 contentAlignment = Alignment.Center,
                 modifier = Modifier.fillMaxSize()
             ) {
-                Text(
-                    stringResource(R.string.anonymous_user),
-                    style = MaterialTheme.typography.headlineMedium.copy(
-                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(
+                        stringResource(R.string.anonymous_user),
+                        style = MaterialTheme.typography.headlineMedium.copy(
+                            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
+                        )
                     )
-                )
+                    if (userDetail.isKicked) {
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            stringResource(R.string.is_kicked),
+                            style = MaterialTheme.typography.bodyMedium.copy(
+                                color = MaterialTheme.colorScheme.error.copy(alpha = 0.8f)
+                            )
+                        )
+                    }
+                }
             }
         }
     }

--- a/presentation/src/main/java/com/pocs/presentation/view/user/detail/UserDetailViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/user/detail/UserDetailViewModel.kt
@@ -40,7 +40,8 @@ class UserDetailViewModel @Inject constructor(
                     isCurrentUserAdmin = isCurrentUserAdminUseCase(),
                     isMyInfo = getCurrentUserUseCase()?.id == id,
                     shownErrorMessage = ::shownErrorMessage,
-                    onKickClick = ::kickUser
+                    onKickClick = ::kickUser,
+                    successToKick = (uiState as? UserDetailUiState.Success)?.successToKick ?: false
                 )
             } else {
                 UserDetailUiState.Failure(
@@ -58,6 +59,7 @@ class UserDetailViewModel @Inject constructor(
             viewModelScope.launch {
                 val result = kickUserUseCase(uiState.userDetail.id)
                 if (result.isSuccess) {
+                    this@UserDetailViewModel.uiState = uiState.copy(successToKick = true)
                     fetchUserInfo(uiState.userDetail.id)
                 } else {
                     val errorMessage = result.exceptionOrNull()?.message ?: "강퇴에 실패했습니다."


### PR DESCRIPTION
Fixes #222 

유저 강퇴 후 회원 목록 화면에서 강퇴된 회원이 그대로 남아있던 문제를 해결했습니다.

추가로 강퇴된 익명 회원의 경우 유저 상세보기에서 "강퇴됨" 글자를 아래와 같이 보이도록 했습니다.

![image](https://user-images.githubusercontent.com/57604817/187075112-993216b0-ed07-4567-886d-40234f536b5e.png)



## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [x] Action에서 진행하는 테스트를 모두 통과했는가?
- [x] 수정 사항을 검증할 테스트를 추가하였는가?
- [x] 리뷰를 받았는가?