### PR TITLE
`Result`, `Response` 관련 부분 단순하게 리팩토링

### DIFF
--- a/data/src/main/java/com/pocs/data/extension/ResponseExt.kt
+++ b/data/src/main/java/com/pocs/data/extension/ResponseExt.kt
@@ -1,18 +1,27 @@
 package com.pocs.data.extension
 
+import com.google.gson.Gson
 import com.pocs.data.model.ResponseBody
-import org.json.JSONObject
 import retrofit2.Response
 
 val <T> Response<ResponseBody<T>>.errorMessage: String?
     get() {
-        if (this.isSuccessful) throw IllegalStateException()
+        if (isSuccessful) throw IllegalStateException()
 
         return try {
-            val jsonString = this.errorBody()?.string() ?: throw IllegalStateException()
-            val jObjError = JSONObject(jsonString)
-            jObjError.getString("message")
+            message()
+            val errorBodyJson = requireNotNull(errorBody()).string()
+            val responseBody = Gson().fromJson(errorBodyJson, ResponseBody::class.java)
+            responseBody.message
         } catch (e: Exception) {
             e.message
         }
     }
+
+fun <T> Response<ResponseBody<T>>.getDataOrThrowMessage(): T {
+    if (isSuccessful) {
+        return requireNotNull(body()).data
+    } else {
+        throw Exception(errorMessage)
+    }
+}

--- a/data/src/main/java/com/pocs/data/repository/AdminRepositoryImpl.kt
+++ b/data/src/main/java/com/pocs/data/repository/AdminRepositoryImpl.kt
@@ -4,7 +4,7 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import com.pocs.data.api.AdminApi
-import com.pocs.data.extension.errorMessage
+import com.pocs.data.extension.getDataOrThrowMessage
 import com.pocs.data.mapper.toDetailEntity
 import com.pocs.data.mapper.toDto
 import com.pocs.data.model.admin.UserKickInfoBody
