### PR TITLE
Compose로 구현된 화면의 에러 화면 코드 개선

### DIFF
--- a/data/src/main/java/com/pocs/data/di/NetworkModule.kt
+++ b/data/src/main/java/com/pocs/data/di/NetworkModule.kt
@@ -32,7 +32,11 @@ class NetworkModule {
             .connectTimeout(5, TimeUnit.SECONDS)
             .writeTimeout(5, TimeUnit.SECONDS)
             .addInterceptor(HttpLoggingInterceptor().apply {
-                this.level = HttpLoggingInterceptor.Level.BODY
+                this.level = if (BuildConfig.DEBUG) {
+                    HttpLoggingInterceptor.Level.BODY
+                } else {
+                    HttpLoggingInterceptor.Level.NONE
+                }
             })
             .addInterceptor {
                 val authLocalData = authLocalDataSource.getData()

--- a/presentation/src/androidTest/java/com/pocs/presentation/UserDetailScreenTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/UserDetailScreenTest.kt
@@ -11,6 +11,7 @@ import com.pocs.presentation.view.user.detail.UserDetailScreen
 import com.pocs.test_library.mock.mockAdminUserDetail
 import org.junit.Rule
 import org.junit.Test
+import java.net.ConnectException
 
 class UserDetailScreenTest {
 
@@ -131,5 +132,20 @@ class UserDetailScreenTest {
 
             onNodeWithText(errorMessage).assertIsDisplayed()
         }
+    }
+
+    @Test
+    fun shouldNotShowServerUrl_WhenExceptionIsConnectException() {
+        val exception = ConnectException("Failed to connect http://123.123.123/")
+        val uiState = UserDetailUiState.Failure(exception, onRetryClick = {})
+        composeTestRule.setContent {
+            UserDetailScreen(
+                uiState = uiState,
+                onEdited = {},
+                onSuccessToKick = {}
+            )
+        }
+
+        composeTestRule.onNodeWithText(exception.message!!).assertDoesNotExist()
     }
 }

--- a/presentation/src/main/java/com/pocs/presentation/model/post/PostDetailUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/post/PostDetailUiState.kt
@@ -15,7 +15,7 @@ sealed class PostDetailUiState {
         val comments: CommentsUiState = CommentsUiState.Loading
     ) : PostDetailUiState()
 
-    data class Failure(val message: String?) : PostDetailUiState()
+    data class Failure(val exception: Throwable) : PostDetailUiState()
 
     object Loading : PostDetailUiState()
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/component/FailureContent.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/FailureContent.kt
@@ -2,7 +2,10 @@ package com.pocs.presentation.view.component
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Error
 import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -14,16 +17,33 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.pocs.presentation.R
+import java.net.ConnectException
 
 @Composable
-fun FailureContent(modifier: Modifier = Modifier, message: String, onRetryClick: () -> Unit) {
+fun FailureContent(
+    modifier: Modifier = Modifier,
+    exception: Throwable,
+    onRetryClick: (() -> Unit)? = null
+) {
+    val message = when (exception) {
+        is ConnectException -> stringResource(id = R.string.fail_to_connect)
+        else -> exception.message ?: stringResource(id = R.string.failed_to_load)
+    }
+
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(horizontal = 16.dp),
+            .padding(horizontal = 20.dp),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
+        Icon(
+            imageVector = Icons.Default.Error,
+            contentDescription = stringResource(R.string.error_icon),
+            modifier = Modifier.size(96.dp),
+            tint = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
+        )
+        Spacer(modifier = Modifier.padding(top = 16.dp))
         SelectionContainer {
             Text(
                 message,
@@ -32,9 +52,11 @@ fun FailureContent(modifier: Modifier = Modifier, message: String, onRetryClick:
                 modifier = Modifier.alpha(0.7f)
             )
         }
-        Spacer(modifier = Modifier.padding(top = 16.dp))
-        Button(onClick = onRetryClick) {
-            Text(text = stringResource(R.string.retry))
+        if (onRetryClick != null) {
+            Spacer(modifier = Modifier.padding(top = 16.dp))
+            Button(onClick = onRetryClick) {
+                Text(text = stringResource(R.string.retry))
+            }
         }
     }
 }
@@ -42,5 +64,5 @@ fun FailureContent(modifier: Modifier = Modifier, message: String, onRetryClick:
 @Composable
 @Preview(showBackground = true)
 fun FailureContentPreview() {
-    FailureContent(message = "로딩을 실패했습니다.", onRetryClick = {})
+    FailureContent(exception = Exception("로딩을 실패했습니다."), onRetryClick = {})
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
@@ -8,22 +8,18 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material3.*
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -360,29 +356,10 @@ private fun PostDetailFailureContent(uiState: PostDetailUiState.Failure) {
             )
         }
     ) {
-        Column(
-            modifier = Modifier
-                .padding(it)
-                .fillMaxSize()
-                .padding(20.dp),
-            verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Icon(
-                imageVector = Icons.Default.Error,
-                contentDescription = stringResource(R.string.error_icon),
-                modifier = Modifier.size(96.dp),
-                tint = MaterialTheme.colorScheme.primary
-            )
-            Box(modifier = Modifier.height(16.dp))
-            Text(
-                text = uiState.message ?: stringResource(id = R.string.failed_to_load),
-                style = MaterialTheme.typography.headlineSmall.copy(
-                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f)
-                ),
-                textAlign = TextAlign.Center
-            )
-        }
+        FailureContent(
+            modifier = Modifier.padding(it),
+            exception = uiState.exception
+        )
     }
 }
 
@@ -444,5 +421,5 @@ private fun PostDetailContentPreview() {
 @Preview
 @Composable
 fun PostDetailFailureContentPreview() {
-    PostDetailFailureContent(PostDetailUiState.Failure("연결 실패"))
+    PostDetailFailureContent(PostDetailUiState.Failure(Exception("연결 실패")))
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailViewModel.kt
@@ -78,8 +78,8 @@ class PostDetailViewModel @Inject constructor(
 
                 fetchComments()
             } else {
-                val errorMessage = result.exceptionOrNull()!!.message
-                _uiState.update { PostDetailUiState.Failure(message = errorMessage) }
+                val exception = result.exceptionOrNull()!!
+                _uiState.update { PostDetailUiState.Failure(exception = exception) }
             }
         }
     }

--- a/presentation/src/main/java/com/pocs/presentation/view/user/detail/UserDetailScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/user/detail/UserDetailScreen.kt
@@ -75,7 +75,7 @@ fun UserDetailScreen(
         }
         is UserDetailUiState.Failure -> {
             UserDetailFailureContent(
-                message = uiState.e.message ?: stringResource(R.string.failed_to_load),
+                exception = uiState.e,
                 onRetryClick = uiState.onRetryClick
             )
         }
@@ -383,13 +383,13 @@ fun UserInfoContainer(label: String, annotatedString: AnnotatedString) {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun UserDetailFailureContent(message: String, onRetryClick: () -> Unit) {
+fun UserDetailFailureContent(exception: Throwable, onRetryClick: () -> Unit) {
     Scaffold(
         topBar = { UserDetailTopBar("", displayActions = false, isUserKicked = false, {}, {}) }
     ) {
         FailureContent(
             modifier = Modifier.padding(it),
-            message = message,
+            exception = exception,
             onRetryClick = onRetryClick
         )
     }

--- a/presentation/src/test/java/com/pocs/presentation/PostDetailViewModelTest.kt
+++ b/presentation/src/test/java/com/pocs/presentation/PostDetailViewModelTest.kt
@@ -95,7 +95,7 @@ class PostDetailViewModelTest {
         assertTrue(viewModel.uiState.value is PostDetailUiState.Failure)
         assertEquals(
             exception.message!!,
-            (viewModel.uiState.value as PostDetailUiState.Failure).message!!
+            (viewModel.uiState.value as PostDetailUiState.Failure).exception.message!!
         )
 
         collectJob.cancel()


### PR DESCRIPTION
Resolves #242 

Compose로 구현한 에러 화면의 코드를 개선했습니다. Exception이 ConnectException인 경우 다른 메시지를 보이도록하여 #242 문제를 해결했습니다.

## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [ ] Action에서 진행하는 테스트를 모두 통과했는가?
- [x] 수정 사항을 검증할 테스트를 추가하였는가?
- [ ] 리뷰를 받았는가?