### PR TITLE
로그인 화면 UI 개선

### DIFF
--- a/presentation/src/androidTest/java/com/pocs/presentation/LoginScreenTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/LoginScreenTest.kt
@@ -26,7 +26,7 @@ class LoginScreenTest {
                 LoginContent(
                     uiState = uiState,
                     onLoginClick = {},
-                    onBrowseAsAnonymousClick = {},
+                    onClickCreateAnonymous = {},
                     onUserMessageShown = {}
                 )
             }
@@ -47,7 +47,7 @@ class LoginScreenTest {
                 LoginContent(
                     uiState = uiState,
                     onLoginClick = {},
-                    onBrowseAsAnonymousClick = {},
+                    onClickCreateAnonymous = {},
                     onUserMessageShown = {}
                 )
             }
@@ -68,7 +68,7 @@ class LoginScreenTest {
                 LoginContent(
                     uiState = uiState,
                     onLoginClick = {},
-                    onBrowseAsAnonymousClick = {},
+                    onClickCreateAnonymous = {},
                     onUserMessageShown = {}
                 )
             }

--- a/presentation/src/main/java/com/pocs/presentation/view/login/LoginActivity.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/login/LoginActivity.kt
@@ -45,7 +45,7 @@ class LoginActivity : AppCompatActivity() {
             Mdc3Theme(this) {
                 LoginScreen(
                     viewModel = viewModel,
-                    onBrowseAsAnonymousClick = ::navigateToAnonymousCreateActivity
+                    onClickCreateAnonymous = ::navigateToAnonymousCreateActivity
                 )
             }
         }

