### PR TITLE
회원 프로필 이미지 용량 및 크기 제한 추가

### DIFF
--- a/presentation/src/androidTest/java/com/pocs/presentation/UserEditScreenTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/UserEditScreenTest.kt
@@ -3,8 +3,10 @@ package com.pocs.presentation
 import android.content.Context
 import android.graphics.BitmapFactory
 import androidx.annotation.StringRes
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -55,6 +57,7 @@ class UserEditScreenTest {
             setContent {
                 UserEditContent(
                     uiState = mockUiState,
+                    snackBarHostState = remember { SnackbarHostState() },
                     navigateUp = {},
                     onSuccessToSave = {}
                 )
@@ -72,6 +75,7 @@ class UserEditScreenTest {
             setContent {
                 UserEditContent(
                     uiState = mockUiState,
+                    snackBarHostState = remember { SnackbarHostState() },
                     navigateUp = {},
                     onSuccessToSave = {}
                 )
@@ -92,6 +96,7 @@ class UserEditScreenTest {
             setContent {
                 UserEditContent(
                     uiState = mockUiState.copy(name = "", email = "abc"),
+                    snackBarHostState = remember { SnackbarHostState() },
                     navigateUp = {},
                     onSuccessToSave = {}
                 )
@@ -107,6 +112,7 @@ class UserEditScreenTest {
             setContent {
                 UserEditContent(
                     uiState = mockUiState.copy(name = "kim", email = ""),
+                    snackBarHostState = remember { SnackbarHostState() },
                     navigateUp = {},
                     onSuccessToSave = {}
                 )
@@ -126,6 +132,7 @@ class UserEditScreenTest {
                         email = "ail@he.com",
                         github = "https://github.com/user"
                     ),
+                    snackBarHostState = remember { SnackbarHostState() },
                     navigateUp = {},
                     onSuccessToSave = {}
                 )
@@ -143,6 +150,7 @@ class UserEditScreenTest {
                     uiState = mockUiState.copy(name = "", onUpdate = {
                         assertTrue(it.name.length <= MAX_USER_NAME_LEN)
                     }),
+                    snackBarHostState = remember { SnackbarHostState() },
                     navigateUp = {},
                     onSuccessToSave = {},
                 )
@@ -166,6 +174,7 @@ class UserEditScreenTest {
             setContent {
                 UserEditContent(
                     uiState = mockUiState.copy(email = "abc@.com"),
+                    snackBarHostState = remember { SnackbarHostState() },
                     navigateUp = {},
                     onSuccessToSave = {},
                 )
@@ -181,6 +190,7 @@ class UserEditScreenTest {
             setContent {
                 UserEditContent(
                     uiState = mockUiState.copy(name = ""),
+                    snackBarHostState = remember { SnackbarHostState() },
                     navigateUp = {},
                     onSuccessToSave = {},
                 )
@@ -196,6 +206,7 @@ class UserEditScreenTest {
             setContent {
                 UserEditContent(
                     uiState = mockUiState.copy(email = ""),
+                    snackBarHostState = remember { SnackbarHostState() },
                     navigateUp = {},
                     onSuccessToSave = {},
                 )
@@ -211,6 +222,7 @@ class UserEditScreenTest {
             setContent {
                 UserEditContent(
                     uiState = mockUiState.copy(profileImageUrl = "https://user-images.githubusercontent.com/57604817/179393181-8521a33b-a344-4f12-afb5-7cb3e77c44f2.png"),
+                    snackBarHostState = remember { SnackbarHostState() },
                     navigateUp = {},
                     onSuccessToSave = {},
                 )
@@ -233,6 +245,7 @@ class UserEditScreenTest {
             setContent {
                 UserEditContent(
                     uiState = mockUiState.copy(newProfileImage = bitmap),
+                    snackBarHostState = remember { SnackbarHostState() },
                     navigateUp = {},
                     onSuccessToSave = {},
                 )

--- a/presentation/src/main/java/com/pocs/presentation/constant/UserConstant.kt
+++ b/presentation/src/main/java/com/pocs/presentation/constant/UserConstant.kt
@@ -9,3 +9,5 @@ const val MAX_USER_EMAIL_LEN = 255
 const val MAX_USER_COMPANY_LEN = 20
 const val MAX_USER_GITHUB_LEN = 255
 const val MIN_USER_NAME_SEARCH_LEN = 2
+
+const val MAX_PROFILE_IMAGE_MB_SIZE = 10

--- a/presentation/src/main/java/com/pocs/presentation/extension/BitmapExt.kt
+++ b/presentation/src/main/java/com/pocs/presentation/extension/BitmapExt.kt
@@ -1,0 +1,34 @@
+package com.pocs.presentation.extension
+
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+import java.io.File
+import java.io.InputStream
+
+fun Uri.getImageSizeInMegaByte(context: Context): Long {
+    val scheme: String? = this.scheme
+    var dataSize = 0L
+    if (scheme == ContentResolver.SCHEME_CONTENT) {
+        try {
+            val fileInputStream: InputStream? = context.contentResolver.openInputStream(this)
+            if (fileInputStream != null) {
+                dataSize = fileInputStream.available().toLong()
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    } else if (scheme == ContentResolver.SCHEME_FILE) {
+        val path: String? = this.path
+        var file: File? = null
+        try {
+            file = path?.let { File(it) }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+        if (file != null) {
+            dataSize = file.length().toInt().toLong()
+        }
+    }
+    return dataSize / (1024 * 1024)
+}

--- a/presentation/src/main/java/com/pocs/presentation/extension/BitmapExt.kt
+++ b/presentation/src/main/java/com/pocs/presentation/extension/BitmapExt.kt
@@ -2,9 +2,11 @@ package com.pocs.presentation.extension
 
 import android.content.ContentResolver
 import android.content.Context
+import android.graphics.Bitmap
 import android.net.Uri
 import java.io.File
 import java.io.InputStream
+import kotlin.math.roundToInt
 
 fun Uri.getImageSizeInMegaByte(context: Context): Long {
     val scheme: String? = this.scheme
@@ -31,4 +33,20 @@ fun Uri.getImageSizeInMegaByte(context: Context): Long {
         }
     }
     return dataSize / (1024 * 1024)
+}
+
+fun Bitmap.scaleDown(maxImageSize: Float): Bitmap {
+    val ratio = (maxImageSize / width).coerceAtMost(maxImageSize / height)
+    val width = (ratio * width).roundToInt()
+    val height = (ratio * height).roundToInt()
+
+    if (ratio >= 1.0) {
+        return this
+    }
+    return Bitmap.createScaledBitmap(
+        this,
+        width,
+        height,
+        true
+    )
 }

--- a/presentation/src/main/java/com/pocs/presentation/model/user/UserEditUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/user/UserEditUiState.kt
@@ -14,6 +14,7 @@ data class UserEditUiState(
     val company: String?,
     val github: String?,
     val isInSaving: Boolean = false,
+    val message: String? = null,
     private val onUpdate: (UserEditUiState) -> Unit,
     val onSave: suspend () -> Result<Unit>
 ) {

--- a/presentation/src/main/java/com/pocs/presentation/view/user/edit/UserEditScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/user/edit/UserEditScreen.kt
@@ -28,10 +28,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import com.pocs.presentation.R
-import com.pocs.presentation.constant.MAX_USER_COMPANY_LEN
-import com.pocs.presentation.constant.MAX_USER_EMAIL_LEN
-import com.pocs.presentation.constant.MAX_USER_GITHUB_LEN
-import com.pocs.presentation.constant.MAX_USER_NAME_LEN
+import com.pocs.presentation.constant.*
+import com.pocs.presentation.extension.getImageSizeInMegaByte
 import com.pocs.presentation.model.user.UserEditUiState
 import com.pocs.presentation.view.component.UserProfileImage
 import com.pocs.presentation.view.component.RecheckHandler
@@ -46,8 +44,19 @@ fun UserEditScreen(
     navigateUp: () -> Unit,
     onSuccessToSave: () -> Unit
 ) {
+    val snackBarHostState = remember { SnackbarHostState() }
+    val uiState = viewModel.uiState.value
+
+    if (uiState.message != null) {
+        LaunchedEffect(Unit) {
+            snackBarHostState.showSnackbar(uiState.message)
+            viewModel.messageShown()
+        }
+    }
+
     UserEditContent(
-        uiState = viewModel.uiState.value,
+        uiState = uiState,
+        snackBarHostState = snackBarHostState,
         navigateUp = navigateUp,
         onSuccessToSave = onSuccessToSave
     )
@@ -55,13 +64,21 @@ fun UserEditScreen(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun UserEditContent(uiState: UserEditUiState, navigateUp: () -> Unit, onSuccessToSave: () -> Unit) {
+fun UserEditContent(
+    uiState: UserEditUiState,
+    snackBarHostState: SnackbarHostState,
+    navigateUp: () -> Unit,
+    onSuccessToSave: () -> Unit
+) {
     val onBackPressedDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
-    val snackBarHostState = remember { SnackbarHostState() }
     var showProfileDialog by remember { mutableStateOf(false) }
     val failedToUpdateString = stringResource(R.string.failed_to_update)
+    val maxProfileImageSizeWarning = stringResource(
+        R.string.user_profile_image_max_size,
+        MAX_PROFILE_IMAGE_MB_SIZE
+    )
     val imagePickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.GetContent()
     ) { uri: Uri? ->
@@ -72,7 +89,15 @@ fun UserEditContent(uiState: UserEditUiState, navigateUp: () -> Unit, onSuccessT
                 val source = ImageDecoder.createSource(context.contentResolver, uri)
                 ImageDecoder.decodeBitmap(source)
             }
-            uiState.update { it.copy(newProfileImage = bitmap) }
+
+            val imageMegaByteSize = uri.getImageSizeInMegaByte(context)
+            uiState.update {
+                if (imageMegaByteSize >= MAX_PROFILE_IMAGE_MB_SIZE) {
+                    it.copy(message = maxProfileImageSizeWarning)
+                } else {
+                    it.copy(newProfileImage = bitmap)
+                }
+            }
         }
     }
 
@@ -313,6 +338,7 @@ fun UserEditContentPreview() {
             onUpdate = {},
             onSave = { Result.success(Unit) }
         ),
+        snackBarHostState = SnackbarHostState(),
         navigateUp = {}
     ) {}
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/user/edit/UserEditScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/user/edit/UserEditScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.window.Dialog
 import com.pocs.presentation.R
 import com.pocs.presentation.constant.*
 import com.pocs.presentation.extension.getImageSizeInMegaByte
+import com.pocs.presentation.extension.scaleDown
 import com.pocs.presentation.model.user.UserEditUiState
 import com.pocs.presentation.view.component.UserProfileImage
 import com.pocs.presentation.view.component.RecheckHandler
@@ -83,12 +84,13 @@ fun UserEditContent(
         contract = ActivityResultContracts.GetContent()
     ) { uri: Uri? ->
         if (uri != null) {
-            val bitmap = if (Build.VERSION.SDK_INT < 28) {
+            var bitmap = if (Build.VERSION.SDK_INT < 28) {
                 MediaStore.Images.Media.getBitmap(context.contentResolver, uri)
             } else {
                 val source = ImageDecoder.createSource(context.contentResolver, uri)
                 ImageDecoder.decodeBitmap(source)
             }
+            bitmap = bitmap.scaleDown(3000f)
 
             val imageMegaByteSize = uri.getImageSizeInMegaByte(context)
             uiState.update {

--- a/presentation/src/main/java/com/pocs/presentation/view/user/edit/UserEditViewModel.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/user/edit/UserEditViewModel.kt
@@ -54,4 +54,8 @@ class UserEditViewModel @Inject constructor(
         _uiState.value = _uiState.value.copy(isInSaving = false)
         return result
     }
+
+    fun messageShown() {
+        _uiState.value = _uiState.value.copy(message = null)
+    }
 }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -129,6 +129,7 @@
     <string name="remove_profile_image">기본 이미지로 변경</string>
     <string name="choose_from_gallery">갤러리에서 선택</string>
     <string name="profile_image">프로필 사진</string>
+    <string name="user_profile_image_max_size">%sMB 미만의 이미지만 가능해요</string>
     <string-array name="admin_tab">
         <item>전체 게시글</item>
         <item>회원목록</item>


### PR DESCRIPTION
Resolves #253 

- 이미지 용량을 최대 10MB로 제한했습니다.
- 이미지 너비 및 높이가 3000 이상인 경우 3000으로 축소하도록 하였습니다. 이유는 너무 크기가 큰 이미지의 경우 `trying to draw too large … bytes bitmap` 메시지와 함께 앱 충돌이 발생하기 때문입니다.

## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [ ] Action에서 진행하는 테스트를 모두 통과했는가?
- [ ] 수정 사항을 검증할 테스트를 추가하였는가?
- [ ] 리뷰를 받았는가?