### PR TITLE
익명 회원일때 게시글 편집화면의 Chips 안보이도록 수정

### DIFF
--- a/presentation/src/androidTest/java/com/pocs/presentation/PostEditScreenTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/PostEditScreenTest.kt
@@ -235,4 +235,32 @@ class PostEditScreenTest {
                 .performTextInput(stringBuilder.toString())
         }
     }
+
+    @Test
+    fun shouldNotShowChips_WhenCurrentUserTypeIsAnonymous() {
+        composeTestRule.setContent {
+            PostEditScreen(uiState = emptyUiState.copy(currentUserType = UserType.ANONYMOUS), {}) {}
+        }
+
+        composeTestRule.onNodeWithTag("PostCategoryChips").assertDoesNotExist()
+    }
+
+    @Test
+    fun shouldShowChips_WhenCurrentUserTypeIsAdmin() {
+        composeTestRule.setContent {
+            PostEditScreen(uiState = emptyUiState.copy(currentUserType = UserType.ADMIN), {}) {}
+        }
+
+        composeTestRule.onNodeWithTag("PostCategoryChips").assertIsDisplayed()
+    }
+
+    @Test
+    fun shouldNotShowNoticeChip_WhenCurrentUserTypeIsMember() {
+        composeTestRule.setContent {
+            PostEditScreen(uiState = emptyUiState.copy(currentUserType = UserType.MEMBER), {}) {}
+        }
+
+        composeTestRule.onNodeWithText("공지사항").assertDoesNotExist()
+        composeTestRule.onNodeWithTag("PostCategoryChips").assertIsDisplayed()
+    }
 }

--- a/presentation/src/main/java/com/pocs/presentation/model/post/BasePostEditUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/post/BasePostEditUiState.kt
@@ -17,9 +17,9 @@ interface BasePostEditUiState {
     val onOnlyMemberChange: (Boolean) -> Unit
     val onSave: suspend () -> Result<Unit>
 
-    val showChips get() = category != PostCategory.QNA
-    val isUserAdmin get() = currentUserType == UserType.ADMIN
+    val showChips get() = currentUserType != UserType.ANONYMOUS
     val showOnlyMemberButton get() = currentUserType != UserType.ANONYMOUS
+    val isUserAdmin get() = currentUserType == UserType.ADMIN
     val canSave get() = title.isNotEmpty() && content.text.isNotEmpty()
     val isEmpty get() = title.isEmpty() && content.text.isEmpty()
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/component/Chips.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/Chips.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.unit.dp
 
 @Composable
 fun <T> HorizontalChips(
+    modifier: Modifier = Modifier,
     items: List<T>,
     itemLabelBuilder: @Composable (T) -> String,
     selectedItem: T,
@@ -22,7 +23,7 @@ fun <T> HorizontalChips(
     val scrollState = rememberScrollState()
 
     Row(
-        Modifier
+        modifier
             .horizontalScroll(scrollState)
             .padding(horizontal = 12.dp)
     ) {

--- a/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -53,7 +54,6 @@ fun PostEditContent(
     val snackBarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
     val onBackPressedDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
-    val showChips = uiState.showChips
 
     RecheckHandler(
         navigateUp = navigateUp,
@@ -96,7 +96,7 @@ fun PostEditContent(
             val contentContentDescription = stringResource(R.string.content_text_field)
             var showToolBar by remember { mutableStateOf(false) }
 
-            if (showChips) {
+            if (uiState.showChips) {
                 PostCategoryChips(
                     isUserAdmin = uiState.isUserAdmin,
                     selectedCategory = uiState.category,
@@ -160,6 +160,7 @@ fun PostCategoryChips(
     }
 
     HorizontalChips(
+        modifier = Modifier.testTag("PostCategoryChips"),
         items = categories,
         itemLabelBuilder = { stringResource(id = it.koreanStringResource) },
         selectedItem = selectedCategory,


### PR DESCRIPTION
Fixes #219 

기존에는 QnA 게시글인 경우 상단의 칩들을 안보이게 했습니다.
수정 후에는 익명 회원인 경우에 상단의 칩들을 안보이게 했습니다.

## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [ ] Action에서 진행하는 테스트를 모두 통과했는가?
- [x] 수정 사항을 검증할 테스트를 추가하였는가?
- [ ] 리뷰를 받았는가?