### PR TITLE
게시글 상세 화면에서 회원 이름 클릭시 프로필 화면으로 전환하는 기능 추가

### DIFF
--- a/presentation/src/androidTest/java/com/pocs/presentation/PostDetailScreenTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/PostDetailScreenTest.kt
@@ -636,8 +636,6 @@ class PostDetailScreenTest {
                 )
             }
 
-            onRoot(useUnmergedTree = true).printToLog("currentLabelExists")
-
             onNodeWithText(name, substring = true)
                 .performTouchInput {
                     click(percentOffset(.1f, .5f))
@@ -677,7 +675,7 @@ class PostDetailScreenTest {
         snackbarHostState: SnackbarHostState,
         onEditClick: () -> Unit = {},
         onDeleteClick: () -> Unit = {},
-        onWriterNameClick: () -> Unit = {},
+        onWriterNameClick: (Int) -> Unit = {},
         onCommentDelete: (commentId: Int) -> Unit = { _ -> },
         onCommentCreated: CommentCreateCallback = { _, _ -> },
         onCommentUpdated: CommentUpdateCallback = { _, _ -> }
@@ -689,7 +687,7 @@ class PostDetailScreenTest {
             snackbarHostState = snackbarHostState,
             onEditClick = onEditClick,
             onDeleteClick = onDeleteClick,
-            onWriterNameClick = onWriterNameClick,
+            onUserNameClick = onWriterNameClick,
             onCommentDelete = onCommentDelete,
             onCommentCreated = onCommentCreated,
             onCommentUpdated = onCommentUpdated

--- a/presentation/src/androidTest/java/com/pocs/presentation/PostDetailScreenTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/PostDetailScreenTest.kt
@@ -3,6 +3,7 @@ package com.pocs.presentation
 import android.content.Context
 import androidx.annotation.StringRes
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -11,12 +12,14 @@ import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.platform.app.InstrumentationRegistry
+import com.pocs.domain.model.post.PostWriter
+import com.pocs.domain.model.user.UserType
 import com.pocs.presentation.mapper.toUiState
 import com.pocs.presentation.model.comment.CommentsUiState
+import com.pocs.presentation.model.comment.item.CommentItemUiState
 import com.pocs.presentation.model.post.PostDetailUiState
 import com.pocs.presentation.model.post.item.PostWriterUiState
-import com.pocs.presentation.view.component.bottomsheet.CommentModalController
-import com.pocs.presentation.view.component.bottomsheet.MODAL_BOTTOM_SHEET_CONTENT_TAG
+import com.pocs.presentation.view.component.bottomsheet.*
 import com.pocs.presentation.view.post.detail.PostDetailContent
 import com.pocs.test_library.mock.mockComment
 import com.pocs.test_library.mock.mockPostDetail1
@@ -55,14 +58,9 @@ class PostDetailScreenTest {
             setContent {
                 val snackbarHostState = remember { SnackbarHostState() }
 
-                PostDetailContent(
+                BuildPostDetailContent(
                     uiState = uiState,
                     snackbarHostState = snackbarHostState,
-                    onEditClick = {},
-                    onDeleteClick = {},
-                    onCommentDelete = {},
-                    onCommentCreated = { _, _ -> },
-                    onCommentUpdated = { _, _ -> }
                 )
             }
 
@@ -78,14 +76,9 @@ class PostDetailScreenTest {
             setContent {
                 val snackbarHostState = remember { SnackbarHostState() }
 
-                PostDetailContent(
+                BuildPostDetailContent(
                     uiState = uiState,
                     snackbarHostState = snackbarHostState,
-                    onEditClick = {},
-                    onDeleteClick = {},
-                    onCommentDelete = {},
-                    onCommentCreated = { _, _ -> },
-                    onCommentUpdated = { _, _ -> }
                 )
             }
 
@@ -103,18 +96,13 @@ class PostDetailScreenTest {
             setContent {
                 val snackbarHostState = remember { SnackbarHostState() }
 
-                PostDetailContent(
+                BuildPostDetailContent(
                     uiState = uiState.copy(
                         comments = commentsUiState.copy(
                             comments = listOf(reply)
                         )
                     ),
                     snackbarHostState = snackbarHostState,
-                    onEditClick = {},
-                    onDeleteClick = {},
-                    onCommentDelete = {},
-                    onCommentCreated = { _, _ -> },
-                    onCommentUpdated = { _, _ -> }
                 )
             }
 
@@ -130,14 +118,9 @@ class PostDetailScreenTest {
             setContent {
                 val snackbarHostState = remember { SnackbarHostState() }
 
-                PostDetailContent(
+                BuildPostDetailContent(
                     uiState = uiState,
                     snackbarHostState = snackbarHostState,
-                    onEditClick = {},
-                    onDeleteClick = {},
-                    onCommentDelete = {},
-                    onCommentCreated = { _, _ -> },
-                    onCommentUpdated = { _, _ -> }
                 )
             }
 
@@ -155,15 +138,10 @@ class PostDetailScreenTest {
             setContent {
                 val snackbarHostState = remember { SnackbarHostState() }
 
-                PostDetailContent(
+                BuildPostDetailContent(
                     uiState = uiState,
                     snackbarHostState = snackbarHostState,
                     commentModalController = commentModalController,
-                    onEditClick = {},
-                    onDeleteClick = {},
-                    onCommentDelete = {},
-                    onCommentCreated = { _, _ -> },
-                    onCommentUpdated = { _, _ -> }
                 )
             }
 
@@ -187,17 +165,12 @@ class PostDetailScreenTest {
             setContent {
                 val snackbarHostState = remember { SnackbarHostState() }
 
-                PostDetailContent(
+                BuildPostDetailContent(
                     commentModalController = commentModalController,
                     uiState = uiState.copy(
                         comments = commentsUiState.copy(comments = listOf(comment))
                     ),
                     snackbarHostState = snackbarHostState,
-                    onEditClick = {},
-                    onDeleteClick = {},
-                    onCommentDelete = {},
-                    onCommentCreated = { _, _ -> },
-                    onCommentUpdated = { _, _ -> }
                 )
             }
 
@@ -218,17 +191,12 @@ class PostDetailScreenTest {
             setContent {
                 val snackbarHostState = remember { SnackbarHostState() }
 
-                PostDetailContent(
+                BuildPostDetailContent(
                     commentModalController = commentModalController,
                     uiState = uiState.copy(
                         comments = commentsUiState.copy(comments = listOf(replyComment))
                     ),
                     snackbarHostState = snackbarHostState,
-                    onEditClick = {},
-                    onDeleteClick = {},
-                    onCommentDelete = {},
-                    onCommentCreated = { _, _ -> },
-                    onCommentUpdated = { _, _ -> }
                 )
             }
 
@@ -281,14 +249,9 @@ class PostDetailScreenTest {
             setContent {
                 val snackbarHostState = remember { SnackbarHostState() }
 
-                PostDetailContent(
+                BuildPostDetailContent(
                     uiState = uiState,
                     snackbarHostState = snackbarHostState,
-                    onEditClick = {},
-                    onDeleteClick = {},
-                    onCommentDelete = {},
-                    onCommentCreated = { _, _ -> },
-                    onCommentUpdated = { _, _ -> }
                 )
             }
 
@@ -306,14 +269,9 @@ class PostDetailScreenTest {
             setContent {
                 val snackbarHostState = remember { SnackbarHostState() }
 
-                PostDetailContent(
+                BuildPostDetailContent(
                     uiState = uiState,
                     snackbarHostState = snackbarHostState,
-                    onEditClick = {},
-                    onDeleteClick = {},
-                    onCommentDelete = {},
-                    onCommentCreated = { _, _ -> },
-                    onCommentUpdated = { _, _ -> }
                 )
             }
 
@@ -334,15 +292,10 @@ class PostDetailScreenTest {
             setContent {
                 val snackbarHostState = remember { SnackbarHostState() }
 
-                PostDetailContent(
+                BuildPostDetailContent(
                     commentModalController = controller,
                     uiState = uiState,
                     snackbarHostState = snackbarHostState,
-                    onEditClick = {},
-                    onDeleteClick = {},
-                    onCommentDelete = {},
-                    onCommentCreated = { _, _ -> },
-                    onCommentUpdated = { _, _ -> }
                 )
             }
 
@@ -363,15 +316,10 @@ class PostDetailScreenTest {
             setContent {
                 val snackbarHostState = remember { SnackbarHostState() }
 
-                PostDetailContent(
+                BuildPostDetailContent(
                     commentModalController = controller,
                     uiState = uiState,
                     snackbarHostState = snackbarHostState,
-                    onEditClick = {},
-                    onDeleteClick = {},
-                    onCommentDelete = {},
-                    onCommentCreated = { _, _ -> },
-                    onCommentUpdated = { _, _ -> }
                 )
             }
 
@@ -394,14 +342,9 @@ class PostDetailScreenTest {
             setContent {
                 val snackbarHostState = remember { SnackbarHostState() }
 
-                PostDetailContent(
+                BuildPostDetailContent(
                     uiState = uiState,
                     snackbarHostState = snackbarHostState,
-                    onEditClick = {},
-                    onDeleteClick = {},
-                    onCommentDelete = {},
-                    onCommentCreated = { _, _ -> },
-                    onCommentUpdated = { _, _ -> }
                 )
             }
 
@@ -422,15 +365,10 @@ class PostDetailScreenTest {
                 keyboardHelper.view = LocalView.current
                 val snackbarHostState = remember { SnackbarHostState() }
 
-                PostDetailContent(
+                BuildPostDetailContent(
                     commentModalController = controller,
                     uiState = uiState,
                     snackbarHostState = snackbarHostState,
-                    onEditClick = {},
-                    onDeleteClick = {},
-                    onCommentDelete = {},
-                    onCommentCreated = { _, _ -> },
-                    onCommentUpdated = { _, _ -> }
                 )
             }
 
@@ -454,16 +392,11 @@ class PostDetailScreenTest {
             setContent {
                 val snackbarHostState = remember { SnackbarHostState() }
 
-                PostDetailContent(
+                BuildPostDetailContent(
                     uiState = uiState.copy(
                         postDetail = mockPostDetail1.copy(views = 10).toUiState()
                     ),
                     snackbarHostState = snackbarHostState,
-                    onEditClick = {},
-                    onDeleteClick = {},
-                    onCommentDelete = {},
-                    onCommentCreated = { _, _ -> },
-                    onCommentUpdated = { _, _ -> }
                 )
             }
 
@@ -479,7 +412,7 @@ class PostDetailScreenTest {
             setContent {
                 val snackbarHostState = remember { SnackbarHostState() }
 
-                PostDetailContent(
+                BuildPostDetailContent(
                     uiState = uiState.copy(
                         postDetail = mockPostDetail1.copy(
                             title = title,
@@ -489,11 +422,6 @@ class PostDetailScreenTest {
                         ).toUiState()
                     ),
                     snackbarHostState = snackbarHostState,
-                    onEditClick = {},
-                    onDeleteClick = {},
-                    onCommentDelete = {},
-                    onCommentCreated = { _, _ -> },
-                    onCommentUpdated = { _, _ -> }
                 )
             }
 
@@ -511,18 +439,13 @@ class PostDetailScreenTest {
             setContent {
                 val snackbarHostState = remember { SnackbarHostState() }
 
-                PostDetailContent(
+                BuildPostDetailContent(
                     uiState = uiState.copy(
                         comments = commentsUiState.copy(
                             comments = listOf(mockComment.copy(isDeleted = true, childrenCount = 2))
                         )
                     ),
                     snackbarHostState = snackbarHostState,
-                    onEditClick = {},
-                    onDeleteClick = {},
-                    onCommentDelete = {},
-                    onCommentCreated = { _, _ -> },
-                    onCommentUpdated = { _, _ -> }
                 )
             }
 
@@ -536,7 +459,7 @@ class PostDetailScreenTest {
             setContent {
                 val snackbarHostState = remember { SnackbarHostState() }
 
-                PostDetailContent(
+                BuildPostDetailContent(
                     uiState = uiState.copy(
                         postDetail = mockPostDetail1.toUiState().copy(
                             writer = PostWriterUiState(
@@ -546,11 +469,6 @@ class PostDetailScreenTest {
                         )
                     ),
                     snackbarHostState = snackbarHostState,
-                    onEditClick = {},
-                    onDeleteClick = {},
-                    onCommentDelete = {},
-                    onCommentCreated = { _, _ -> },
-                    onCommentUpdated = { _, _ -> }
                 )
             }
 
@@ -568,7 +486,7 @@ class PostDetailScreenTest {
             setContent {
                 val snackbarHostState = remember { SnackbarHostState() }
 
-                PostDetailContent(
+                BuildPostDetailContent(
                     uiState = uiState.copy(
                         comments = CommentsUiState.Success(
                             comments = listOf(comment),
@@ -576,11 +494,6 @@ class PostDetailScreenTest {
                         )
                     ),
                     snackbarHostState = snackbarHostState,
-                    onEditClick = {},
-                    onDeleteClick = {},
-                    onCommentDelete = {},
-                    onCommentCreated = { _, _ -> },
-                    onCommentUpdated = { _, _ -> }
                 )
             }
 
@@ -598,7 +511,7 @@ class PostDetailScreenTest {
             setContent {
                 val snackbarHostState = remember { SnackbarHostState() }
 
-                PostDetailContent(
+                BuildPostDetailContent(
                     uiState = uiState.copy(
                         comments = CommentsUiState.Success(
                             comments = listOf(comment),
@@ -606,11 +519,6 @@ class PostDetailScreenTest {
                         )
                     ),
                     snackbarHostState = snackbarHostState,
-                    onEditClick = {},
-                    onDeleteClick = {},
-                    onCommentDelete = {},
-                    onCommentCreated = { _, _ -> },
-                    onCommentUpdated = { _, _ -> }
                 )
             }
 
@@ -628,7 +536,7 @@ class PostDetailScreenTest {
             setContent {
                 val snackbarHostState = remember { SnackbarHostState() }
 
-                PostDetailContent(
+                BuildPostDetailContent(
                     uiState = uiState.copy(
                         comments = CommentsUiState.Success(
                             comments = emptyList(),
@@ -636,11 +544,6 @@ class PostDetailScreenTest {
                         )
                     ),
                     snackbarHostState = snackbarHostState,
-                    onEditClick = {},
-                    onDeleteClick = {},
-                    onCommentDelete = {},
-                    onCommentCreated = { _, _ -> },
-                    onCommentUpdated = { _, _ -> }
                 )
             }
 
@@ -656,7 +559,7 @@ class PostDetailScreenTest {
             setContent {
                 val snackbarHostState = remember { SnackbarHostState() }
 
-                PostDetailContent(
+                BuildPostDetailContent(
                     uiState = uiState.copy(
                         comments = CommentsUiState.Success(
                             comments = listOf(comment),
@@ -664,11 +567,6 @@ class PostDetailScreenTest {
                         )
                     ),
                     snackbarHostState = snackbarHostState,
-                    onEditClick = {},
-                    onDeleteClick = {},
-                    onCommentDelete = {},
-                    onCommentCreated = { _, _ -> },
-                    onCommentUpdated = { _, _ -> }
                 )
             }
 
@@ -682,16 +580,11 @@ class PostDetailScreenTest {
             setContent {
                 val snackbarHostState = remember { SnackbarHostState() }
 
-                PostDetailContent(
+                BuildPostDetailContent(
                     uiState = uiState.copy(
                         postDetail = mockPostDetail1.copy(onlyMember = true).toUiState()
                     ),
                     snackbarHostState = snackbarHostState,
-                    onEditClick = {},
-                    onDeleteClick = {},
-                    onCommentDelete = {},
-                    onCommentCreated = { _, _ -> },
-                    onCommentUpdated = { _, _ -> }
                 )
             }
 
@@ -705,20 +598,52 @@ class PostDetailScreenTest {
             setContent {
                 val snackbarHostState = remember { SnackbarHostState() }
 
-                PostDetailContent(
+                BuildPostDetailContent(
                     uiState = uiState.copy(
                         postDetail = mockPostDetail1.copy(onlyMember = false).toUiState()
                     ),
                     snackbarHostState = snackbarHostState,
-                    onEditClick = {},
-                    onDeleteClick = {},
-                    onCommentDelete = {},
-                    onCommentCreated = { _, _ -> },
-                    onCommentUpdated = { _, _ -> }
                 )
             }
 
             onNodeWithText(getString(R.string.can_see_only_member)).assertDoesNotExist()
+        }
+    }
+
+    @Test
+    fun onWriterNameClick() {
+        val name = "김민성"
+
+        composeRule.run {
+            var counter = 0
+
+            setContent {
+                val snackbarHostState = remember { SnackbarHostState() }
+
+                BuildPostDetailContent(
+                    uiState = uiState.copy(
+                        postDetail = mockPostDetail1.copy(
+                            writer = PostWriter(
+                                id = 0,
+                                name = name,
+                                email = "",
+                                type = UserType.MEMBER,
+                            )
+                        ).toUiState()
+                    ),
+                    snackbarHostState = snackbarHostState,
+                    onWriterNameClick = { ++counter }
+                )
+            }
+
+            onRoot(useUnmergedTree = true).printToLog("currentLabelExists")
+
+            onNodeWithText(name, substring = true)
+                .performTouchInput {
+                    click(percentOffset(.1f, .5f))
+                }
+
+            assertEquals(1, counter)
         }
     }
 
@@ -739,5 +664,35 @@ class PostDetailScreenTest {
 
     private fun findCommentTextField(): SemanticsNodeInteraction {
         return composeRule.onNodeWithContentDescription(getString(R.string.comment_text_field))
+    }
+
+    @Suppress("TestFunctionName")
+    @Composable
+    private fun BuildPostDetailContent(
+        uiState: PostDetailUiState.Success,
+        commentModalController: CommentModalController = remember { CommentModalController() },
+        optionModalController: OptionModalController<CommentItemUiState> = remember {
+            OptionModalController()
+        },
+        snackbarHostState: SnackbarHostState,
+        onEditClick: () -> Unit = {},
+        onDeleteClick: () -> Unit = {},
+        onWriterNameClick: () -> Unit = {},
+        onCommentDelete: (commentId: Int) -> Unit = { _ -> },
+        onCommentCreated: CommentCreateCallback = { _, _ -> },
+        onCommentUpdated: CommentUpdateCallback = { _, _ -> }
+    ) {
+        PostDetailContent(
+            uiState = uiState,
+            commentModalController = commentModalController,
+            optionModalController = optionModalController,
+            snackbarHostState = snackbarHostState,
+            onEditClick = onEditClick,
+            onDeleteClick = onDeleteClick,
+            onWriterNameClick = onWriterNameClick,
+            onCommentDelete = onCommentDelete,
+            onCommentCreated = onCommentCreated,
+            onCommentUpdated = onCommentUpdated
+        )
     }
 }

--- a/presentation/src/androidTest/java/com/pocs/presentation/comment/CommentTest.kt
+++ b/presentation/src/androidTest/java/com/pocs/presentation/comment/CommentTest.kt
@@ -2,6 +2,7 @@ package com.pocs.presentation.comment
 
 import android.content.Context
 import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.platform.app.InstrumentationRegistry
@@ -10,6 +11,7 @@ import com.pocs.presentation.model.comment.item.CommentItemUiState
 import com.pocs.presentation.view.component.Comment
 import com.pocs.test_library.mock.mockComment
 import com.pocs.test_library.mock.mockReply
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -32,7 +34,7 @@ class CommentTest {
     fun shouldShowReplyIcon_WhenItIsComment() {
         composeRule.run {
             setContent {
-                Comment(
+                BuildComment(
                     uiState = mockComment,
                     onClick = {}, onMoreButtonClick = {}, onReplyIconClick = {}, canAddReply = true
                 )
@@ -46,7 +48,7 @@ class CommentTest {
     fun shouldNotShowReplyIcon_WhenItIsReply() {
         composeRule.run {
             setContent {
-                Comment(
+                BuildComment(
                     uiState = mockReply,
                     onClick = {}, onMoreButtonClick = {}, onReplyIconClick = {}, canAddReply = true
                 )
@@ -60,7 +62,7 @@ class CommentTest {
     fun shouldShowReplyCount_WhenItHasRepliesOverOne() {
         composeRule.run {
             setContent {
-                Comment(
+                BuildComment(
                     uiState = mockComment.copy(childrenCount = 1),
                     onClick = {}, onMoreButtonClick = {}, onReplyIconClick = {}, canAddReply = true
                 )
@@ -74,7 +76,7 @@ class CommentTest {
     fun shouldNotShowReplyCount_WhenItDoesNotHaveReply() {
         composeRule.run {
             setContent {
-                Comment(
+                BuildComment(
                     uiState = mockComment.copy(childrenCount = 0),
                     onClick = {}, onMoreButtonClick = {}, onReplyIconClick = {}, canAddReply = true
                 )
@@ -88,7 +90,7 @@ class CommentTest {
     fun shouldShowMoreInfoButton_WhenCanEdit() {
         composeRule.run {
             setContent {
-                Comment(
+                BuildComment(
                     uiState = mockComment.copy(canEdit = true, canDelete = false),
                     onClick = {}, onMoreButtonClick = {}, onReplyIconClick = {}, canAddReply = true
                 )
@@ -102,7 +104,7 @@ class CommentTest {
     fun shouldShowMoreInfoButton_WhenCanDelete() {
         composeRule.run {
             setContent {
-                Comment(
+                BuildComment(
                     uiState = mockComment.copy(canEdit = false, canDelete = true),
                     onClick = {}, onMoreButtonClick = {}, onReplyIconClick = {}, canAddReply = true
                 )
@@ -116,7 +118,7 @@ class CommentTest {
     fun shouldNotShowMoreInfoButton_WhenCanNotEditAndDelete() {
         composeRule.run {
             setContent {
-                Comment(
+                BuildComment(
                     uiState = mockComment.copy(canEdit = false, canDelete = false),
                     onClick = {}, onMoreButtonClick = {}, onReplyIconClick = {}, canAddReply = true
                 )
@@ -131,7 +133,7 @@ class CommentTest {
         composeRule.run {
             val comment = mockComment
             setContent {
-                Comment(
+                BuildComment(
                     canAddReply = false,
                     uiState = comment,
                     onClick = {}, onMoreButtonClick = {}, onReplyIconClick = {}
@@ -146,7 +148,7 @@ class CommentTest {
     fun shouldDisableReplyIconClick_WhenCanAddReplyIsFalse() {
         composeRule.run {
             setContent {
-                Comment(
+                BuildComment(
                     canAddReply = false,
                     uiState = mockComment,
                     onClick = {}, onMoreButtonClick = {}, onReplyIconClick = {}
@@ -154,6 +156,29 @@ class CommentTest {
             }
 
             findReplyLabelButton().assertIsNotEnabled()
+        }
+    }
+
+    @Test
+    fun onWriterNameClick() {
+        val writerName = mockComment.writer.name ?: "익명"
+        var count = 0
+
+        composeRule.run {
+            setContent {
+                BuildComment(
+                    uiState = mockComment,
+                    canAddReply = true,
+                    onWriterNameClick = { ++count }
+                )
+            }
+
+            onNodeWithText(text = writerName, substring = true)
+                .performTouchInput {
+                    click(percentOffset(.1f, .5f))
+                }
+
+            assertEquals(1, count)
         }
     }
 
@@ -167,5 +192,25 @@ class CommentTest {
 
     private fun findCommentInfoButton(): SemanticsNodeInteraction {
         return composeRule.onNodeWithContentDescription(getString(R.string.comment_info_button))
+    }
+
+    @Suppress("TestFunctionName")
+    @Composable
+    private fun BuildComment(
+        uiState: CommentItemUiState,
+        canAddReply: Boolean,
+        onClick: () -> Unit = {},
+        onWriterNameClick: (userId: Int) -> Unit = {},
+        onReplyIconClick: () -> Unit = {},
+        onMoreButtonClick: () -> Unit = {}
+    ) {
+        Comment(
+            uiState = uiState,
+            canAddReply = canAddReply,
+            onClick = onClick,
+            onWriterNameClick = onWriterNameClick,
+            onReplyIconClick = onReplyIconClick,
+            onMoreButtonClick = onMoreButtonClick
+        )
     }
 }

--- a/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/component/Comments.kt
@@ -34,6 +34,7 @@ typealias CommentCallback = (CommentItemUiState) -> Unit
 fun LazyListScope.commentItems(
     uiState: CommentsUiState,
     onCommentClick: CommentCallback,
+    onWriterNameClick: (userId: Int) -> Unit,
     onReplyIconClick: CommentCallback,
     onMoreButtonClick: CommentCallback
 ) {
@@ -62,6 +63,7 @@ fun LazyListScope.commentItems(
                             uiState = comment,
                             canAddReply = uiState.canAddComment,
                             onClick = { onCommentClick(comment) },
+                            onWriterNameClick = onWriterNameClick,
                             onReplyIconClick = { onReplyIconClick(comment) },
                             onMoreButtonClick = { onMoreButtonClick(comment) }
                         )
@@ -107,6 +109,7 @@ fun Comment(
     uiState: CommentItemUiState,
     canAddReply: Boolean,
     onClick: () -> Unit,
+    onWriterNameClick: (userId: Int) -> Unit,
     onReplyIconClick: () -> Unit,
     onMoreButtonClick: () -> Unit
 ) {
@@ -132,16 +135,22 @@ fun Comment(
             modifier = Modifier.padding(top = 20.dp, start = 20.dp),
             verticalAlignment = Alignment.Top
         ) {
-            val onBackgroundColor = MaterialTheme.colorScheme.onBackground
             val name = uiState.writer.name ?: stringResource(id = R.string.anonymous)
+            val onBackgroundColor = MaterialTheme.colorScheme.onBackground
+            val infoTextStyle = MaterialTheme.typography.bodySmall.copy(
+                color = onBackgroundColor.copy(alpha = 0.5f)
+            )
 
             Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = name + stringResource(R.string.middle_dot) + uiState.date,
-                    style = MaterialTheme.typography.bodySmall.copy(
-                        color = onBackgroundColor.copy(alpha = 0.5f)
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = name,
+                        style = infoTextStyle,
+                        modifier = Modifier.clickable { onWriterNameClick(uiState.writer.userId) },
                     )
-                )
+                    Text(text = stringResource(id = R.string.middle_dot), style = infoTextStyle)
+                    Text(text = uiState.date, style = infoTextStyle)
+                }
                 Box(Modifier.height(8.dp))
                 Text(
                     text = uiState.content,
@@ -243,6 +252,7 @@ fun CommentsPreview() {
         commentItems(
             uiState = uiState,
             onCommentClick = {},
+            onWriterNameClick = {},
             onReplyIconClick = {},
             onMoreButtonClick = {}
         )
@@ -269,6 +279,7 @@ fun CommentPreview() {
             isDeleted = false
         ),
         onClick = {},
+        onWriterNameClick = {},
         onMoreButtonClick = {},
         onReplyIconClick = {},
         canAddReply = true

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailActivity.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailActivity.kt
@@ -42,7 +42,7 @@ class PostDetailActivity : AppCompatActivity() {
                     viewModel,
                     onEditClick = ::startPostEditActivity,
                     onDeleteSuccess = ::onDeleteSuccess,
-                    onWriterNameClick = ::onWriterNameClick
+                    onUserNameClick = ::onUserNameClick
                 )
             }
         }
@@ -63,10 +63,8 @@ class PostDetailActivity : AppCompatActivity() {
         finish()
     }
 
-    private fun onWriterNameClick() {
-        val uiState = viewModel.uiState.value
-        check(uiState is PostDetailUiState.Success)
-        val intent = UserDetailActivity.getIntent(this, uiState.postDetail.writer.id)
+    private fun onUserNameClick(userId: Int) {
+        val intent = UserDetailActivity.getIntent(this, userId)
         startActivity(intent)
     }
 

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailActivity.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailActivity.kt
@@ -14,6 +14,7 @@ import com.pocs.presentation.extension.RefreshStateContract
 import com.pocs.presentation.extension.setResultRefresh
 import com.pocs.presentation.model.post.PostDetailUiState
 import com.pocs.presentation.view.post.edit.PostEditActivity
+import com.pocs.presentation.view.user.detail.UserDetailActivity
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -40,7 +41,8 @@ class PostDetailActivity : AppCompatActivity() {
                 PostDetailScreen(
                     viewModel,
                     onEditClick = ::startPostEditActivity,
-                    onDeleteSuccess = ::onDeleteSuccess
+                    onDeleteSuccess = ::onDeleteSuccess,
+                    onWriterNameClick = ::onWriterNameClick
                 )
             }
         }
@@ -59,6 +61,13 @@ class PostDetailActivity : AppCompatActivity() {
     private fun onDeleteSuccess() {
         setResultRefresh(R.string.post_deleted)
         finish()
+    }
+
+    private fun onWriterNameClick() {
+        val uiState = viewModel.uiState.value
+        check(uiState is PostDetailUiState.Success)
+        val intent = UserDetailActivity.getIntent(this, uiState.postDetail.writer.id)
+        startActivity(intent)
     }
 
     private fun fetchPost() {

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
@@ -19,6 +20,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -46,6 +48,7 @@ fun PostDetailScreen(
     viewModel: PostDetailViewModel,
     onEditClick: () -> Unit,
     onDeleteSuccess: () -> Unit,
+    onWriterNameClick: () -> Unit
 ) {
     when (val uiState = viewModel.uiState.collectAsState().value) {
         is PostDetailUiState.Failure -> {
@@ -77,6 +80,7 @@ fun PostDetailScreen(
                 snackbarHostState = snackbarHostState,
                 onEditClick = onEditClick,
                 onDeleteClick = { viewModel.requestPostDeleting(uiState.postDetail.id) },
+                onWriterNameClick = onWriterNameClick,
                 onCommentDelete = viewModel::deleteComment,
                 onCommentCreated = viewModel::addComment,
                 onCommentUpdated = viewModel::updateComment
@@ -96,6 +100,7 @@ fun PostDetailContent(
     snackbarHostState: SnackbarHostState,
     onEditClick: () -> Unit,
     onDeleteClick: () -> Unit,
+    onWriterNameClick: () -> Unit,
     onCommentDelete: (commentId: Int) -> Unit,
     onCommentCreated: CommentCreateCallback,
     onCommentUpdated: CommentUpdateCallback
@@ -174,12 +179,16 @@ fun PostDetailContent(
                 }
             ) { paddingValues ->
                 val anonymousString = stringResource(id = R.string.anonymous)
+                val middleDot = stringResource(id = R.string.middle_dot)
+
                 LazyColumn(Modifier.padding(paddingValues), state = lazyListState) {
                     headerItems(
                         title = postDetail.title,
                         writerName = postDetail.writer.name ?: anonymousString,
+                        subtitleDivider = middleDot,
                         date = postDetail.date,
-                        onlyMember = postDetail.onlyMember
+                        onlyMember = postDetail.onlyMember,
+                        onWriterNameClick = onWriterNameClick
                     )
                     item {
                         MarkdownText(
@@ -296,12 +305,24 @@ fun PostDetailTopAppBar(
     )
 }
 
+private const val USER_NAME_TAG = "userName"
+
 private fun LazyListScope.headerItems(
     title: String,
     writerName: String,
+    subtitleDivider: String,
     date: String,
-    onlyMember: Boolean
+    onlyMember: Boolean,
+    onWriterNameClick: () -> Unit
 ) {
+    val annotatedText = buildAnnotatedString {
+        pushStringAnnotation(tag = USER_NAME_TAG, annotation = "")
+        append(writerName)
+        append(subtitleDivider)
+        pop()
+        append(date)
+    }
+
     item(HEADER_KEY) {
         Column(modifier = Modifier.padding(20.dp)) {
             Text(
@@ -312,15 +333,20 @@ private fun LazyListScope.headerItems(
                 )
             )
             Box(modifier = Modifier.height(8.dp))
-            Text(
-                text = stringResource(
-                    id = R.string.post_subtitle,
-                    writerName,
-                    date
-                ),
+            ClickableText(
+                text = annotatedText,
                 style = MaterialTheme.typography.bodyMedium.copy(
                     color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
-                )
+                ),
+                onClick = { offset ->
+                    annotatedText.getStringAnnotations(
+                        tag = USER_NAME_TAG,
+                        offset,
+                        offset
+                    ).firstOrNull()?.let {
+                        onWriterNameClick()
+                    }
+                },
             )
             if (onlyMember) {
                 Box(modifier = Modifier.height(8.dp))
@@ -417,6 +443,7 @@ private fun PostDetailContentPreview() {
         snackbarHostState = SnackbarHostState(),
         onEditClick = {},
         onDeleteClick = {},
+        onWriterNameClick = {},
         onCommentDelete = {},
         onCommentCreated = { _, _ -> },
         onCommentUpdated = { _, _ -> }

--- a/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
+++ b/presentation/src/main/java/com/pocs/presentation/view/post/detail/PostDetailScreen.kt
@@ -48,7 +48,7 @@ fun PostDetailScreen(
     viewModel: PostDetailViewModel,
     onEditClick: () -> Unit,
     onDeleteSuccess: () -> Unit,
-    onWriterNameClick: () -> Unit
+    onUserNameClick: (userId: Int) -> Unit
 ) {
     when (val uiState = viewModel.uiState.collectAsState().value) {
         is PostDetailUiState.Failure -> {
@@ -80,7 +80,7 @@ fun PostDetailScreen(
                 snackbarHostState = snackbarHostState,
                 onEditClick = onEditClick,
                 onDeleteClick = { viewModel.requestPostDeleting(uiState.postDetail.id) },
-                onWriterNameClick = onWriterNameClick,
+                onUserNameClick = onUserNameClick,
                 onCommentDelete = viewModel::deleteComment,
                 onCommentCreated = viewModel::addComment,
                 onCommentUpdated = viewModel::updateComment
@@ -100,7 +100,7 @@ fun PostDetailContent(
     snackbarHostState: SnackbarHostState,
     onEditClick: () -> Unit,
     onDeleteClick: () -> Unit,
-    onWriterNameClick: () -> Unit,
+    onUserNameClick: (userId: Int) -> Unit,
     onCommentDelete: (commentId: Int) -> Unit,
     onCommentCreated: CommentCreateCallback,
     onCommentUpdated: CommentUpdateCallback
@@ -188,7 +188,7 @@ fun PostDetailContent(
                         subtitleDivider = middleDot,
                         date = postDetail.date,
                         onlyMember = postDetail.onlyMember,
-                        onWriterNameClick = onWriterNameClick
+                        onWriterNameClick = { onUserNameClick(postDetail.writer.id) }
                     )
                     item {
                         MarkdownText(
@@ -232,6 +232,7 @@ fun PostDetailContent(
                                 commentModalController.showForCreate(parentComment = it)
                             }
                         },
+                        onWriterNameClick = onUserNameClick,
                         onCommentClick = {
                             coroutineScope.launch {
                                 commentModalController.showForCreate(parentComment = it)
@@ -315,7 +316,7 @@ private fun LazyListScope.headerItems(
     onlyMember: Boolean,
     onWriterNameClick: () -> Unit
 ) {
-    val annotatedText = buildAnnotatedString {
+    val annotatedInfoText = buildAnnotatedString {
         pushStringAnnotation(tag = USER_NAME_TAG, annotation = "")
         append(writerName)
         append(subtitleDivider)
@@ -334,12 +335,12 @@ private fun LazyListScope.headerItems(
             )
             Box(modifier = Modifier.height(8.dp))
             ClickableText(
-                text = annotatedText,
+                text = annotatedInfoText,
                 style = MaterialTheme.typography.bodyMedium.copy(
                     color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
                 ),
                 onClick = { offset ->
-                    annotatedText.getStringAnnotations(
+                    annotatedInfoText.getStringAnnotations(
                         tag = USER_NAME_TAG,
                         offset,
                         offset
@@ -443,7 +444,7 @@ private fun PostDetailContentPreview() {
         snackbarHostState = SnackbarHostState(),
         onEditClick = {},
         onDeleteClick = {},
-        onWriterNameClick = {},
+        onUserNameClick = {},
         onCommentDelete = {},
         onCommentCreated = { _, _ -> },
         onCommentUpdated = { _, _ -> }


### PR DESCRIPTION
Resolves #292 

오랜만에 개발해봅니다. 간단한 기능을 구현해봤어요.

테스트 코드 작성이 편리하도록 helper method를 추가했습니다. 함수에 매개변수가 추가되면 기존 모든 코드를 수정해야 했기 때문입니다.


https://user-images.githubusercontent.com/57604817/210923716-b756316b-c0d0-453b-8c40-6cc960f958fb.mov


## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [x] Action에서 진행하는 테스트를 모두 통과했는가?
- [x] 수정 사항을 검증할 테스트를 추가하였는가?
- [ ] 리뷰를 받았는가?