### PR TITLE
Compose로 구현된 화면에서 Divider 색상 더 진하게 수정

### DIFF
--- a/presentation/src/main/java/com/pocs/presentation/view/component/PocsDivider.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/PocsDivider.kt
@@ -9,10 +9,10 @@ import androidx.compose.ui.unit.dp
 
 @Composable
 fun PocsDivider(startIndent: Dp = 0.dp, thickness: Dp = 1.dp) {
-    Divider(startIndent = startIndent, modifier = Modifier.alpha(0.5f), thickness = thickness)
+    Divider(startIndent = startIndent, thickness = thickness)
 }
 
 @Composable
 fun ThickDivider() {
-    Divider(modifier = Modifier.alpha(0.4f), thickness = 16.dp)
+    Divider(modifier = Modifier.alpha(0.5f), thickness = 16.dp)
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/component/PocsDivider.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/PocsDivider.kt
@@ -9,10 +9,10 @@ import androidx.compose.ui.unit.dp
 
 @Composable
 fun PocsDivider(startIndent: Dp = 0.dp, thickness: Dp = 1.dp) {
-    Divider(startIndent = startIndent, modifier = Modifier.alpha(0.2f), thickness = thickness)
+    Divider(startIndent = startIndent, modifier = Modifier.alpha(0.5f), thickness = thickness)
 }
 
 @Composable
 fun ThickDivider() {
-    Divider(modifier = Modifier.alpha(0.1f), thickness = 16.dp)
+    Divider(modifier = Modifier.alpha(0.4f), thickness = 16.dp)
 }


### PR DESCRIPTION
Fixes #234 

Compose 라이브러리 버전을 수정하고나서 Divider의 색상이 변경된것 같습니다. 아마 라이브러리 내부적으로 Divider 색상이 바뀐것 같아요.

![image](https://user-images.githubusercontent.com/57604817/187639156-06727cf4-babb-434c-bd3f-ffbb684f827f.png)

## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [ ] Action에서 진행하는 테스트를 모두 통과했는가?
- [ ] 수정 사항을 검증할 테스트를 추가하였는가?
- [ ] 리뷰를 받았는가?