### PR TITLE
불안정한 SearchAppBarTest 수정

### DIFF
--- a/presentation/src/androidTest/java/com/pocs/presentation/SearchAppBarTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/SearchAppBarTest.kt
@@ -62,7 +62,7 @@ class SearchAppBarTest {
 
             findSearchTextField().performTextInput(query)
             waitForIdle()
-            mainClock.advanceTimeBy(200)
+            mainClock.advanceTimeBy(100)
 
             findSearchTextField().performTextInput(query)
             waitForIdle()
@@ -70,7 +70,7 @@ class SearchAppBarTest {
 
             findSearchTextField().performTextInput(query)
             waitForIdle()
-            mainClock.advanceTimeBy(200)
+            mainClock.advanceTimeBy(100)
 
             findSearchTextField().performTextInput(query)
             waitForIdle()


### PR DESCRIPTION
Fixes #248 

`shouldDebounceOnSearchEventCorrectly_WhenTypingText` 테스트에서 mainClock을 조종하는 시간을 100 + 200 + 200 = 500(==`searchDebounceDelay`) 으로 테스트를 만들었기 때문에 중간에 디바운스가 한번 더 된것같습니다.

수정후 테스트 결과는 아래와 같습니다.

![스크린샷 2022-09-03 오후 12 46 31](https://user-images.githubusercontent.com/57604817/188254646-375cf201-de96-483a-92c5-cd60fca28f4b.png)


## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [ ] Action에서 진행하는 테스트를 모두 통과했는가?
- [ ] 수정 사항을 검증할 테스트를 추가하였는가?
- [ ] 리뷰를 받았는가?