### PR TITLE
비밀번호 최소 6자 이상 입력하도록 수정

### DIFF
--- a/presentation/src/androidTest/java/com/pocs/presentation/AdminUserCreateScreenTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/AdminUserCreateScreenTest.kt
@@ -3,14 +3,16 @@ package com.pocs.presentation
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onNodeWithContentDescription
-import androidx.compose.ui.test.onNodeWithText
+import com.pocs.domain.model.user.UserType
+import com.pocs.presentation.constant.MAX_USER_PASSWORD_LEN
+import com.pocs.presentation.constant.MIN_USER_PASSWORD_LEN
 import com.pocs.presentation.model.admin.AdminUserCreateUiState
+import com.pocs.presentation.model.admin.UserCreateInfoUiState
 import com.pocs.presentation.view.admin.user.create.AdminUserCreateScreen
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 
@@ -18,6 +20,16 @@ class AdminUserCreateScreenTest {
 
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    private val validUserCreateInfo = UserCreateInfoUiState(
+        userName = "Name",
+        password = "password",
+        name = "Kim parkhong",
+        studentId = "1820391",
+        email = "abc@gmail.com",
+        generation = "31",
+        type = UserType.MEMBER
+    )
 
     private var mockUiState by mutableStateOf(AdminUserCreateUiState(
         onSave = {},
@@ -68,18 +80,51 @@ class AdminUserCreateScreenTest {
     @Test
     fun shouldDisableSaveButton_WhenEmailIsNotValid() {
         composeTestRule.run {
-            var callCount = 0
             setContent {
                 AdminUserCreateScreen(
                     uiState = mockUiState.copy(
-                        createInfo = mockUiState.createInfo.copy(email = "abd@fe")
+                        createInfo = validUserCreateInfo.copy(email = "abd@fe")
                     ),
-                    navigateUp = { callCount++ },
+                    navigateUp = {},
                     onSuccessToCreate = {}
                 )
             }
 
             onNodeWithContentDescription("저장하기").assertIsNotEnabled()
+        }
+    }
+
+    @Test
+    fun shouldDisableSaveButton_WhenPasswordLengthIsShort() {
+        composeTestRule.run {
+            val createInfo = validUserCreateInfo.copy(password = "abd")
+            assertTrue(createInfo.password.length < MAX_USER_PASSWORD_LEN)
+            setContent {
+                AdminUserCreateScreen(
+                    uiState = mockUiState.copy(createInfo = createInfo),
+                    navigateUp = {},
+                    onSuccessToCreate = {}
+                )
+            }
+
+            onNodeWithContentDescription("저장하기").assertIsNotEnabled()
+        }
+    }
+
+    @Test
+    fun shouldEnableSaveButton_WhenPasswordLengthIsUpperSix() {
+        composeTestRule.run {
+            val createInfo = validUserCreateInfo.copy(password = "helloNice")
+            assertTrue(createInfo.password.length >= MIN_USER_PASSWORD_LEN)
+            setContent {
+                AdminUserCreateScreen(
+                    uiState = mockUiState.copy(createInfo = createInfo),
+                    navigateUp = {},
+                    onSuccessToCreate = {}
+                )
+            }
+
+            onNodeWithContentDescription("저장하기").assertIsEnabled()
         }
     }
 }

--- a/presentation/src/androidTest/java/com/pocs/presentation/AnonymousCreateScreenTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/AnonymousCreateScreenTest.kt
@@ -1,0 +1,69 @@
+package com.pocs.presentation
+
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import com.pocs.presentation.constant.MIN_USER_PASSWORD_LEN
+import com.pocs.presentation.model.user.anonymous.AnonymousCreateInfoUiState
+import com.pocs.presentation.model.user.anonymous.AnonymousCreateUiState
+import com.pocs.presentation.view.user.anonymous.AnonymousCreateScreen
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class AnonymousCreateScreenTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun shouldDisableCreateButton_WhenPasswordIsShort() {
+        composeRule.run {
+            val createInfo = AnonymousCreateInfoUiState(
+                userName = "id",
+                password = "hi"
+            )
+            assertTrue(createInfo.password.length < MIN_USER_PASSWORD_LEN)
+            setContent {
+                AnonymousCreateScreen(
+                    uiState = AnonymousCreateUiState(
+                        createInfo = createInfo,
+                        onCreate = {},
+                        onUpdateCreateInfo = {},
+                        shownErrorMessage = {}
+                    ),
+                    navigateUp = {},
+                    onSuccessToCreate = {}
+                )
+            }
+
+            onNodeWithText("생성하기").assertIsNotEnabled()
+        }
+    }
+
+    @Test
+    fun shouldEnableCreateButton_WhenInfoIsCorrect() {
+        composeRule.run {
+            val createInfo = AnonymousCreateInfoUiState(
+                userName = "id",
+                password = "hiNiceToMeet"
+            )
+            assertTrue(createInfo.password.length >= MIN_USER_PASSWORD_LEN)
+            setContent {
+                AnonymousCreateScreen(
+                    uiState = AnonymousCreateUiState(
+                        createInfo = createInfo,
+                        onCreate = {},
+                        onUpdateCreateInfo = {},
+                        shownErrorMessage = {}
+                    ),
+                    navigateUp = {},
+                    onSuccessToCreate = {}
+                )
+            }
+
+            onNodeWithText("생성하기").assertIsEnabled()
+        }
+    }
+}

--- a/presentation/src/androidTest/java/com/pocs/presentation/LoginScreenTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/LoginScreenTest.kt
@@ -18,7 +18,7 @@ class LoginScreenTest {
     fun disableLoginButton_WhenUserNameIsEmtpy() {
         val uiState = LoginUiState(
             userName = "",
-            password = "123",
+            password = "123456",
             onUpdate = {}
         )
         composeRule.run {
@@ -57,10 +57,31 @@ class LoginScreenTest {
     }
 
     @Test
-    fun enableLoginButton_WhenUserNameAndPasswordIsNotEmtpy() {
+    fun disableLoginButton_WhenPasswordIsShort() {
+        val uiState = LoginUiState(
+            userName = "32",
+            password = "12345",
+            onUpdate = {}
+        )
+        composeRule.run {
+            setContent {
+                LoginContent(
+                    uiState = uiState,
+                    onLoginClick = {},
+                    onClickCreateAnonymous = {},
+                    onUserMessageShown = {}
+                )
+            }
+
+            onNodeWithText("로그인").assertIsNotEnabled()
+        }
+    }
+
+    @Test
+    fun enableLoginButton_WhenUserNameAndPasswordLengthAreCorrect() {
         val uiState = LoginUiState(
             userName = "423",
-            password = "123",
+            password = "123456",
             onUpdate = {}
         )
         composeRule.run {

--- a/presentation/src/androidTest/java/com/pocs/presentation/UserEditScreenTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/UserEditScreenTest.kt
@@ -257,4 +257,20 @@ class UserEditScreenTest {
             assertNull(mockUiState.profileImageUrl)
         }
     }
+
+    @Test
+    fun shouldDisableSaveButton_WhenPasswordIsShortAndNotEmpty() {
+        composeTestRule.run {
+            setContent {
+                UserEditContent(
+                    uiState = mockUiState.copy(password = "hey"),
+                    snackBarHostState = remember { SnackbarHostState() },
+                    navigateUp = {},
+                    onSuccessToSave = {},
+                )
+            }
+
+            onNodeWithContentDescription(getString(R.string.save)).assertIsNotEnabled()
+        }
+    }
 }

--- a/presentation/src/main/java/com/pocs/presentation/constant/UserConstant.kt
+++ b/presentation/src/main/java/com/pocs/presentation/constant/UserConstant.kt
@@ -2,7 +2,10 @@ package com.pocs.presentation.constant
 
 const val MAX_USER_ID_LEN = 15
 const val MAX_USER_NAME_LEN = 20
+
+const val MIN_USER_PASSWORD_LEN = 6
 const val MAX_USER_PASSWORD_LEN = 255
+
 const val MAX_USER_STUDENT_ID_LEN = 7
 const val MAX_USER_GENERATION_LEN = 5
 const val MAX_USER_EMAIL_LEN = 255

--- a/presentation/src/main/java/com/pocs/presentation/model/admin/AdminUserCreateUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/admin/AdminUserCreateUiState.kt
@@ -1,5 +1,6 @@
 package com.pocs.presentation.model.admin
 
+import com.pocs.presentation.constant.MIN_USER_PASSWORD_LEN
 import com.pocs.presentation.extension.canSaveAsGithubUrl
 import com.pocs.presentation.extension.isValidEmail
 
@@ -15,7 +16,7 @@ data class AdminUserCreateUiState(
     val canSave
         get() : Boolean {
             return createInfo.userName.isNotEmpty()
-                    && createInfo.password.isNotEmpty()
+                    && createInfo.password.length >= MIN_USER_PASSWORD_LEN
                     && createInfo.name.isNotEmpty()
                     && createInfo.studentId.isNotEmpty()
                     && createInfo.generation.isNotEmpty()

--- a/presentation/src/main/java/com/pocs/presentation/model/auth/LoginUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/auth/LoginUiState.kt
@@ -1,5 +1,7 @@
 package com.pocs.presentation.model.auth
 
+import com.pocs.presentation.constant.MIN_USER_PASSWORD_LEN
+
 data class LoginUiState(
     val hideSplashScreen: Boolean = false,
     val isLoggedIn: Boolean = false,
@@ -12,5 +14,6 @@ data class LoginUiState(
         onUpdate(function(this))
     }
 
-    val enableLoginButton: Boolean get() = userName.isNotEmpty() && password.isNotEmpty()
+    val enableLoginButton: Boolean
+        get() = userName.isNotEmpty() && password.length >= MIN_USER_PASSWORD_LEN
 }

--- a/presentation/src/main/java/com/pocs/presentation/model/user/UserEditUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/user/UserEditUiState.kt
@@ -1,6 +1,7 @@
 package com.pocs.presentation.model.user
 
 import android.graphics.Bitmap
+import com.pocs.presentation.constant.MIN_USER_PASSWORD_LEN
 import com.pocs.presentation.extension.canSaveAsGithubUrl
 import com.pocs.presentation.extension.isValidEmail
 
@@ -20,9 +21,10 @@ data class UserEditUiState(
 ) {
     val canSave: Boolean
         get() {
-            return canSaveName && canSaveEmail && canSaveGithubUrl
+            return canSaveName && canSavePassword && canSaveEmail && canSaveGithubUrl
         }
 
+    private val canSavePassword = password.isEmpty() || password.length >= MIN_USER_PASSWORD_LEN
     val canSaveName = name.isNotEmpty()
     val canSaveEmail = email.isValidEmail()
     val canSaveGithubUrl = github == null || github.canSaveAsGithubUrl()

--- a/presentation/src/main/java/com/pocs/presentation/model/user/anonymous/AnonymousCreateUiState.kt
+++ b/presentation/src/main/java/com/pocs/presentation/model/user/anonymous/AnonymousCreateUiState.kt
@@ -1,5 +1,7 @@
 package com.pocs.presentation.model.user.anonymous
 
+import com.pocs.presentation.constant.MIN_USER_PASSWORD_LEN
+
 data class AnonymousCreateUiState(
     val createInfo: AnonymousCreateInfoUiState = AnonymousCreateInfoUiState(),
     val isInCreating: Boolean = false,
@@ -8,10 +10,12 @@ data class AnonymousCreateUiState(
     val errorMessage: String? = null,
     val shownErrorMessage: () -> Unit,
     private val onUpdateCreateInfo: (AnonymousCreateInfoUiState) -> Unit,
-){
+) {
     fun updateCreateInfo(updater: (AnonymousCreateInfoUiState) -> AnonymousCreateInfoUiState) {
         onUpdateCreateInfo(updater(createInfo))
     }
 
-    val enableCreateButton: Boolean get() = createInfo.userName.isNotEmpty() && createInfo.password.isNotEmpty()
+    val enableCreateButton: Boolean
+        get() = createInfo.userName.isNotEmpty()
+                && createInfo.password.length >= MIN_USER_PASSWORD_LEN
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/admin/user/create/AdminUserCreateScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/admin/user/create/AdminUserCreateScreen.kt
@@ -18,6 +18,7 @@ import com.pocs.presentation.constant.*
 import com.pocs.presentation.model.admin.AdminUserCreateUiState
 import com.pocs.presentation.view.component.RecheckHandler
 import com.pocs.presentation.view.component.appbar.EditContentAppBar
+import com.pocs.presentation.view.component.textfield.PasswordOutlineTextField
 import com.pocs.presentation.view.component.textfield.PocsOutlineTextField
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -78,15 +79,13 @@ fun AdminUserCreateScreen(
                     uiState.updateCreateInfo { it.copy(userName = "") }
                 }
             )
-            PocsOutlineTextField(
-                value = createInfo.password,
-                label = stringResource(R.string.password),
-                maxLength = MAX_USER_PASSWORD_LEN,
+            PasswordOutlineTextField(
+                password = createInfo.password,
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Password,
                     imeAction = ImeAction.Next
                 ),
-                onValueChange = { password ->
+                onPasswordChange = { password ->
                     uiState.updateCreateInfo { it.copy(password = password) }
                 },
                 onClearClick = {

--- a/presentation/src/main/java/com/pocs/presentation/view/component/textfield/PasswordOutlineTextField.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/textfield/PasswordOutlineTextField.kt
@@ -16,8 +16,8 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import com.pocs.presentation.R
 import com.pocs.presentation.constant.MAX_USER_PASSWORD_LEN
+import com.pocs.presentation.constant.MIN_USER_PASSWORD_LEN
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PasswordOutlineTextField(
     modifier: Modifier = Modifier,
@@ -26,19 +26,30 @@ fun PasswordOutlineTextField(
         keyboardType = KeyboardType.Password,
         imeAction = ImeAction.Send
     ),
+    enableMinLengthError: Boolean = true,
     onPasswordChange: (String) -> Unit,
     onSend: ((String) -> Unit)? = null,
     onClearClick: () -> Unit,
 ) {
     var passwordVisible by remember { mutableStateOf(false) }
+    val showMinPasswordLengthError by rememberUpdatedState(
+        newValue = enableMinLengthError && password.isNotEmpty() && password.length < MIN_USER_PASSWORD_LEN
+    )
 
     PocsOutlineTextField(
-        label = stringResource(id = R.string.password),
+        label = stringResource(
+            if (showMinPasswordLengthError) {
+                R.string.password_min_legnth_error
+            } else {
+                R.string.password
+            }
+        ),
         modifier = modifier.fillMaxWidth(),
         value = password,
         onValueChange = {
             onPasswordChange(it)
         },
+        isError = showMinPasswordLengthError,
         keyboardOptions = keyboardOptions,
         keyboardActions = KeyboardActions(
             onSend = {

--- a/presentation/src/main/java/com/pocs/presentation/view/login/LoginScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/login/LoginScreen.kt
@@ -93,6 +93,7 @@ fun LoginContent(
             PasswordOutlineTextField(
                 modifier = Modifier.focusRequester(passwordFocusRequester),
                 password = uiState.password,
+                enableMinLengthError = false,
                 onPasswordChange = { password ->
                     uiState.update { it.copy(password = password) }
                 },

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -130,6 +130,7 @@
     <string name="choose_from_gallery">갤러리에서 선택</string>
     <string name="profile_image">프로필 사진</string>
     <string name="user_profile_image_max_size">%sMB 미만의 이미지만 가능해요</string>
+    <string name="password_min_legnth_error">비밀번호는 최소 6자 이상입니다.</string>
     <string-array name="admin_tab">
         <item>전체 게시글</item>
         <item>회원목록</item>


### PR DESCRIPTION
Resolves #169 

### 적용한 화면
- 로그인 화면
- 관리자 유저 생성 화면
- 유저 편집 화면
- 익명 회원 생성 화면

로그인 화면은 아래와 같이 비밀번호가 6자 이상이어야지 로그인 버튼이 활성화됩니다. 이외의 생성/편집 화면들은 6자 미만으로 입력시 "비밀번호는 6자 이상입니다." 경고 문구를 보이도록 했습니다.

https://user-images.githubusercontent.com/57604817/189252375-a5c2bd11-8aa6-42e0-9aeb-856f1519ac02.mov



## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [ ] Action에서 진행하는 테스트를 모두 통과했는가?
- [x] 수정 사항을 검증할 테스트를 추가하였는가?
- [ ] 리뷰를 받았는가?