@@ -36,44 +36,26 @@ class AdminRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getUserDetail(id: Int): Result<UserDetail> {
-        return try {
+        return runCatching {
             val response = dataSource.getUserDetail(id)
-            if (response.isSuccessful) {
-                Result.success(response.body()!!.data.toDetailEntity())
-            } else {
-                throw Exception(response.errorMessage)
-            }
-        } catch (e: Exception) {
-            Result.failure(e)
+            response.getDataOrThrowMessage().toDetailEntity()
         }
     }
 
     override suspend fun createUser(userCreateInfo: UserCreateInfo): Result<Unit> {
-        return try {
+        return runCatching {
             val response = dataSource.createUser(userCreateInfo.toDto())
-            if (response.isSuccessful) {
-                Result.success(Unit)
-            } else {
-                throw Exception(response.errorMessage)
-            }
-        } catch (e: Exception) {
-            Result.failure(e)
+            response.getDataOrThrowMessage()
         }
     }
 
     override suspend fun kickUser(id: Int): Result<Unit> {
-        return try {
+        return runCatching {
             val response = dataSource.kickUser(
                 id = id,
                 userKickInfoBody = UserKickInfoBody(canceledAt = getCurrentDateTime())
             )
-            if (response.isSuccessful) {
-                Result.success(Unit)
-            } else {
-                throw Exception(response.errorMessage)
-            }
-        } catch (e: Exception) {
-            Result.failure(e)
+            response.getDataOrThrowMessage()
         }
     }
 

--- a/data/src/main/java/com/pocs/data/repository/CommentRepositoryImpl.kt
+++ b/data/src/main/java/com/pocs/data/repository/CommentRepositoryImpl.kt
@@ -1,6 +1,6 @@
 package com.pocs.data.repository
 
-import com.pocs.data.extension.errorMessage
+import com.pocs.data.extension.getDataOrThrowMessage
 import com.pocs.data.mapper.toEntity
 import com.pocs.data.model.comment.CommentAddBody
 import com.pocs.data.model.comment.CommentUpdateBody
@@ -14,63 +14,38 @@ class CommentRepositoryImpl @Inject constructor(
 ) : CommentRepository {
 
     override suspend fun getAllBy(postId: Int): Result<List<Comment>> {
-        return try {
+        return runCatching {
             val response = dataSource.getAllBy(postId = postId)
-            if (response.isSuccessful) {
-                val comments = response.body()!!.data.comments.map { it.toEntity() }
-                Result.success(comments)
-            } else {
-                throw Exception(response.errorMessage)
-            }
-        } catch (e: Exception) {
-            Result.failure(e)
+            response.getDataOrThrowMessage().comments.map { it.toEntity() }
         }
     }
 
     override suspend fun add(content: String, postId: Int, parentId: Int?): Result<Unit> {
-        return try {
+        return runCatching {
             val requestBody = CommentAddBody(
                 content = content,
                 postId = postId,
                 parentId = parentId
             )
             val response = dataSource.add(requestBody)
-            if (response.isSuccessful) {
-                Result.success(Unit)
-            } else {
-                throw Exception(response.errorMessage)
-            }
-        } catch (e: Exception) {
-            Result.failure(e)
+            response.getDataOrThrowMessage()
         }
     }
 
     override suspend fun update(commentId: Int, content: String): Result<Unit> {
-        return try {
+        return runCatching {
             val response = dataSource.update(
                 commentId = commentId,
                 commentUpdateBody = CommentUpdateBody(content = content)
             )
-            if (response.isSuccessful) {
-                Result.success(Unit)
-            } else {
-                throw Exception(response.errorMessage)
-            }
-        } catch (e: Exception) {
-            Result.failure(e)
+            response.getDataOrThrowMessage()
         }
     }
 
     override suspend fun delete(commentId: Int): Result<Unit> {
-        return try {
+        return runCatching {
             val response = dataSource.delete(commentId = commentId)
-            if (response.isSuccessful) {
-                Result.success(Unit)
-            } else {
-                throw Exception(response.errorMessage)
-            }
-        } catch (e: Exception) {
-            Result.failure(e)
+            response.getDataOrThrowMessage()
         }
     }
 }

--- a/data/src/main/java/com/pocs/data/repository/PostRepositoryImpl.kt
+++ b/data/src/main/java/com/pocs/data/repository/PostRepositoryImpl.kt
@@ -4,7 +4,7 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import com.pocs.data.api.PostApi
-import com.pocs.data.extension.errorMessage
+import com.pocs.data.extension.getDataOrThrowMessage
 import com.pocs.data.mapper.toDto
 import com.pocs.data.mapper.toEntity
 import com.pocs.data.model.post.PostAddBody
@@ -34,15 +34,9 @@ class PostRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getPostDetail(id: Int): Result<PostDetail> {
-        return try {
+        return runCatching {
             val response = dataSource.getPostDetail(id)
-            if (response.isSuccessful) {
-                Result.success(response.body()!!.data.toEntity(id))
-            } else {
-                throw Exception(response.errorMessage)
-            }
-        } catch (e: Exception) {
-            Result.failure(e)
+            response.getDataOrThrowMessage().toEntity(id)
         }
     }
 
@@ -53,7 +47,7 @@ class PostRepositoryImpl @Inject constructor(
         userId: Int,
         category: PostCategory
     ): Result<Unit> {
-        return try {
+        return runCatching {
             val response = dataSource.addPost(
                 PostAddBody(
                     title = title,
@@ -63,13 +57,7 @@ class PostRepositoryImpl @Inject constructor(
                     category = category.toDto()
                 )
             )
-            if (response.isSuccessful) {
-                Result.success(Unit)
-            } else {
-                throw Exception(response.errorMessage)
-            }
-        } catch (e: Exception) {
-            Result.failure(e)
+            response.getDataOrThrowMessage()
         }
     }
 
@@ -81,7 +69,7 @@ class PostRepositoryImpl @Inject constructor(
         userId: Int,
         category: PostCategory
     ): Result<Unit> {
-        return try {
+        return runCatching {
             val response = dataSource.updatePost(
                 postId = postId,
                 postUpdateBody = PostUpdateBody(
@@ -92,13 +80,7 @@ class PostRepositoryImpl @Inject constructor(
                     category = category.toDto()
                 )
             )
-            if (response.isSuccessful) {
-                Result.success(Unit)
-            } else {
-                throw Exception(response.errorMessage)
-            }
-        } catch (e: Exception) {
-            Result.failure(e)
+            response.getDataOrThrowMessage()
         }
     }
 
@@ -106,18 +88,12 @@ class PostRepositoryImpl @Inject constructor(
         postId: Int,
         userId: Int
     ): Result<Unit> {
-        return try {
-            val result = dataSource.deletePost(
+        return runCatching {
+            val response = dataSource.deletePost(
                 postId = postId,
                 postDeleteBody = PostDeleteBody(userId = userId)
             )
-            if (result.isSuccessful) {
-                Result.success(Unit)
-            } else {
-                throw Exception(result.errorMessage)
-            }
-        } catch (e: Exception) {
-            Result.failure(e)
+            response.getDataOrThrowMessage()
         }
     }
 }

--- a/data/src/main/java/com/pocs/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/pocs/data/repository/UserRepositoryImpl.kt
@@ -5,6 +5,7 @@ import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import com.pocs.data.api.UserApi
 import com.pocs.data.extension.errorMessage
+import com.pocs.data.extension.getDataOrThrowMessage
 import com.pocs.data.mapper.toDetailEntity
 import com.pocs.data.mapper.toDto
 import com.pocs.data.mapper.toUserProfileImageUrl
@@ -54,15 +55,9 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getUserDetail(id: Int): Result<UserDetail> {
-        return try {
+        return runCatching {
             val response = dataSource.getUserDetail(id)
-            if (response.isSuccessful) {
-                Result.success(response.body()!!.data.toDetailEntity())
-            } else {
-                throw Exception(response.errorMessage)
-            }
-        } catch (e: Exception) {
-            Result.failure(e)
+            response.getDataOrThrowMessage().toDetailEntity()
         }
     }
 
@@ -124,15 +119,9 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun createAnonymous(anonymousCreateInfo: AnonymousCreateInfo): Result<Unit> {
-        return try {
+        return runCatching {
             val response = dataSource.createAnonymous(anonymousCreateInfo.toDto())
-            if (response.isSuccessful) {
-                Result.success(Unit)
-            } else {
-                throw Exception(response.errorMessage)
-            }
-        } catch (e: Exception) {
-            Result.failure(e)
+            response.getDataOrThrowMessage()
         }
     }
 }

--- a/data/src/test/java/com.pocs/data/ResponseExtTest.kt
+++ b/data/src/test/java/com.pocs/data/ResponseExtTest.kt
@@ -1,0 +1,46 @@
+package com.pocs.data
+
+import com.google.gson.Gson
+import com.pocs.data.extension.getDataOrThrowMessage
+import com.pocs.data.model.ResponseBody
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import retrofit2.Response
+
+class ResponseExtTest {
+
+    @Test
+    fun `should have data when calling getDataOrThrowMessage from successful response`() {
+        // given
+        val response =
+            Response.success(ResponseBody(data = 10, message = "", status = 200, serverTime = ""))
+
+        // when
+        val data = response.getDataOrThrowMessage()
+
+        // then
+        assertEquals(10, data)
+    }
+
+    @Test
+    fun `should throw error message when calling getDataOrThrowMessage from failure response`() {
+        // given
+        val message = "error message"
+        val response = Response.error<ResponseBody<Int>>(
+            404,
+            Gson().toJson(
+                ResponseBody(
+                    data = null,
+                    message = message,
+                    status = 404,
+                    serverTime = ""
+                )
+            ).toResponseBody(null)
+        )
+
+        // when, then
+        assertThrows(message, Exception::class.java) { response.getDataOrThrowMessage() }
+    }
+}


### PR DESCRIPTION
- `runCatching`을 활용하여 중복되는 코드를 단순하게 리팩토링 해보았습니다.
- `Response.getDataOrThrowMessage()`라는 extension 함수를 만들어 더욱 단순하게 하였습니다.
- `errorrMessage` 확장 함수를 `Gson`를 사용하여 안전하게 파싱하도록 수정했습니다.

## Merge 전 체크리스트

- [x] 코딩 컨벤션을 지켰는가?
- [x] Action에서 진행하는 테스트를 모두 통과했는가?
- [x] 수정 사항을 검증할 테스트를 추가하였는가?
- [x] 리뷰를 받았는가?