--- a/presentation/src/main/java/com/pocs/presentation/view/login/LoginScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/login/LoginScreen.kt
@@ -112,13 +112,13 @@ fun LoginContent(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
-                    text = stringResource(id = R.string.are_not_you_member),
+                    text = stringResource(id = R.string.are_not_you_member) + " ",
                     style = MaterialTheme.typography.labelLarge.copy(
                         color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5F)
                     )
                 )
                 TextButton(
-                    contentPadding = PaddingValues(horizontal = 4.dp, vertical = 8.dp),
+                    contentPadding = PaddingValues(vertical = 8.dp),
                     onClick = onBrowseAsAnonymousClick
                 ) {
                     Text(

--- a/presentation/src/main/java/com/pocs/presentation/view/login/LoginScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/login/LoginScreen.kt
@@ -27,13 +27,13 @@ import com.pocs.presentation.view.component.textfield.PasswordOutlineTextField
 import com.pocs.presentation.view.component.textfield.PocsOutlineTextField
 
 @Composable
-fun LoginScreen(viewModel: LoginViewModel, onBrowseAsAnonymousClick: () -> Unit) {
+fun LoginScreen(viewModel: LoginViewModel, onClickCreateAnonymous: () -> Unit) {
     val uiState = viewModel.uiState.collectAsState()
 
     LoginContent(
         uiState = uiState.value,
         onLoginClick = viewModel::login,
-        onBrowseAsAnonymousClick = onBrowseAsAnonymousClick,
+        onClickCreateAnonymous = onClickCreateAnonymous,
         onUserMessageShown = viewModel::userMessageShown
     )
 }
@@ -43,7 +43,7 @@ fun LoginScreen(viewModel: LoginViewModel, onBrowseAsAnonymousClick: () -> Unit)
 fun LoginContent(
     uiState: LoginUiState,
     onLoginClick: () -> Unit,
-    onBrowseAsAnonymousClick: () -> Unit,
+    onClickCreateAnonymous: () -> Unit,
     onUserMessageShown: () -> Unit
 ) {
     val snackBarHostState = remember { SnackbarHostState() }
@@ -119,7 +119,7 @@ fun LoginContent(
                 )
                 TextButton(
                     contentPadding = PaddingValues(vertical = 8.dp),
-                    onClick = onBrowseAsAnonymousClick
+                    onClick = onClickCreateAnonymous
                 ) {
                     Text(
                         text = stringResource(R.string.sign_up_as_anonymous),
@@ -157,7 +157,7 @@ fun LoginContentPreview() {
             onUpdate = {}
         ),
         onLoginClick = {},
-        onBrowseAsAnonymousClick = {},
+        onClickCreateAnonymous = {},
         onUserMessageShown = {}
     )
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/login/LoginScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/login/LoginScreen.kt
@@ -117,7 +117,10 @@ fun LoginContent(
                         color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5F)
                     )
                 )
-                TextButton(onClick = onBrowseAsAnonymousClick) {
+                TextButton(
+                    contentPadding = PaddingValues(horizontal = 4.dp, vertical = 8.dp),
+                    onClick = onBrowseAsAnonymousClick
+                ) {
                     Text(
                         text = stringResource(R.string.sign_up_as_anonymous),
                         style = MaterialTheme.typography.labelLarge.copy(

--- a/presentation/src/main/java/com/pocs/presentation/view/login/LoginScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/login/LoginScreen.kt
@@ -2,6 +2,7 @@ package com.pocs.presentation.view.login
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
@@ -11,6 +12,8 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
@@ -57,6 +60,7 @@ fun LoginContent(
         snackbarHost = { SnackbarHost(hostState = snackBarHostState) }
     ) { innerPadding ->
         val scrollState = rememberScrollState()
+        val passwordFocusRequester = remember { FocusRequester() }
 
         Column(
             Modifier
@@ -81,9 +85,13 @@ fun LoginContent(
                 maxLength = MAX_USER_ID_LEN,
                 keyboardOptions = KeyboardOptions(
                     imeAction = ImeAction.Next
+                ),
+                keyboardActions = KeyboardActions(
+                    onNext = { passwordFocusRequester.requestFocus() }
                 )
             )
             PasswordOutlineTextField(
+                modifier = Modifier.focusRequester(passwordFocusRequester),
                 password = uiState.password,
                 onPasswordChange = { password ->
                     uiState.update { it.copy(password = password) }

--- a/presentation/src/main/java/com/pocs/presentation/view/login/LoginScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/login/LoginScreen.kt
@@ -100,11 +100,23 @@ fun LoginContent(
                 onClick = onLoginClick
             )
             Box(modifier = Modifier.height(8.dp))
-            TextButton(onClick = onBrowseAsAnonymousClick) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
                 Text(
-                    text = stringResource(R.string.sign_up_as_anonymous),
-                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.4F)
+                    text = stringResource(id = R.string.are_not_you_member),
+                    style = MaterialTheme.typography.labelLarge.copy(
+                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5F)
+                    )
                 )
+                TextButton(onClick = onBrowseAsAnonymousClick) {
+                    Text(
+                        text = stringResource(R.string.sign_up_as_anonymous),
+                        style = MaterialTheme.typography.labelLarge.copy(
+                            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.6F)
+                        )
+                    )
+                }
             }
         }
     }

--- a/presentation/src/main/java/com/pocs/presentation/view/user/anonymous/AnonymousCreateScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/user/anonymous/AnonymousCreateScreen.kt
@@ -104,7 +104,7 @@ fun AnonymousCreateScreen(
             )
             Box(modifier = Modifier.height(16.dp))
             PocsButton(
-                label = stringResource(R.string.create_a_temporary_account),
+                label = stringResource(R.string.create),
                 enabled = uiState.enableCreateButton,
                 onClick = { uiState.onCreate() }
             )

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -84,7 +84,8 @@
     <string name="sorting_by_created_at_descending">가입일 최근순</string>
     <string name="password">비밀번호</string>
     <string name="id">아이디</string>
-    <string name="sign_up_as_anonymous">익명으로 시작하기</string>
+    <string name="are_not_you_member">동아리원이 아니신가요?</string>
+    <string name="sign_up_as_anonymous">임시 계정 생성</string>
     <string name="login_title">POCS</string>
     <string name="setting">설정</string>
     <string name="anonymous">익명</string>
@@ -108,7 +109,7 @@
     <string name="search_by_name">이름 검색</string>
     <string name="query_min_length_error">2글자 이상 입력하세요.</string>
     <string name="views">조회수</string>
-    <string name="create_a_temporary_account">임시계정 생성하기</string>
+    <string name="create">생성하기</string>
     <string name="anonymous_user">익명 회원</string>
     <string name="deleted_comment">삭제된 댓글입니다.</string>
     <string name="comment_added">댓글 추가됨</string>


### PR DESCRIPTION
Resolves #231 

- 임시 계정 생성 문구를 개선했습니다.
- 아래의 동영상과 같은 focus 이동 버그를 해결했습니다.(실제 모바일 기기에서는 문제가 없긴함. 에뮬레이터에서 컴퓨터 키보드로 입력시 발생하고있음)
- 임시 계정 생성하기 화면에서 버튼을 "생성하기"로 간소화했습니다.

### 수정된 로그인 화면 

<img width="314" alt="image" src="https://user-images.githubusercontent.com/57604817/187377644-fdc0741f-a2b7-4175-a7a4-d6b92a859790.png">

### Focus 문제가 되었던 부분


https://user-images.githubusercontent.com/57604817/187378310-d63827a7-6ed3-4c9e-85e5-d57e834582a5.mov



## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [ ] Action에서 진행하는 테스트를 모두 통과했는가?
- [ ] 수정 사항을 검증할 테스트를 추가하였는가?
- [ ] 리뷰를 받았는가?