### PR TITLE
PostEditScreen에서 Body 부분 전체 스크롤 가능하도록 수정

### DIFF
--- a/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/edit/PostEditScreen.kt
@@ -2,13 +2,19 @@ package com.pocs.presentation.view.post.edit
 
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.relocation.BringIntoViewRequester
+import androidx.compose.foundation.relocation.bringIntoViewRequester
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.focus.onFocusEvent
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -31,6 +37,7 @@ import com.pocs.presentation.view.component.appbar.EditContentAppBar
 import com.pocs.presentation.view.component.checkbox.LabeledCheckBox
 import com.pocs.presentation.view.component.markdown.MarkdownToolBar
 import com.pocs.presentation.view.component.textfield.SimpleTextField
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 @Composable
@@ -43,7 +50,7 @@ fun PostEditScreen(uiState: PostEditUiState, navigateUp: () -> Unit, onSuccessSa
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun PostEditContent(
     title: String,
@@ -94,47 +101,70 @@ fun PostEditContent(
         ) {
             val titleContentDescription = stringResource(R.string.title_text_field)
             val contentContentDescription = stringResource(R.string.content_text_field)
+            val viewRequester = remember { BringIntoViewRequester() }
             var showToolBar by remember { mutableStateOf(false) }
 
-            if (uiState.showChips) {
-                PostCategoryChips(
-                    isUserAdmin = uiState.isUserAdmin,
-                    selectedCategory = uiState.category,
-                    onClick = uiState.onCategoryChange
+            Column(
+                Modifier
+                    .weight(1f)
+                    .verticalScroll(
+                        state = rememberScrollState(),
+                        // TODO: https://issuetracker.google.com/issues/192043120 이슈 때문에 엔터키 입력시 자동으로
+                        //       커서 위치로 스크롤 되지 않는다. 따라서 일단 아래와 같이 거꾸로 스크롤링 한다. 추후에 위의 이슈가
+                        //       해결되면 아래의 코드는 지워도 된다.
+                        reverseScrolling = true
+                    )
+            ) {
+                if (uiState.showChips) {
+                    PostCategoryChips(
+                        isUserAdmin = uiState.isUserAdmin,
+                        selectedCategory = uiState.category,
+                        onClick = uiState.onCategoryChange
+                    )
+                }
+                if (uiState.showOnlyMemberButton) {
+                    LabeledCheckBox(
+                        modifier = Modifier.padding(horizontal = 6.dp, vertical = 4.dp),
+                        checked = uiState.onlyMember,
+                        onCheckedChange = uiState.onOnlyMemberChange,
+                        label = stringResource(id = R.string.can_see_only_member)
+                    )
+                }
+                SimpleTextField(
+                    hint = stringResource(R.string.title),
+                    value = uiState.title,
+                    maxLength = MAX_POST_TITLE_LEN,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+                    onValueChange = {
+                        uiState.onTitleChange(it.filter { char -> char != '\n' })
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .semantics { contentDescription = titleContentDescription }
+                        // TODO: https://issuetracker.google.com/issues/192043120 에서 문제 해결되면 아래의 두 부분 지우기
+                        .bringIntoViewRequester(viewRequester)
+                        .onFocusEvent {
+                            if (it.isFocused) {
+                                coroutineScope.launch {
+                                    delay(200)
+                                    viewRequester.bringIntoView()
+                                }
+                            }
+                        },
+                )
+                PocsDivider(startIndent = 16.dp)
+                SimpleTextField(
+                    hint = stringResource(R.string.content),
+                    value = uiState.content,
+                    maxLength = MAX_POST_CONTENT_LEN,
+                    onValueChange = uiState.onContentChange,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(min = 160.dp)
+                        .semantics { contentDescription = contentContentDescription }
+                        .onFocusChanged { showToolBar = it.hasFocus }
                 )
             }
-            if (uiState.showOnlyMemberButton) {
-                LabeledCheckBox(
-                    modifier = Modifier.padding(horizontal = 6.dp, vertical = 4.dp),
-                    checked = uiState.onlyMember,
-                    onCheckedChange = uiState.onOnlyMemberChange,
-                    label = stringResource(id = R.string.can_see_only_member)
-                )
-            }
-            SimpleTextField(
-                hint = stringResource(R.string.title),
-                value = uiState.title,
-                maxLength = MAX_POST_TITLE_LEN,
-                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
-                onValueChange = {
-                    uiState.onTitleChange(it.filter { char -> char != '\n' })
-                },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .semantics { contentDescription = titleContentDescription }
-            )
-            PocsDivider(startIndent = 16.dp)
-            SimpleTextField(
-                hint = stringResource(R.string.content),
-                value = uiState.content,
-                maxLength = MAX_POST_CONTENT_LEN,
-                onValueChange = uiState.onContentChange,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1.0f)
-                    .semantics { contentDescription = contentContentDescription }
-                    .onFocusChanged { showToolBar = it.hasFocus }
-            )
             AnimatedVisibility(visible = showToolBar) {
                 MarkdownToolBar(
                     textFieldValue = uiState.content,


### PR DESCRIPTION
Resolves #218 

구현은 되었으나 textField의 사용자 경험이 완벽하지는 않습니다. 그 이유는 compose의 TextField에 https://issuetracker.google.com/issues/192043120 이슈가 존재하기 때문입니다. 

이 이슈를 요약하자면, 스크롤 가능한 레이아웃 내에 textField가 위치한 경우 텍스트 필드를 탭 했을때 키보드가 올라오며 커서가 안보이는 문제입니다. 즉, 해당 커서로 자동 스크롤이 정확히 작동하지 않는 문제가 존재합니다. 또 다른 예로 텍스트 필드에 엔터키를 입력할때 자동으로 커서 위치로 스크롤 되지 않아 불편한 사용자 경험도 있습니다.

그래서 일단 `bringIntoViewRequester`와 `reverseScrolling = true`를 이용하여 임시로 해결책을 두었습니다. 하지만 이는 말그대로 임시 방편이며 추후 안드로이드 팀에서 해당 이슈를 해결하기를 바라야 합니다.

https://user-images.githubusercontent.com/57604817/187182608-b68fe873-8ade-447d-81b9-58f50533da27.mov


## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [ ] Action에서 진행하는 테스트를 모두 통과했는가?
- [ ] 수정 사항을 검증할 테스트를 추가하였는가?
- [ ] 리뷰를 받았는가?